### PR TITLE
Replace relative includes by absolute ones

### DIFF
--- a/src/compile.h
+++ b/src/compile.h
@@ -54,4 +54,13 @@
 #endif
 #endif
 
+// Users triggering this error, either:
+//  - has no idea what they are doing, and shell prefer using the Makefile
+//  - are autonomous, and can add all the necessary build flags
+//      (among which -I$(BUILD_DIR)/objs/sketch and other -D<define>)
+//
+#ifndef LMBD_MISSING_DEFINE
+#error "LMBD_MISSING_DEFINE missing, are you using the Makefile to build?"
+#endif
+
 #endif

--- a/src/system/behavior.cpp
+++ b/src/system/behavior.cpp
@@ -3,15 +3,15 @@
 #include <cstdint>
 
 #ifdef LMBD_LAMP_TYPE__SIMPLE
-#include "../user/simple/functions.h"
+#include "src/user/simple/functions.h"
 #endif
 
 #ifdef LMBD_LAMP_TYPE__CCT
-#include "../user/cct/functions.h"
+#include "src/user/cct/functions.h"
 #endif
 
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
-#include "../user/indexable/functions.h"
+#include "src/user/indexable/functions.h"
 #endif
 
 #include "alerts.h"

--- a/src/system/charger/charger.cpp
+++ b/src/system/charger/charger.cpp
@@ -2,10 +2,11 @@
 
 #include <cstdint>
 
-#include "../alerts.h"
-#include "../physical/BQ25703A.h"
-#include "../physical/battery.h"
-#include "../utils/constants.h"
+#include "src/system/alerts.h"
+#include "src/system/physical/BQ25703A.h"
+#include "src/system/physical/battery.h"
+#include "src/system/utils/constants.h"
+
 #include "Arduino.h"
 #include "FUSB302/PD_UFP.h"
 

--- a/src/system/colors/animations.cpp
+++ b/src/system/colors/animations.cpp
@@ -8,12 +8,13 @@
 #include <cmath>
 #include <cstdint>
 
-#include "../ext/math8.h"
-#include "../ext/noise.h"
-#include "../ext/random8.h"
-#include "../utils/constants.h"
-#include "../utils/coordinates.h"
-#include "../utils/utils.h"
+#include "src/system/ext/math8.h"
+#include "src/system/ext/noise.h"
+#include "src/system/ext/random8.h"
+#include "src/system/utils/constants.h"
+#include "src/system/utils/coordinates.h"
+#include "src/system/utils/utils.h"
+
 #include "palettes.h"
 #include "wipes.h"
 

--- a/src/system/colors/animations.h
+++ b/src/system/colors/animations.h
@@ -3,8 +3,9 @@
 
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
 
-#include "../utils/colorspace.h"
-#include "../utils/strip.h"
+#include "src/system/utils/colorspace.h"
+#include "src/system/utils/strip.h"
+
 #include "colors.h"
 
 namespace animations {

--- a/src/system/colors/colors.cpp
+++ b/src/system/colors/colors.cpp
@@ -5,9 +5,10 @@
 #include <cmath>
 #include <cstdint>
 
-#include "../utils/colorspace.h"
-#include "../utils/strip.h"
-#include "../utils/utils.h"
+#include "src/system/utils/colorspace.h"
+#include "src/system/utils/strip.h"
+#include "src/system/utils/utils.h"
+
 #include "palettes.h"
 
 uint32_t GenerateSolidColor::get_color_internal(const uint16_t index,

--- a/src/system/colors/colors.h
+++ b/src/system/colors/colors.h
@@ -3,11 +3,11 @@
 
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
 
+#include <cstdint>
 #include <Arduino.h>
 
-#include <cstdint>
+#include "src/system/utils/constants.h"
 
-#include "../utils/constants.h"
 #include "palettes.h"
 
 // min color update frequency

--- a/src/system/colors/palettes.cpp
+++ b/src/system/colors/palettes.cpp
@@ -4,7 +4,7 @@
 
 #include <cstdint>
 
-#include "../utils/utils.h"
+#include "src/system/utils/utils.h"
 
 /// Cloudy color palette/ blue to blue-white
 const palette_t PaletteCloudColors = {Blue,      DarkBlue, DarkBlue,  DarkBlue,

--- a/src/system/colors/wipes.cpp
+++ b/src/system/colors/wipes.cpp
@@ -2,9 +2,10 @@
 
 #include <cstdint>
 
-#include "../utils/constants.h"
-#include "../utils/coordinates.h"
-#include "../utils/strip.h"
+#include "src/system/utils/constants.h"
+#include "src/system/utils/coordinates.h"
+#include "src/system/utils/strip.h"
+
 #include "colors.h"
 
 namespace animations {

--- a/src/system/colors/wipes.h
+++ b/src/system/colors/wipes.h
@@ -3,7 +3,8 @@
 
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
 
-#include "../utils/strip.h"
+#include "src/system/utils/strip.h"
+
 #include "colors.h"
 
 namespace animations {

--- a/src/system/ext/noise.cpp
+++ b/src/system/ext/noise.cpp
@@ -1,6 +1,7 @@
 #include "noise.h"
 
-#include "../utils/utils.h"
+#include "src/system/utils/utils.h"
+
 #include "math8.h"
 
 static uint8_t const p[] = {

--- a/src/system/physical/MicroPhone.cpp
+++ b/src/system/physical/MicroPhone.cpp
@@ -5,9 +5,10 @@
 #include <algorithm>
 #include <cstdint>
 
-#include "../ext/noise.h"
-#include "../ext/random8.h"
-#include "../utils/constants.h"
+#include "src/system/ext/noise.h"
+#include "src/system/ext/random8.h"
+#include "src/system/utils/constants.h"
+
 #include "fft.h"
 
 namespace microphone {

--- a/src/system/physical/battery.cpp
+++ b/src/system/physical/battery.cpp
@@ -1,8 +1,8 @@
 #include "battery.h"
 
-#include "../alerts.h"
-#include "../utils/constants.h"
-#include "../utils/utils.h"
+#include "src/system/alerts.h"
+#include "src/system/utils/constants.h"
+#include "src/system/utils/utils.h"
 
 namespace battery {
 

--- a/src/system/physical/bluetooth.cpp
+++ b/src/system/physical/bluetooth.cpp
@@ -2,7 +2,7 @@
 
 #include <bluefruit.h>
 
-#include "../alerts.h"
+#include "src/system/alerts.h"
 
 namespace bluetooth {
 

--- a/src/system/physical/button.cpp
+++ b/src/system/physical/button.cpp
@@ -1,7 +1,7 @@
 #include "button.h"
 
-#include "../utils/constants.h"
-#include "../utils/utils.h"
+#include "src/system/utils/constants.h"
+#include "src/system/utils/utils.h"
 
 #define RELEASE_TIMING_MS 200
 #define RELEASE_BETWEEN_CLICKS 50

--- a/src/system/physical/button.h
+++ b/src/system/physical/button.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <functional>
 
-#include "../utils/colorspace.h"
+#include "src/system/utils/colorspace.h"
 
 namespace button {
 

--- a/src/system/physical/fileSystem.cpp
+++ b/src/system/physical/fileSystem.cpp
@@ -7,7 +7,7 @@
 #include <map>
 #include <vector>
 
-#include "../utils/constants.h"
+#include "src/system/utils/constants.h"
 
 namespace fileSystem {
 

--- a/src/system/physical/led_power.cpp
+++ b/src/system/physical/led_power.cpp
@@ -3,8 +3,8 @@
 #include <cmath>
 #include <cstdint>
 
-#include "../utils/constants.h"
-#include "../utils/utils.h"
+#include "src/system/utils/constants.h"
+#include "src/system/utils/utils.h"
 
 namespace ledpower {
 

--- a/src/system/utils/constants.h
+++ b/src/system/utils/constants.h
@@ -4,15 +4,15 @@
 #include <cstdint>
 
 #ifdef LMBD_LAMP_TYPE__SIMPLE
-#include "../../user/simple/constants.h"
+#include "src/user/simple/constants.h"
 #endif
 
 #ifdef LMBD_LAMP_TYPE__CCT
-#include "../../user/cct/constants.h"
+#include "src/user/cct/constants.h"
 #endif
 
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
-#include "../../user/indexable/constants.h"
+#include "src/user/indexable/constants.h"
 #endif
 
 #ifdef ARDUINO

--- a/src/system/utils/coordinates.cpp
+++ b/src/system/utils/coordinates.cpp
@@ -5,7 +5,8 @@
 #include <cmath>
 #include <cstdint>
 
-#include "../ext/math8.h"
+#include "src/system/ext/math8.h"
+
 #include "constants.h"
 
 uint16_t to_screen_x(const uint16_t ledIndex) {

--- a/src/system/utils/serial.cpp
+++ b/src/system/utils/serial.cpp
@@ -2,9 +2,10 @@
 
 #include <Arduino.h>
 
-#include "../charger/charger.h"
-#include "../physical/battery.h"
-#include "../utils/constants.h"
+#include "src/system/charger/charger.h"
+#include "src/system/physical/battery.h"
+#include "src/system/utils/constants.h"
+
 #include "constants.h"
 #include "utils.h"
 

--- a/src/system/utils/strip.h
+++ b/src/system/utils/strip.h
@@ -8,8 +8,9 @@
 #include <cstdint>
 #include <cstring>
 
-#include "../../user/indexable/constants.h"
-#include "../ext/scale8.h"
+#include "src/user/indexable/constants.h"
+#include "src/system/ext/scale8.h"
+
 #include "constants.h"
 #include "coordinates.h"
 #include "utils.h"

--- a/src/system/utils/utils.cpp
+++ b/src/system/utils/utils.cpp
@@ -5,8 +5,9 @@
 
 #include <cstdint>
 
-#include "../ext/math8.h"
-#include "../ext/scale8.h"
+#include "src/system/ext/math8.h"
+#include "src/system/ext/scale8.h"
+
 #include "colorspace.h"
 
 namespace utils {

--- a/src/user/cct/functions.cpp
+++ b/src/user/cct/functions.cpp
@@ -4,9 +4,9 @@
 
 #include <cstdint>
 
-#include "../../system/behavior.h"
-#include "../../system/physical/fileSystem.h"
-#include "../../system/utils/utils.h"
+#include "src/system/behavior.h"
+#include "src/system/physical/fileSystem.h"
+#include "src/system/utils/utils.h"
 
 namespace user {
 

--- a/src/user/indexable/functions.cpp
+++ b/src/user/indexable/functions.cpp
@@ -2,16 +2,16 @@
 
 #include "functions.h"
 
-#include "../../system/behavior.h"
-#include "../../system/charger/charger.h"
-#include "../../system/colors/animations.h"
-#include "../../system/colors/colors.h"
-#include "../../system/colors/palettes.h"
-#include "../../system/colors/wipes.h"
-#include "../../system/physical/IMU.h"
-#include "../../system/physical/MicroPhone.h"
-#include "../../system/physical/fileSystem.h"
-#include "../../system/utils/utils.h"
+#include "src/system/behavior.h"
+#include "src/system/charger/charger.h"
+#include "src/system/colors/animations.h"
+#include "src/system/colors/colors.h"
+#include "src/system/colors/palettes.h"
+#include "src/system/colors/wipes.h"
+#include "src/system/physical/IMU.h"
+#include "src/system/physical/MicroPhone.h"
+#include "src/system/physical/fileSystem.h"
+#include "src/system/utils/utils.h"
 
 namespace user {
 

--- a/src/user/indexable/functions.h
+++ b/src/user/indexable/functions.h
@@ -3,7 +3,8 @@
 
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
 
-#include "../../system/utils/strip.h"
+#include "src/system/utils/strip.h"
+
 #include "Arduino.h"
 
 namespace user {

--- a/src/user/simple/functions.cpp
+++ b/src/user/simple/functions.cpp
@@ -2,10 +2,10 @@
 
 #include "functions.h"
 
-#include "../../system/behavior.h"
-#include "../../system/physical/fileSystem.h"
-#include "../../system/physical/led_power.h"
-#include "../../system/utils/utils.h"
+#include "src/system/behavior.h"
+#include "src/system/physical/fileSystem.h"
+#include "src/system/physical/led_power.h"
+#include "src/system/utils/utils.h"
 
 namespace user {
 


### PR DESCRIPTION
This can be considered as a controversial change, but prefer

```diff
+ #include "src/user/simple/functions.h"
```
over
```diff
- #include "../user/simple/functions.h"
```

I've taken the occasion to add a guard in the project, to guide inexperienced users towards using `Makefile`