### PR TITLE
Expose raw "button state" to user

### DIFF
--- a/src/system/physical/button.h
+++ b/src/system/physical/button.h
@@ -38,6 +38,27 @@ void blink(const uint32_t offFreq, const uint32_t onFreq,
 void breeze(const uint32_t periodOn, const uint32_t periodOff,
             const utils::ColorSpace::RGB& color);
 
+// Button state
+struct ButtonStateTy {
+  bool isPressed = false; // is the button pressed?
+  bool isLongPressed = false; // is button in long press?
+  uint32_t lastPressTime = 0; // timestamp (millis) of last press
+  uint32_t firstHoldTime = 0; // timestamp (millis) of first press (hold)
+  uint8_t nbClicksCounted = 0; // nb of counted clicks
+
+  bool wasTriggered = false; // was button triggered last update?
+  uint32_t pressDuration = 0; // estimated (millis) press duration
+  uint32_t sinceLastCall = 0; // time (unprocessed) since last call
+  uint32_t lastEventTime = 0; // last (unprocessed) time of call
+  bool lastRawButton = false; // last (unprocessed) boolean value read
+};
+
+/**
+ * \brief Get a copy of the raw internal button state
+ */
+extern ButtonStateTy get_button_state();
+
+
 }  // namespace button
 
 #endif


### PR DESCRIPTION
This is a refactoring to centralize all the values used inside a "ButtonStateTy" structure.

This is related to on-going work (see #13 ) to have better-structured custom modes, including the ability for the user to temporarily disable the default button controls on demand, hence opening the possibility for a custom mode to implement its own custom button-handling process.

Note that `get_button_state()` is not used anywhere and this change should not affect current functionality.