### PR TITLE
Add basic simulator for indexable modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,10 +493,35 @@ clean-doc:
 	@echo; echo " --- $@"
 	rm -f doc/index.html
 
-clean: clean-artifacts clean-doc
+clean: clean-artifacts clean-simulator clean-doc
 	@echo; echo " --- $@"
 	rm -rf $(OBJECTS_DIR) $(CACHE_DIR) $(BUILD_DIR)/*.txt
 	rm -rf $(BUILD_DIR)/.process-*-success $(BUILD_DIR)/.skip-*-clean
+
+#
+# simulator
+#
+
+.PRECIOUS: $(BUILD_DIR)/simulator/%-simulator
+
+$(BUILD_DIR)/simulator/%-simulator:
+	@echo; echo " --- $@"
+	@mkdir -p $(BUILD_DIR) $(BUILD_DIR)/simulator
+	@cd $(SRC_DIR)/simulator && \
+		LMBD_ROOT_DIR=$(SRC_DIR) SIMU_BUILD_DIR=$(BUILD_DIR)/simulator make $(shell basename "$@")
+
+clean-simulator:
+	@echo; echo " --- $@"
+	rm -rf $(BUILD_DIR)/simulator
+
+%-simulator: $(BUILD_DIR)/simulator/%-simulator
+	@echo " --- ok: $@"
+	@test -x '$<' \
+		&& (echo 'Artifact is ready here:'; echo '$<'; echo) \
+		|| (echo 'No artifact found, build failed?'; rm -f '$<')
+
+simulator: fire-simulator
+	@echo " --- ok: $@"
 
 #
 # remove

--- a/README.md
+++ b/README.md
@@ -209,6 +209,24 @@ ln -s venv path/to/other/virtualenv
 make clean-artifacts upload-indexable
 ```
 
+If you want simulate a view of an "indexable mode" animation and have the
+[SFML](https://www.sfml-dev.org/) installed:
+
+```sh
+cd LampColorControler
+make simulator
+./_build/simulator/*-simulator
+```
+
+If you want to work with "indexable mode" simulator, add your custom `$NAME`
+simulation in `$(SRC_DIR)/simulator/src/$NAME-simulator.cpp` then build with:
+
+```sh
+cd LampColorControler
+make clean-simulator $NAME-simulator
+./_build/simulator/$NAME-simulator
+```
+
 Once you're finished with your work on the project:
 
 ```sh

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -9,7 +9,7 @@ BUILD_DIR=${SIMU_BUILD_DIR}
 CXX=$(shell which c++)
 CXX_INCLUDE_DIRECTORIES=-I$(ROOT_DIR) -I$(SRC_DIR)include
 CXX_LDFLAGS=-lsfml-graphics -lsfml-window -lsfml-audio -lsfml-system
-CXX_EXTRA_FLAGS=#-Wall -Wextra -pedantic
+CXX_EXTRA_FLAGS=-fconcepts -DLMBD_CPP17 #-Wall -Wextra -pedantic
 CXX_BUILD_FLAGS=--std=c++17 -O3 $(CXX_EXTRA_FLAGS) $(CXX_INCLUDE_DIRECTORIES)
 
 all: build

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -1,0 +1,60 @@
+SRC_DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+ROOT_DIR=${LMBD_ROOT_DIR}
+BUILD_DIR=${SIMU_BUILD_DIR}
+#
+# Required environment variables:
+# 	- LMBD_ROOT_DIR root directory of the repository
+# 	- SIMU_BUILD_DIR target build directory (named "simulator")
+
+CXX=$(shell which c++)
+CXX_INCLUDE_DIRECTORIES=-I$(ROOT_DIR) -I$(SRC_DIR)include
+CXX_LDFLAGS=-lsfml-graphics -lsfml-window -lsfml-audio -lsfml-system
+CXX_EXTRA_FLAGS=#-Wall -Wextra -pedantic
+CXX_BUILD_FLAGS=--std=c++17 -O3 $(CXX_EXTRA_FLAGS) $(CXX_INCLUDE_DIRECTORIES)
+
+all: build
+
+check-deps:
+	@echo; echo " --- $@"
+	# building test program linked with SFML...
+	@echo 'int main(){}' > '$(BUILD_DIR)/.main.cpp'
+	@($(CXX) $(CXX_LDFLAGS) '$(BUILD_DIR)/.main.cpp' -o /dev/zero) || \
+		(echo; echo\
+		 ; echo 'ERROR: unable to link against the SFML library!' \
+		 ; echo \
+		 ; echo 'Troubleshooting:' \
+		 ; echo ' - detected compiler is $(CXX_BIN)' \
+		 ; echo ' - have you install the SFML development packages?'\
+		 ; echo ' - for example, use:' \
+		 ; echo '    - on Debian / Ubuntu: "apt-get install libsfml-dev"' \
+		 ; echo '    - on Archlinux / Manjaro: "pacman -S sfml"' \
+		 ; echo ' - listing /usr/lib for SFML is:' \
+		 ; echo ; ls /usr/lib/libsfml-*.so \
+		 ; echo \
+		 ; false)
+
+check-dirs:
+	@echo; echo " --- $@"
+	@test -d '$(BUILD_DIR)/../simulator' \
+		|| (echo; echo 'Bad path: SIMU_BUILD_DIR='$$SIMU_BUILD_DIR \
+			; echo 'Usage: SIMU_BUILD_DIR=../_build/simulator make' \
+			; echo; false)
+	@test -d '$(ROOT_DIR)/src/user' \
+		|| (echo; echo 'Bad path: LMBD_ROOT_DIR='$$LMBD_ROOT_DIR \
+			; echo 'Usage: LMBD_ROOT_DIR=../../LampColorControler make' \
+			; echo; false)
+
+.PRECIOUS: $(BUILD_DIR)/%-simulator
+
+$(BUILD_DIR)/%-simulator: $(SRC_DIR)src/%-simulator.cpp
+	@echo; echo " --- $@"
+	$(CXX) $(CXX_LDFLAGS) $(CXX_BUILD_FLAGS) $< -o $@
+
+%-simulator: check-dirs check-deps $(BUILD_DIR)/%-simulator
+	@echo " --- ok: $@$%"
+
+build: fire-simulator
+	@echo " --- ok: $@"
+
+clean:
+	rm -f $(BUILD_DIR)/*-simulator

--- a/simulator/include/Arduino.h
+++ b/simulator/include/Arduino.h
@@ -1,0 +1,93 @@
+#ifndef FAKE_ARDUINO_H
+#define FAKE_ARDUINO_H
+
+//
+// minimal Arduino.h replacement
+//
+
+#include <string>
+#include <type_traits>
+
+#include <cstdint>
+#include <cmath>
+
+// constants
+using String = std::string;
+
+#define PI 3.1415926535897
+#define TWO_PI 6.2831853071795
+#define HALF_PI 1.5707963267948
+
+//
+// lampda-specific hacks
+//
+
+#define D4 0x1004;
+#define D5 0x1005;
+#define D6 0x1006;
+#define D7 0x1007;
+#define D8 0x1008;
+
+using byte = uint8_t;
+
+template <typename T, typename U>
+T random(T min, U max) {
+  uint32_t n = random();
+  // bad random, but who cares?
+  return (n % (max - min)) + min;
+}
+
+template <typename T>
+T random(T max) {
+  return random(0, max);
+}
+
+//
+// ambiguous min/fmin/max/fmax/abs
+//
+
+static constexpr double min(double a, double b) {
+  return fmin(a, b);
+}
+
+static constexpr double max(double a, double b) {
+  return fmax(a, b);
+}
+
+using std::abs;
+
+//
+// misc functions
+//
+
+float radians(float degrees) {
+  return (degrees / 180.f) * PI;
+}
+
+template <typename T, typename V, typename U>
+static constexpr T constrain(const T& a, const V& mini, const U& maxi) {
+  if (a <= mini) return mini;
+  if (a >= maxi) return maxi;
+  return a;
+}
+
+template <typename T, typename V>
+static constexpr T pow(const T& a, const V& b) {
+  T acc = 1;
+  for (V i = 0; i < b; ++i) {
+    acc *= a;
+  }
+  return acc;
+}
+
+//
+// emulate millis()
+//
+
+static uint64_t globalMillis;
+
+uint64_t millis() {
+  return globalMillis;
+}
+
+#endif

--- a/simulator/include/simulator.h
+++ b/simulator/include/simulator.h
@@ -1,0 +1,351 @@
+#include <Arduino.h>
+
+#define LMBD_LAMP_TYPE__INDEXABLE
+#include "src/user/constants.h"
+
+#include <memory>
+#include <cstring>
+
+#include <SFML/Graphics.hpp>
+#include <SFML/Audio/SoundRecorder.hpp>
+
+#define LMBD_SIMU_ENABLED
+#define LMBD_SIMU_REALCOLORS
+
+constexpr int ledW = stripXCoordinates;
+constexpr int ledH = stripYCoordinates;
+
+namespace {
+#include "src/system/utils/utils.h"
+#include "src/system/utils/colorspace.cpp"
+}
+using utils::map;
+
+#include "src/system/utils/coordinates.cpp"
+
+//
+// led strip fake struct
+//
+
+struct LedStrip {
+  uint8_t brightness;
+  uint32_t leds[LED_COUNT];
+
+  uint8_t _buffer8b[LED_COUNT];
+  uint16_t _buffer16b[LED_COUNT];
+
+  std::unique_ptr<sf::RectangleShape> shapes[LED_COUNT];
+
+  LedStrip() {
+
+    brightness = 255;
+    for (size_t I = 0; I < LED_COUNT; ++I) {
+      leds[I] = 0;
+      shapes[I] = std::make_unique<sf::RectangleShape>();
+    }
+  }
+
+  uint8_t getBrightness() {
+    return brightness;
+  }
+
+  void setPixelColorXY(uint8_t X, uint8_t Y, uint8_t r, uint8_t g, uint8_t b);
+
+  template <typename T>
+  void setPixelColorXY(uint8_t X, uint8_t Y, T cc) {
+    uint32_t c;
+    memcpy(&c, &cc, sizeof(c));
+    uint64_t r = ((c >> 16) & 0xff);
+    uint64_t g = ((c >> 8) & 0xff);
+    uint64_t b = (c & 0xff);
+    setPixelColorXY(X, Y, r, g, b);
+  }
+
+  void setPixelColor(uint16_t led, uint8_t r, uint8_t g, uint8_t b) {
+
+#ifndef LMBD_SIMU_REALCOLORS
+    // non-linear scale for better display
+    if (r < 64) r *= 4;
+    if (g < 64) g *= 4;
+    if (b < 64) b *= 4;
+    if (r < 32) r *= 4;
+    if (g < 32) g *= 4;
+    if (b < 32) b *= 4;
+    if (r < 16) r *= 4;
+    if (g < 16) g *= 4;
+    if (b < 16) b *= 4;
+#endif
+
+    leds[led] = (r << 16) | (g << 8) | b;
+    return;
+  }
+
+  template <typename T>
+  void setPixelColor(uint16_t led, T cc) {
+    uint32_t c;
+    memcpy(&c, &cc, sizeof(c));
+    uint64_t r = ((c >> 16) & 0xff);
+    uint64_t g = ((c >> 8) & 0xff);
+    uint64_t b = (c & 0xff);
+    setPixelColor(led, r, g, b);
+  }
+
+  void fadeToBlackBy(uint8_t amount) {
+    for (size_t I = 0; I < LED_COUNT; ++I) {
+      uint64_t b = (leds[I] & 0xff);
+      uint64_t g = ((leds[I] >> 8) & 0xff);
+      uint64_t r = ((leds[I] >> 16) & 0xff);
+
+      r *= (240 - amount);
+      g *= (240 - amount);
+      b *= (240 - amount);
+
+      r /= 256;
+      g /= 256;
+      b /= 256;
+
+      leds[I] = (r << 16) | (g << 8) | b;
+    }
+  }
+
+  void fill(uint32_t c, uint16_t start, uint16_t end) {
+    for (size_t I = start; I < end; ++I) {
+      leds[I] = c;
+    }
+  }
+
+  void clear() {
+    fill(0, 0, LED_COUNT);
+  }
+
+  static uint32_t Color(uint8_t r, uint8_t g, uint8_t b) {
+    return (r << 16) | (g << 8) | b;
+  }
+
+  static uint32_t ColorHSV(double h, double s = 255, double v = 255);
+
+  uint32_t* get_buffer_ptr(int) {
+    return leds;
+  }
+
+  uint32_t getPixelColor(uint16_t idx) {
+    return leds[idx];
+  }
+
+  void buffer_current_colors(int) { }; // TODO: implement
+  void blur(int) { } // TODO: implement
+
+  Cartesian get_lamp_coordinates(int i) {
+    return to_lamp(i);
+  }
+};
+
+//
+// lampda-specific code
+//
+
+#define STRIP_H
+#include "src/system/ext/noise.cpp"
+#include "src/system/colors/palettes.cpp"
+#include "src/system/colors/colors.cpp"
+#include "src/system/colors/wipes.cpp"
+#include "src/system/colors/animations.cpp"
+
+namespace {
+#include "src/system/utils/utils.cpp"
+}
+
+//
+// LedStrip hacks
+//
+
+void LedStrip::setPixelColorXY(uint8_t X, uint8_t Y, uint8_t r, uint8_t g, uint8_t b) {
+  setPixelColor(to_strip(X, Y), r, g, b);
+}
+
+uint32_t LedStrip::ColorHSV(double h, double s, double v) {
+
+  int range = (int)std::floor(h / 60.0);
+  double c = v * s;
+  double x = c * (1 - abs(std::fmod(h / 60.0, 2) - 1.0));
+  double m = v - c;
+
+  uint8_t red = 0, green = 0, blue = 0;
+  switch (range) {
+    case 0:
+      red = (c + m) * 255;
+      green = (x + m) * 255;
+      blue = m * 255;
+      break;
+    case 1:
+      red = (x + m) * 255;
+      green = (c + m) * 255;
+      blue = m * 255;
+      break;
+    case 2:
+      red = m * 255;
+      green = (c + m) * 255;
+      blue = (x + m) * 255;
+      break;
+    case 3:
+      red = m * 255;
+      green = (x + m) * 255;
+      blue = (c + m) * 255;
+      break;
+    case 4:
+      red = (x + m) * 255;
+      green = m * 255;
+      blue = (c + m) * 255;
+      break;
+    default:  // case 5:
+      red = (c + m) * 255;
+      green = m * 255;
+      blue = (x + m) * 255;
+      break;
+  }
+
+  return (red << 16) | (blue << 8) | green;
+}
+
+//
+// basic microphone emulation
+//
+
+namespace microphone {
+
+static constexpr float silenceLevelDb = -57;
+static constexpr float highLevelDb = 80;
+
+static float sound_level;
+
+float get_sound_level_Db() {
+  return sound_level;
+}
+
+// to hook microphone & measure levelDb
+class LevelRecorder : public sf::SoundRecorder {
+    virtual bool onStart() { return true; }
+
+    virtual bool onProcessSamples(const sf::Int16* samples, std::size_t sampleCount) {
+      float sumOfAll = 0;
+      for(std::size_t i = 0; i < sampleCount; i++) {
+          sumOfAll += powf(samples[i] / (float) 1024.0, 2.0);
+	    }
+
+      const float average = sumOfAll / (float) sampleCount;
+      sound_level = 20.0 * log10f(sqrtf(average));
+      return true;
+    }
+
+    virtual void onStop() { }
+
+public:
+    ~LevelRecorder() { stop(); }
+};
+
+}
+
+using namespace microphone;
+
+//
+// simulator core loop
+//
+
+template <typename T>
+struct simulator {
+  static constexpr float screenWidth = 1920;
+  static constexpr float screenHeight = 1080;
+  static constexpr char title[] = "lampda simulator";
+
+  static int run() {
+    T simu{};
+
+    // time
+    sf::Clock clock;
+
+    // sound
+    LevelRecorder recorder;
+    recorder.start();
+
+    // fake strip
+    LedStrip strip{};
+
+    // render window
+    sf::RenderWindow window(sf::VideoMode(screenWidth, screenHeight), title);
+
+    uint64_t skipframe = 0;
+    while (window.isOpen()){
+
+      // faster fps if "F" key is pressed
+      if (simu.fps < 1000) {
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::F)) {
+          sf::sleep(sf::milliseconds(1000.f / (simu.fps * 3)));
+        } else {
+          sf::sleep(sf::milliseconds(1000.f / simu.fps));
+        }
+      }
+
+      // update millis
+      globalMillis = clock.getElapsedTime().asMilliseconds();
+
+      sf::Event event;
+      while (window.pollEvent(event)) {
+        if (event.type == sf::Event::Closed) {
+          window.close();
+          recorder.stop();
+        }
+
+        simu.customEventHandler(event);
+      }
+
+      // execute user function
+      simu.loop(strip);
+
+      if (simu.fps > 250) {
+        skipframe += 1;
+        if (skipframe % (((uint64_t) simu.fps) - 250) != 0)
+          continue;
+      }
+
+      // draw fake leds
+      window.clear();
+
+      for (int fXpos = -simu.fakeXorigin; fXpos < ledW - simu.fakeXend; ++fXpos) {
+        for (int Ypos = 0; Ypos < ledH; ++Ypos) {
+          int Yoff = 0;
+
+          int Xpos = fXpos;
+          if (fXpos < 0) {
+            Xpos = ledW + fXpos;
+            Yoff = 1;
+          }
+
+          size_t I = to_strip(Xpos, Ypos);
+          auto& shape = *strip.shapes[I];
+
+          const float ledSz = simu.ledSizePx;
+          const auto ledPadSz = simu.ledPaddingPx + simu.ledSizePx;
+          const auto ledOffset = simu.ledOffsetPx;
+          shape.setSize({ledSz, ledSz});
+
+          int rXpos = fXpos + simu.fakeXorigin;
+          int rYpos = Ypos + Yoff;
+          shape.setPosition(ledSz + rXpos * ledPadSz + ledOffset * (Ypos % 2) - Yoff * ledOffset,
+                            rYpos * ledPadSz);
+
+          uint64_t b = (strip.leds[I] & 0xff);
+          uint64_t g = ((strip.leds[I] >> 8) & 0xff);
+          uint64_t r = ((strip.leds[I] >> 16) & 0xff);
+
+          shape.setFillColor(sf::Color(r, g, b));
+          window.draw(shape);
+        }
+      }
+
+      window.display();
+    }
+
+    return 0;
+  }
+
+};

--- a/simulator/src/default_simulation.h
+++ b/simulator/src/default_simulation.h
@@ -1,0 +1,41 @@
+#ifndef LMBD_DEFAULT_SIMULATION_H
+#define LMBD_DEFAULT_SIMULATION_H
+
+struct defaultSimulation {
+  float fps = 60.f; // how fast animation is
+
+  float ledSizePx = 24.f; // square size to represent one LED (in pixels)
+  float ledPaddingPx = 4.f; // padding between two LEDs (in pixels)
+  float ledOffsetPx = 12.f; // how much LED offsets diagonally (in pixels)
+
+  float fakeXorigin = 0; // start strip N led to the left
+  float fakeXend = 0; // remove N led from right
+
+  void loop(LedStrip& strip) { }
+  void customEventHandler(sf::Event& event) { };
+
+  // TODO: implement
+  void button_clicked_default(const uint8_t clicks) { }
+  void button_hold_default(const uint8_t clicks,
+                           const bool isEndOfHoldEvent,
+                           const uint32_t holdDuration) { }
+
+  // TODO: implement
+  bool button_clicked_usermode(const uint8_t) { return false; }
+  bool button_hold_usermode(const uint8_t, const bool, const uint32_t) { return false; }
+
+  // warning: these are NOT implemented
+  void power_on_sequence() { }
+  void power_off_sequence() { }
+  void brightness_update(const uint8_t) { }
+  void write_parameters() { }
+  void read_parameters() { }
+  //
+  // TODO: implement
+
+  // warning these are NOT implemented
+  bool should_spawn_thread() { return false; }
+  void user_thread() { }
+};
+
+#endif

--- a/simulator/src/default_simulation.h
+++ b/simulator/src/default_simulation.h
@@ -11,6 +11,8 @@ struct defaultSimulation {
   float fakeXorigin = 0; // start strip N led to the left
   float fakeXend = 0; // remove N led from right
 
+  defaultSimulation(LedStrip& strip) { }
+
   void loop(LedStrip& strip) { }
   void customEventHandler(sf::Event& event) { };
 

--- a/simulator/src/distort-simulator.cpp
+++ b/simulator/src/distort-simulator.cpp
@@ -1,0 +1,79 @@
+#include <simulator.h>
+
+#include "default_simulation.h"
+
+void mode_2Ddistortionwaves(const uint8_t scale, const uint8_t speed,
+                            LedStrip& strip) {
+  const uint16_t cols = ceil(stripXCoordinates);
+  const uint16_t rows = ceil(stripYCoordinates);
+
+  uint8_t _speed = speed / 32;
+  uint8_t _scale = scale / 32;
+
+  uint8_t w = 2;
+
+  uint16_t a = millis() / 32;
+  uint16_t a2 = a / 2;
+  uint16_t a3 = a / 3;
+
+  uint16_t cx = beatsin8(10 - _speed, 0, cols - 1) * _scale;
+  uint16_t cy = beatsin8(12 - _speed, 0, rows - 1) * _scale;
+  uint16_t cx1 = beatsin8(13 - _speed, 0, cols - 1) * _scale;
+  uint16_t cy1 = beatsin8(15 - _speed, 0, rows - 1) * _scale;
+  uint16_t cx2 = beatsin8(17 - _speed, 0, cols - 1) * _scale;
+  uint16_t cy2 = beatsin8(14 - _speed, 0, rows - 1) * _scale;
+
+  uint16_t xoffs = 0;
+  for (int x = 0; x < cols; x++) {
+    xoffs += _scale;
+    uint16_t yoffs = 0;
+
+    for (int y = 0; y < rows; y++) {
+      yoffs += _scale;
+
+      byte rdistort =
+          cos8((cos8(((x << 3) + a) & 255) + cos8(((y << 3) - a2) & 255) + a3) &
+               255) >>
+          1;
+      byte gdistort = cos8((cos8(((x << 3) - a2) & 255) +
+                            cos8(((y << 3) + a3) & 255) + a + 32) &
+                           255) >>
+                      1;
+      byte bdistort = cos8((cos8(((x << 3) + a3) & 255) +
+                            cos8(((y << 3) - a) & 255) + a2 + 64) &
+                           255) >>
+                      1;
+
+      COLOR c;
+      c.red = rdistort + w * (a - (((xoffs - cx) * (xoffs - cx) +
+                                    (yoffs - cy) * (yoffs - cy)) >>
+                                   7));
+      c.green = gdistort + w * (a2 - (((xoffs - cx1) * (xoffs - cx1) +
+                                       (yoffs - cy1) * (yoffs - cy1)) >>
+                                      7));
+      c.blue = bdistort + w * (a3 - (((xoffs - cx2) * (xoffs - cx2) +
+                                      (yoffs - cy2) * (yoffs - cy2)) >>
+                                     7));
+
+      c.red = utils::gamma8(cos8(c.red));
+      c.green = utils::gamma8(cos8(c.green));
+      c.blue = utils::gamma8(cos8(c.blue));
+
+      strip.setPixelColorXY(x, y, c);
+    }
+  }
+}
+
+struct distortSimulation : public defaultSimulation {
+  float fps = 20.f;
+
+  void loop(LedStrip& strip) {
+    mode_2Ddistortionwaves(128, 128, strip);
+  }
+
+};
+
+int main() {
+  return simulator<distortSimulation>::run();
+}
+

--- a/simulator/src/fire-simulator.cpp
+++ b/simulator/src/fire-simulator.cpp
@@ -1,0 +1,36 @@
+#include <simulator.h>
+
+#include "default_simulation.h"
+
+void fire(const uint8_t scalex, const uint8_t scaley, const uint8_t speed,
+          const palette_t& palette, LedStrip& strip) {
+  static uint32_t step = 0;
+  uint16_t zSpeed = step / (256 - speed);
+  uint16_t ySpeed = millis() / (256 - speed);
+  for (int i = 0; i < ceil(stripXCoordinates); i++) {
+    for (int j = 0; j < ceil(stripYCoordinates); j++) {
+      strip.setPixelColorXY(
+          stripXCoordinates - i, j,
+          get_color_from_palette(
+              qsub8(noise8::inoise(i * scalex, j * scaley + ySpeed, zSpeed),
+                    abs8(j - (stripXCoordinates - 1)) * 255 /
+                        (stripXCoordinates - 1)),
+              palette));
+    }
+  }
+  step++;
+}
+
+struct fireSimulation : public defaultSimulation {
+  float fps = 20.f;
+
+  void loop(LedStrip& strip) {
+    fire(60, 60, 255, PaletteHeatColors, strip);
+  }
+
+};
+
+int main() {
+  return simulator<fireSimulation>::run();
+}
+


### PR DESCRIPTION
This is a quick & dirty simulator to help working with "indexable mode" animations:

![2024-11-07_18-07](https://github.com/user-attachments/assets/1f1fade0-26d5-48cd-8bde-56a342ae156e)

This is an example of the output produced:

![fire](https://github.com/user-attachments/assets/1d22a565-28d6-461f-8e07-1c637f559740)

**Note:** Some dubious hacks have been made and simulator code is brittle (subject to change / repaired many times)

Hopefully, as we move forward with better delimitation between hardware and user code, this caveat will fix itself!