### PR TITLE
Improve utils::hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ FQBN=adafruit:nrf52:lampDa_nrf52840
 PROJECT_INO=LampColorControler.ino
 COMPILER_CMD=$(shell $(ARDUINO_CLI) compile -b $(FQBN) --show-properties|grep compiler.cpp.cmd|cut -f2 -d=)
 COMPILER_PATH=$(shell $(ARDUINO_CLI) compile -b $(FQBN) --show-properties|grep compiler.path|cut -f2 -d=)
-CPP_BASIC_FLAGS=-std=gnu++17 -fconcepts -D$(FULL_LAMP_TYPE) -DLMBD_EXPLICIT_CPP17_SUPPORT
+CPP_BASIC_FLAGS=-std=gnu++17 -fconcepts -D$(FULL_LAMP_TYPE) -DLMBD_CPP17
 CPP_BUILD_FLAGS=-fdiagnostics-color=always -Wno-unused-parameter -ftemplate-backtrace-limit=1
 #
 # to enable warnings:

--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,15 @@ $(BUILD_DIR)/process-${LMBD_LAMP_TYPE}.sh: has-lamp-type $(BUILD_DIR)/verbose-cl
 	>> $(BUILD_DIR)/process-${LMBD_LAMP_TYPE}.sh
 	@echo 'touch $(BUILD_DIR)/objs/.last-used' >> $(BUILD_DIR)/process-${LMBD_LAMP_TYPE}.sh
 	@echo 'touch $(BUILD_DIR)/.process-${LMBD_LAMP_TYPE}-success' >> $(BUILD_DIR)/process-${LMBD_LAMP_TYPE}.sh
+	@test 8 -le $$(wc -l $@|cut -f 1 -d ' ') \
+		|| (echo; echo \
+			; echo 'ERROR: process-${LMBD_LAMP_TYPE}.sh is too short to be correct!' \
+			; echo \
+			; echo 'Troubleshooting:' \
+			; echo ' - does "LMBD_LAMP_TYPE=${LMBD_LAMP_TYPE} make clean build-clean" returns with no error?' \
+			; echo ' - if not, behavior detection may fail, as build can not be completed!' \
+			; echo \
+			; false)
 
 $(BUILD_DIR)/clear-${LMBD_LAMP_TYPE}.sh: has-lamp-type $(BUILD_DIR)/process-${LMBD_LAMP_TYPE}.sh
 	@echo; echo " --- $@"

--- a/src/system/behavior.cpp
+++ b/src/system/behavior.cpp
@@ -330,7 +330,7 @@ void handle_alerts() {
   }
 }
 
-#ifdef LMBD_EXPLICIT_CPP17_SUPPORT
+#ifdef LMBD_CPP17
 const char* ensure_build_canary() {
 #ifdef LMBD_LAMP_TYPE__SIMPLE
   return "_lmbd__build_canary__simple";

--- a/src/system/behavior.h
+++ b/src/system/behavior.h
@@ -49,7 +49,7 @@ extern void button_hold_callback(const uint8_t consecutiveButtonCheck,
 extern void handle_alerts();
 
 /// \private Internal symbol used to signify which LMBD_LAMP_TYPE was specified
-#ifdef LMBD_EXPLICIT_CPP17_SUPPORT
+#ifdef LMBD_CPP17
 extern const char* ensure_build_canary();
 #endif
 

--- a/src/system/utils/utils.h
+++ b/src/system/utils/utils.h
@@ -86,7 +86,7 @@ template <typename T>
 static constexpr uint32_t hash(const T s,
                                const uint16_t maxSize = 12,
                                const uint16_t off = 0) {
-#ifdef LMBD_EXPLICIT_CPP17_SUPPORT
+#ifdef LMBD_CPP17
   uint32_t hashAcc = 5381;
   for (uint16_t I = 0; I < maxSize; ++I) {
     if (s[I + off] == '\0') {

--- a/src/system/utils/utils.h
+++ b/src/system/utils/utils.h
@@ -72,10 +72,40 @@ constexpr float map(float x, float in_min, float in_max, float out_min,
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
-// hash a string
-// param[in] off should be left to 0
-constexpr uint32_t hash(const char* s, const uint16_t off = 0) {
-  return !s[off] ? 5381 : (hash(s, off + 1) * 33) ^ s[off];
+/** \brief Hash input string into a 32-bit unsigned integer
+ *
+ * This is the xor-variant of the "djb2 hash" in its iterative form, starting
+ * from the beginning of the string for simplicity.
+ *
+ * \param[in] s Zero-terminated input string
+ * \param[in] maxSize (optional) Maximal byte count to process, defaults to 12
+ * \param[in] off (optional) Skip the first \p off bytes, defaults to 0
+ * \remark By default, only the first 12 bytes of the string are used!
+ */
+template <typename T>
+static constexpr uint32_t hash(const T s,
+                               const uint16_t maxSize = 12,
+                               const uint16_t off = 0) {
+#ifdef LMBD_EXPLICIT_CPP17_SUPPORT
+  uint32_t hashAcc = 5381;
+  for (uint16_t I = 0; I < maxSize; ++I) {
+    if (s[I + off] == '\0') {
+      return hashAcc;
+    }
+
+    hashAcc = ((hashAcc << 5) + hashAcc) ^ s[I + off];
+  }
+  return hashAcc;
+#else
+  return !s[off] ? 5381 : (hash(s, maxSize, off + 1) * 33) ^ s[off];
+#endif
+}
+
+/// \private Same as hash, but takes priority when called with hash("string")
+template <int16_t N>
+static constexpr uint32_t hash(const char (&s)[N]) {
+  static_assert((N-1 <= 12) && "Use hash(s, maxSize) to hash strings longer than 12 bytes!");
+  return hash(s, 12);
 }
 
 void calcGammaTable(float gamma);

--- a/src/user/cct/functions.cpp
+++ b/src/user/cct/functions.cpp
@@ -53,7 +53,7 @@ void power_off_sequence() {
   currentBrightness = 0;
   set_color(0);
 
-#ifdef LMBD_EXPLICIT_CPP17_SUPPORT
+#ifdef LMBD_CPP17
   ensure_build_canary();  // (no-op) internal symbol used during build
 #endif
 }

--- a/src/user/indexable/functions.cpp
+++ b/src/user/indexable/functions.cpp
@@ -381,7 +381,7 @@ void power_off_sequence() {
   // The only way to discharge the DC-DC pin...
   pinMode(LED_POWER_PIN, OUTPUT_H0H1);
 
-#ifdef LMBD_EXPLICIT_CPP17_SUPPORT
+#ifdef LMBD_CPP17
   ensure_build_canary();  // (no-op) internal symbol used during build
 #endif
 }

--- a/src/user/simple/functions.cpp
+++ b/src/user/simple/functions.cpp
@@ -12,7 +12,7 @@ namespace user {
 void power_on_sequence() { ledpower::write_brightness(BRIGHTNESS); }
 
 void power_off_sequence() {
-#ifdef LMBD_EXPLICIT_CPP17_SUPPORT
+#ifdef LMBD_CPP17
   ensure_build_canary();  // (no-op) internal symbol used during build
 #endif
 }


### PR DESCRIPTION
Was working on something else, when I saw the previous recursive hash, which was likely to not properly optimized by the compiler and spend unnecessary cycles, while being simple enough to have a faster implementation.

Several changes:
 - only process first 12 bytes, to avoid accidental infinite loops
 - iterative version is better optimized, often inlined unrolled
 - stricter version for compile-time `hash("string")` usage

Uses the same [djb2 algorithm](http://www.cse.yorku.ca/~oz/hash.html) but process the bytes in a different order than the recursive version for performance, which is incompatible with previous utils::hash (which should not cause problem)

-------------

**Note:** the 12-bytes limit was intentionally set low to enable aggressive optimizations (inline+unroll)

To avoid misuse, an error is raised if a longer string is used, as seen [on that example](https://godbolt.org/z/MnbPM9s16):
```
<source>: In instantiation of 'constexpr uint32_t hash(const char (&)[N]) [with short int N = 14; uint32_t = unsigned int]':
<source>:33:28:   required from here
   33 |     return (hash(h) == hash("magic_string+"));
      |                        ~~~~^~~~~~~~~~~~~~~~~
<source>:22:23: error: static assertion failed: Use hash(s, maxSize) to hash strings longer than 12 bytes!
   22 |     static_assert(N-1 <= 12, "Use hash(s, maxSize) to hash strings longer than 12 bytes!");
      |                   ~~~~^~~~~
<source>:22:23: note: the comparison reduces to '(13 <= 12)'
Compiler returned: 1
```

And of course, the longer version is also `constexpr` optimized, but will be larger to inline and more expensive.