### PR TITLE
Introduce a "mode manager" to abstract software from hardware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ COMPILER_CMD=$(shell $(ARDUINO_CLI) compile -b $(FQBN) --show-properties|grep co
 COMPILER_PATH=$(shell $(ARDUINO_CLI) compile -b $(FQBN) --show-properties|grep compiler.path|cut -f2 -d=)
 
 CPP_INCLUDES=-I$(OBJECTS_DIR)/sketch -DLMBD_MISSING_DEFINE
-CPP_BASIC_FLAGS=-std=gnu++17 -fconcepts -DLMBD_CPP17 -D$(FULL_LAMP_TYPE) $(CPP_INCLUDES)
+CPP_BASIC_FLAGS=-std=gnu++17 -fconcepts -DNDEBUG -DLMBD_CPP17 -D$(FULL_LAMP_TYPE) $(CPP_INCLUDES)
 CPP_BUILD_FLAGS=$(CPP_BASIC_FLAGS) -fdiagnostics-color=always -Wno-unused-parameter -ftemplate-backtrace-limit=1
 ARDUINO_EXTRA_FLAGS="compiler.cpp.extra_flags='$(CPP_INCLUDES) -D$(FULL_LAMP_TYPE)'"
 #
@@ -520,7 +520,7 @@ clean-simulator:
 		&& (echo 'Artifact is ready here:'; echo '$<'; echo) \
 		|| (echo 'No artifact found, build failed?'; rm -f '$<')
 
-simulator: fire-simulator
+simulator: main-simulator
 	@echo " --- ok: $@"
 
 #

--- a/doxygen.conf
+++ b/doxygen.conf
@@ -1103,7 +1103,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = src
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -9,7 +9,7 @@ BUILD_DIR=${SIMU_BUILD_DIR}
 CXX=$(shell which c++)
 CXX_INCLUDE_DIRECTORIES=-I$(ROOT_DIR) -I$(SRC_DIR)include
 CXX_LDFLAGS=-lsfml-graphics -lsfml-window -lsfml-audio -lsfml-system
-CXX_EXTRA_FLAGS=-fconcepts -DLMBD_CPP17 #-Wall -Wextra -pedantic
+CXX_EXTRA_FLAGS=-fconcepts -DLMBD_CPP17 -ftemplate-backtrace-limit=1 #-Wall -Wextra -pedantic
 CXX_BUILD_FLAGS=--std=c++17 -O3 $(CXX_EXTRA_FLAGS) $(CXX_INCLUDE_DIRECTORIES)
 
 all: build

--- a/simulator/src/default_simulation.h
+++ b/simulator/src/default_simulation.h
@@ -16,26 +16,21 @@ struct defaultSimulation {
   void loop(LedStrip& strip) { }
   void customEventHandler(sf::Event& event) { };
 
-  // TODO: implement
   void button_clicked_default(const uint8_t clicks) { }
   void button_hold_default(const uint8_t clicks,
                            const bool isEndOfHoldEvent,
                            const uint32_t holdDuration) { }
 
-  // TODO: implement
   bool button_clicked_usermode(const uint8_t) { return false; }
   bool button_hold_usermode(const uint8_t, const bool, const uint32_t) { return false; }
 
-  // warning: these are NOT implemented
+  void brightness_update(const uint8_t) { }
+
   void power_on_sequence() { }
   void power_off_sequence() { }
-  void brightness_update(const uint8_t) { }
   void write_parameters() { }
   void read_parameters() { }
-  //
-  // TODO: implement
 
-  // warning these are NOT implemented
   bool should_spawn_thread() { return false; }
   void user_thread() { }
 };

--- a/simulator/src/mode-simulator.cpp
+++ b/simulator/src/mode-simulator.cpp
@@ -1,0 +1,39 @@
+#include <simulator.h>
+
+#include "default_simulation.h"
+
+#include "src/modes/group_type.h"
+#include "src/modes/manager_type.h"
+#include "src/modes/mode_type.h"
+
+#include "src/modes/default/fixed_modes.h"
+#include "src/modes/legacy/legacy_modes.h"
+
+using ManagerTy = modes::ManagerFor<
+    modes::FixedModes,
+    modes::MiscFixedModes,
+    modes::legacy::CalmModes,
+    modes::legacy::PartyModes
+  >;
+
+struct modeSimulation : public defaultSimulation {
+  float fps = 60.f;
+
+  auto get_context() { return modeManager.get_context(); }
+
+  modeSimulation(LedStrip& strip)
+      : defaultSimulation(strip),
+        modeManager(strip) { }
+
+  void loop(auto&) { loop(); }
+
+#include "src/modes/behavior_manager.h"
+
+private:
+  ManagerTy modeManager;
+};
+
+int main() {
+  return simulator<modeSimulation>::run();
+}
+

--- a/src/modes/behavior_manager.hpp
+++ b/src/modes/behavior_manager.hpp
@@ -1,0 +1,218 @@
+#ifndef BEHAVIOR_MANAGER_H
+#define BEHAVIOR_MANAGER_H
+
+//
+// note: this code is included as-is by:
+//  - user/indexable_functions.h
+//  - simulator/src/mode-simulator.cpp
+//
+
+void power_on_sequence() {
+  auto manager = get_context();
+
+  // power on
+  pinMode(LED_POWER_PIN, OUTPUT);
+  digitalWrite(LED_POWER_PIN, HIGH);
+
+  // initialize the strip object
+  manager.strip.begin();
+  manager.strip.clear();
+  manager.strip.show();  // Turn OFF all pixels ASAP
+  manager.strip.setBrightness(BRIGHTNESS);
+
+  // callbacks
+  manager.power_on_sequence();
+}
+
+void power_off_sequence() {
+
+  // callbacks
+  auto manager = get_context();
+  manager.power_off_sequence();
+
+  // clean strip object
+  manager.strip.clear();
+  manager.strip.show();  // Clear all pixels
+
+  // power off
+  digitalWrite(LED_POWER_PIN, LOW);
+  pinMode(LED_POWER_PIN, OUTPUT_H0H1);
+  //
+  // high drive input (5mA)
+  // The only way to discharge the DC-DC pin...
+
+  // (no-op) internal symbol used during build
+  ensure_build_canary();
+}
+
+void brightness_update(const uint8_t brightness) {
+  auto manager = get_context();
+
+  // set brightness in strip object
+  manager.strip.setBrightness(brightness);
+
+  // callbacks
+  manager.brightness_update(brightness);
+}
+
+void write_parameters() {
+  auto manager = get_context();
+  manager.write_parameters();
+}
+
+void read_parameters() {
+  auto manager = get_context();
+  manager.read_parameters();
+  manager.reset_mode();
+}
+
+void button_clicked_default(const uint8_t clicks) {
+  auto manager = get_context();
+
+  switch (clicks) {
+    case 2: // 2 clicks: next mode
+      manager.next_mode();
+      break;
+
+    case 3: // 3 clicks: next group
+      manager.next_group();
+      break;
+
+    case 4: // 4 clicks: jump to favorite
+      manager.jump_to_favorite();
+      break;
+  }
+
+#ifdef LMBD_SIMU_ENABLED
+  fprintf(stderr, "group %d *mode %d\n",
+    manager.get_active_group(),
+    manager.get_active_mode());
+#endif
+}
+
+void button_hold_default(const uint8_t clicks,
+                         const bool isEndOfHoldEvent,
+                         const uint32_t holdDuration) {
+  auto manager = get_context();
+  auto& rampHandler = manager.state.rampHandler;
+  auto& scrollHandler = manager.state.scrollHandler;
+
+  switch (clicks) {
+    case 3: // 3 click+hold: configure custom ramp
+      rampHandler.update_ramp(
+        manager.get_active_custom_ramp(), holdDuration,
+        [&](uint8_t rampValue) {
+          manager.custom_ramp_update(rampValue);
+          manager.set_active_custom_ramp(rampValue);
+        });
+      break;
+
+    case 4: // 4 click+hold: scroll across modes and group
+      scrollHandler.update_ramp(128, holdDuration,
+        [&](uint8_t rampValue) {
+          uint8_t modeIndex = manager.get_active_mode();
+          uint8_t groupIndex = manager.get_active_group();
+          uint8_t modeCount = manager.get_modes_count();
+          uint8_t groupCount = manager.get_groups_count();
+
+          // we are going backward
+          //
+          if (rampValue < 128) {
+
+            // if modeIndex is not the first, just decrement it
+            if (modeIndex > 0) {
+              manager.set_active_mode(modeIndex - 1, modeCount);
+              manager.reset_mode();
+
+            // or else decrement group, then set mode to last one
+            } else {
+
+              // if groupIndex is not the first, just decrement it
+              if (groupIndex > 0) {
+                manager.set_active_group(groupIndex - 1, groupCount);
+
+              // else wrap to last group
+              } else {
+                manager.set_active_group(groupCount - 1, groupCount);
+              }
+
+              // backward scroll: set mode to last one on group change
+              modeCount = manager.get_modes_count();
+              manager.set_active_mode(modeCount - 1, modeCount);
+              manager.reset_mode();
+            }
+
+          // we are going forward
+          //
+          } else {
+
+            // if modeIndex is not the last, just increment it
+            if (modeIndex + 1 < modeCount) {
+              manager.next_mode();
+
+            // or else increment group
+            } else {
+
+              // if groupIndex is not the last, just increment it
+              if (groupIndex + 1 < groupCount) {
+                manager.next_group();
+
+              // else wrap to first group
+              } else {
+                manager.set_active_group(0, groupCount);
+              }
+
+              // forward scroll: set mode to first one on group change
+              manager.set_active_mode(0, modeCount);
+              manager.reset_mode();
+            }
+          }
+
+        });
+      break;
+
+    case 5: // 5 click+hold: configure favorite
+
+      // TODO: add button animation to help know when favorite is set
+      if (holdDuration > 2000) {
+        manager.set_favorite_now();
+      }
+
+      break;
+
+    default:
+      break;
+  }
+}
+
+bool button_clicked_usermode(const uint8_t clicks) {
+  auto manager = get_context();
+  return manager.custom_click(clicks);
+}
+
+bool button_hold_usermode(const uint8_t clicks,
+                          const bool isEndOfHoldEvent,
+                          const uint32_t holdDuration) {
+  auto manager = get_context();
+  return manager.custom_hold(clicks, isEndOfHoldEvent, holdDuration);
+}
+
+void loop() {
+  auto manager = get_context();
+  manager.loop();
+}
+
+bool should_spawn_thread() {
+  return true;
+}
+
+void user_thread() {
+  auto manager = get_context();
+  manager.strip.show();
+
+  if (manager.should_spawn_thread()) {
+    manager.user_thread();
+  }
+}
+
+#endif

--- a/src/modes/context_type.hpp
+++ b/src/modes/context_type.hpp
@@ -1,0 +1,327 @@
+#ifndef CONTEXT_TYPE_H
+#define CONTEXT_TYPE_H
+
+#include <cstdint>
+#include <type_traits>
+
+/** \file context_type.h
+ *  \brief ContextTy and associated definitions
+ **/
+
+#include "src/modes/tools.hpp"
+
+namespace modes {
+
+/// Bind provided context to another modes::BasicMode
+///
+/// \param[in] ctx Local context to bind to \p NewLocalMode
+/// \return A new context instance bound to the provided modes::BasicMode
+template <typename NewLocalMode>
+static auto context_as(auto& ctx) {
+  return ctx.template context_as<NewLocalMode>();
+}
+
+/// Local context exposing system features to active BasicMode
+template <typename LocalBasicMode, typename ModeManager>
+struct ContextTy {
+  friend ModeManager;
+
+  using SelfTy = ContextTy<LocalBasicMode, ModeManager>;
+  using ModeManagerTy = ModeManager;
+  using LocalModeTy = LocalBasicMode;
+  using StateTy = StateTyOf<LocalModeTy>;
+
+  //
+  // constructors
+  //
+
+  /// Get the same context, but for another mode, see modes::context_as()
+  template <typename NewLocalMode>
+  auto LMBD_INLINE context_as() {
+    return ContextTy<NewLocalMode, ModeManagerTy>(modeManager);
+  }
+
+  /// \private Use ModeManagerTy::get_context() to construct context
+  ContextTy(ModeManagerTy& modeManager)
+      : strip{modeManager.strip},
+        state{modeManager.template getStateOf<LocalModeTy>()},
+        modeManager{modeManager} { }
+
+  ContextTy() = delete; ///< \private
+  ContextTy(const ContextTy&) = delete; ///< \private
+  ContextTy& operator=(const ContextTy&) = delete; ///< \private
+
+  //
+  // manager calls
+  //
+
+  /// \private Jump to next group
+  auto LMBD_INLINE next_group() {
+    if constexpr (LocalModeTy::isGroupManager) {
+      LocalModeTy::next_group(*this);
+    } else {
+      auto& manager = modeManager.get_context();
+      return manager.next_group();
+    }
+  }
+
+  /// \private Jump to next mode
+  auto LMBD_INLINE next_mode() {
+    if constexpr (LocalModeTy::isModeManager) {
+      LocalModeTy::next_mode(*this);
+    } else {
+      auto& manager = modeManager.get_context();
+      return manager.next_mode();
+    }
+  }
+
+  /// \private Jump to favorite mode
+  auto LMBD_INLINE jump_to_favorite() {
+    if constexpr (LocalModeTy::isModeManager) {
+      LocalModeTy::jump_to_favorite(*this);
+    } else {
+      auto& manager = modeManager.get_context();
+      return manager.jump_to_favorite();
+    }
+  }
+
+  /// \private Set active favorite now
+  auto LMBD_INLINE set_favorite_now() {
+    if constexpr (LocalModeTy::isModeManager) {
+      LocalModeTy::set_favorite_now(*this);
+    } else {
+      auto& manager = modeManager.get_context();
+      return manager.set_favorite_now();
+    }
+  }
+
+
+  /// \private Get number of groups available
+  auto LMBD_INLINE get_groups_count() {
+    return modeManager.nbGroups;
+  }
+
+  /// \private Get number of modes available
+  auto LMBD_INLINE get_modes_count() {
+    if constexpr (LocalModeTy::isModeManager) {
+      return modeManager.get_modes_count(*this);
+    } else {
+      auto& manager = modeManager.get_context();
+      return manager.get_modes_count();
+    }
+  }
+
+  /// \private Reset active mode
+  auto LMBD_INLINE reset_mode() {
+    if constexpr (LocalModeTy::isModeManager) {
+      LocalModeTy::reset_mode(*this);
+    } else {
+      auto& manager = modeManager.get_context();
+      return manager.reset_mode();
+    }
+  }
+
+  //
+  // getters / setters for activeIndex
+  //
+
+  /// (getter) Get active group index
+  uint8_t LMBD_INLINE get_active_group(uint8_t maxValueWrap = 255) const {
+    uint8_t groupIndex = modeManager.activeIndex.groupIndex;
+    return (groupIndex + 1) > maxValueWrap ? 0 : groupIndex;
+  }
+
+  /// (setter) Set active group index
+  uint8_t LMBD_INLINE set_active_group(uint8_t value, uint8_t maxValueWrap = 255) {
+    if (value + 1 > maxValueWrap) value = 0;
+    modeManager.activeIndex.groupIndex = value;
+    return value;
+  }
+
+  /// (getter) Get active mode index (as numbered in local group)
+  uint8_t LMBD_INLINE get_active_mode(uint8_t maxValueWrap = 255) const {
+    uint8_t modeIndex = modeManager.activeIndex.modeIndex;
+    return (modeIndex + 1) > maxValueWrap ? 0 : modeIndex;
+  }
+
+  /// (setter) Set active mode index (as numbered in local group)
+  uint8_t LMBD_INLINE set_active_mode(uint8_t value, uint8_t maxValueWrap = 255) {
+    if (value + 1 > maxValueWrap) value = 0;
+    modeManager.activeIndex.modeIndex = value;
+    return value;
+  }
+
+  /** \brief (getter) Get active custom ramp value (as configured by user)
+   *
+   * \see BasicMode::custom_ramp_update()
+   */
+  uint8_t LMBD_INLINE get_active_custom_ramp() const {
+    return modeManager.activeIndex.rampIndex;
+  }
+
+  /** \brief (setter) Set active custom ramp value (overrides user choice)
+   *
+   * \see BasicMode::custom_ramp_update()
+   */
+  uint8_t LMBD_INLINE set_active_custom_ramp(uint8_t value) {
+    modeManager.activeIndex.rampIndex = value;
+    return value;
+  }
+
+  /** \brief (setter) Set if the custom ramp saturates or wrap around
+   *
+   * \in rampSaturates Set True if ramp should saturates, False to wrap around
+   */
+  void LMBD_INLINE set_custom_ramp_saturation(bool rampSaturates) {
+    auto ctx = modeManager.get_context();
+    ctx.state.rampHandler.rampSaturates = rampSaturates;
+  }
+
+  /// (getter) Get active custom index (recalled when jumping favorites)
+  uint8_t LMBD_INLINE get_active_custom_index() const {
+    return modeManager.activeIndex.customIndex;
+  }
+
+  /// (setter) Set active custom index (recalled when jumping favorites)
+  uint8_t LMBD_INLINE set_active_custom_index(uint8_t value) {
+    modeManager.activeIndex.customIndex = value;
+    return value;
+  }
+
+  //
+  // getters / setters for other properties
+  //
+
+  /// (getter) Return current brightness value
+  uint8_t LMBD_INLINE get_brightness() {
+    return BRIGHTNESS;
+  }
+
+  //
+  // strip interaction (indexable only)
+  //
+
+#ifdef LMBD_LAMP_TYPE__INDEXABLE
+  //
+  // TODO: better interface with hardware / indexable strip
+
+  void LMBD_INLINE fill(uint32_t color) {
+    for (uint16_t I = 0; I < LED_COUNT; ++I)
+      strip.setPixelColor(I, color);
+  }
+
+  void LMBD_INLINE fill(uint32_t color, uint16_t start, uint16_t end) {
+    for (uint16_t I = start; I < end; ++I)
+      strip.setPixelColor(I, color);
+  }
+
+#endif
+
+  //
+  // quick bindings to \p LocalModeTy
+  //
+
+  /// Binds to local BasicMode::loop()
+  void LMBD_INLINE loop() {
+    if constexpr (LocalModeTy::simpleMode) {
+      LocalModeTy::loop(this->strip);
+    } else {
+      LocalModeTy::loop(*this);
+    }
+  }
+
+  /// Binds to local BasicMode::reset()
+  void LMBD_INLINE reset() {
+    LocalModeTy::reset(*this);
+  }
+
+  /// Binds to local BasicMode::brightness_update()
+  void LMBD_INLINE brightness_update(LMBD_USED uint8_t brightness) {
+    if constexpr (LocalModeTy::hasBrightCallback) {
+      LocalModeTy::brightness_update(*this, brightness);
+    }
+  }
+
+  /// Binds to local BasicMode::custom_ramp_update()
+  void LMBD_INLINE custom_ramp_update(LMBD_USED uint8_t rampValue) {
+    if constexpr (LocalModeTy::hasCustomRamp) {
+      LocalModeTy::custom_ramp_update(*this, rampValue);
+    }
+  }
+
+  /// Binds to local BasicMode::custom_click()
+  bool LMBD_INLINE custom_click(LMBD_USED uint8_t nbClick) {
+    if constexpr (LocalModeTy::hasButtonCustomUI) {
+      return LocalModeTy::custom_click(*this, nbClick);
+    }
+
+    return false;
+  }
+
+  /// Binds to local BasicMode::custom_hold()
+  bool LMBD_INLINE custom_hold(LMBD_USED uint8_t nbClickAndHold,
+                               LMBD_USED bool isEndOfHoldEvent,
+                               LMBD_USED uint32_t holdDuration) {
+    if constexpr (LocalModeTy::hasButtonCustomUI) {
+      return LocalModeTy::custom_hold(*this,
+                                      nbClickAndHold,
+                                      isEndOfHoldEvent,
+                                      holdDuration);
+    }
+
+    return false;
+  }
+
+  /// Binds to local BasicMode::power_on_sequence()
+  void LMBD_INLINE power_on_sequence() {
+    if constexpr (LocalModeTy::hasSystemCallbacks) {
+      LocalModeTy::power_on_sequence(*this);
+    }
+  }
+
+  /// Binds to local BasicMode::power_off_sequence()
+  void LMBD_INLINE power_off_sequence() {
+    if constexpr (LocalModeTy::hasSystemCallbacks) {
+      LocalModeTy::power_off_sequence(*this);
+    }
+  }
+
+  /// Binds to local BasicMode::write_parameters()
+  void LMBD_INLINE write_parameters() {
+    if constexpr (LocalModeTy::hasSystemCallbacks) {
+      LocalModeTy::write_parameters(*this);
+    }
+  }
+
+  /// Binds to local BasicMode::read_parameters()
+  void LMBD_INLINE read_parameters() {
+    if constexpr (LocalModeTy::hasSystemCallbacks) {
+      LocalModeTy::read_parameters(*this);
+    }
+  }
+
+  /// Returns BasicMode::requireUserThread
+  bool LMBD_INLINE should_spawn_thread() {
+    return LocalModeTy::requireUserThread;
+  }
+
+  /// Binds to local BasicMode::user_thread()
+  void LMBD_INLINE user_thread() {
+    if constexpr (LocalModeTy::requireUserThread) {
+      LocalModeTy::user_thread(*this);
+    }
+  }
+
+  //
+  // context members for direct access
+  //
+
+  LedStrip& strip;
+  StateTy& state;
+private:
+  ModeManagerTy& modeManager;
+};
+
+} // namespace modes
+
+#endif

--- a/src/modes/custom/my_custom_mode.hpp
+++ b/src/modes/custom/my_custom_mode.hpp
@@ -1,0 +1,47 @@
+#ifndef MY_CUSTOM_MODE_H
+#define MY_CUSTOM_MODE_H
+
+struct MyCustomMode : public modes::FullMode {
+
+  static void loop(auto& ctx) { }
+  static void reset(auto& ctx) { }
+
+  // only if hasBrightCallback
+  static void brightness_update(auto& ctx, uint8_t brightness) { }
+
+  // only if hasCustomRamp
+  static void custom_ramp_update(auto& ctx, uint8_t rampValue) { }
+
+  // only if hasButtonCustomUI
+  static bool custom_click(auto& ctx, uint8_t nbClick) {
+    return false;
+  }
+
+  static bool custom_hold(auto& ctx,
+                          uint8_t nbClickAndHold,
+                          bool isEndOfHoldEvent,
+                          uint32_t holdDuration) {
+    return false;
+  }
+
+  // only if hasSystemCallbacks
+  static void power_on_sequence(auto& ctx) { }
+  static void power_off_sequence(auto& ctx) { }
+  static void read_parameters(auto& ctx) { }
+  static void write_parameters(auto& ctx) { }
+
+  // only if requireUserThread
+  static void user_thread(auto& ctx) { }
+
+  // keep only if customized
+  struct StateTy { };
+
+  // keep only the ones you need (= true)
+  static constexpr bool hasBrightCallback = false;
+  static constexpr bool hasCustomRamp = false;
+  static constexpr bool hasButtonCustomUI = false;
+  static constexpr bool hasSystemCallbacks = false;
+  static constexpr bool requireUserThread = false;
+}
+
+#endif

--- a/src/modes/default/fixed_modes.hpp
+++ b/src/modes/default/fixed_modes.hpp
@@ -1,0 +1,91 @@
+#ifndef FIXED_MODES_H
+#define FIXED_MODES_H
+
+#include "src/modes/include/colors/palettes.hpp"
+
+namespace modes {
+
+namespace fixed {
+
+/// Single-color mode for indexable strips with palette ramp
+struct FixedMode : public modes::FullMode {
+  static void loop(auto& ctx) {
+    uint32_t color = modes::colors::from_palette(
+      ctx.get_active_custom_ramp(),
+      ctx.state.palette);
+    ctx.fill(color);
+  }
+};
+
+//
+// main lightning modes
+//
+
+/// Black-body fixed colors ramp mode
+struct KelvinMode : public FixedMode {
+  struct StateTy {
+    static constexpr modes::colors::PaletteTy palette = modes::colors::PaletteBlackBodyColors;
+  };
+
+  // (enable the ramp to saturates, instead of wrapping ramp around)
+  static void reset(auto& ctx) {
+    ctx.set_custom_ramp_saturation(true);
+  }
+};
+
+/// Rainbow fixed colors ramp mode
+struct RainbowMode : public modes::FullMode {
+  static void loop(auto& ctx) {
+    const float index = ctx.get_active_custom_ramp();
+    const float hue = (index / 256.f) * 360.f;
+    uint32_t color = utils::hue_to_rgb_sinus(hue);
+
+    ctx.fill(color);
+  }
+};
+
+//
+// optional "miscellaneous" group of other gradients
+//
+
+/// Party fixed colors ramp mode
+struct PalettePartyMode : public FixedMode {
+  struct StateTy {
+    static constexpr modes::colors::PaletteTy palette = modes::colors::PalettePartyColors;
+  };
+};
+
+/// Forest fixed colors ramp mode
+struct PaletteForestMode : public FixedMode {
+  struct StateTy {
+    static constexpr modes::colors::PaletteTy palette = modes::colors::PaletteForestColors;
+  };
+};
+
+/// Ocean fixed colors ramp mode
+struct PaletteOceanMode : public FixedMode {
+  struct StateTy {
+    static constexpr modes::colors::PaletteTy palette = modes::colors::PaletteOceanColors;
+  };
+};
+
+} // modes::fixed
+
+//
+// Fixed modes groups
+//
+
+using FixedModes = modes::GroupFor<
+  fixed::KelvinMode,
+  fixed::RainbowMode
+>;
+
+using MiscFixedModes = modes::GroupFor<
+  fixed::PalettePartyMode,
+  fixed::PaletteForestMode,
+  fixed::PaletteOceanMode
+>;
+
+} // modes
+
+#endif

--- a/src/modes/group_type.hpp
+++ b/src/modes/group_type.hpp
@@ -1,0 +1,230 @@
+#ifndef MODE_GROUP_H
+#define MODE_GROUP_H
+
+#include <cstdint>
+#include <cassert>
+#include <utility>
+#include <optional>
+#include <tuple>
+#include <array>
+
+/** \file group_type.h
+ *  \brief modes::GroupFor and associated definitions
+ **/
+
+#include "src/modes/context_type.hpp"
+#include "src/modes/manager_type.hpp"
+#include "src/modes/mode_type.hpp"
+#include "src/modes/tools.hpp"
+
+namespace modes {
+
+/// \private Return true if a mode failed verification to prevent extra errors
+template <typename AllModes>
+static constexpr bool verifyGroup() {
+    constexpr bool inheritsFromBasicMode = details::allOf<AllModes>::inheritsFromBasicMode;
+    static_assert(inheritsFromBasicMode, "All modes must inherit from modes::BasicMode!");
+
+    constexpr bool stateDefaultConstructible = details::allOf<AllModes>::stateDefaultConstructible;
+    static_assert(stateDefaultConstructible, "All states must be default constructible!");
+
+    bool acc = false;
+    acc |= !inheritsFromBasicMode;
+    acc |= !stateDefaultConstructible;
+    return acc ;
+}
+
+/// \private Implementation details of modes::GroupFor
+template <typename AllModes, bool earlyFail = verifyGroup<AllModes>()>
+struct GroupTy {
+
+  // tuple helper
+  using SelfTy = GroupTy<AllModes>;
+  using AllModesTy = AllModes;
+  using AllStatesTy = details::StateTyFrom<AllModes>;
+  static constexpr uint8_t nbModes{std::tuple_size_v<AllModesTy>};
+
+  template <uint8_t Idx>
+  using ModeAtRaw = std::tuple_element_t<Idx, AllModesTy>;
+
+  template <uint8_t Idx>
+  using ModeAt = std::conditional_t<!earlyFail, ModeAtRaw<Idx>, BasicMode>;
+
+  // required to support group-level context
+  using HasAnyMode = details::anyOf<AllModesTy, earlyFail>;
+  static constexpr bool simpleMode = false;
+  static constexpr bool hasBrightCallback = HasAnyMode::hasBrightCallback;
+  static constexpr bool hasSystemCallbacks = HasAnyMode::hasSystemCallbacks;
+  static constexpr bool requireUserThread = HasAnyMode::requireUserThread;
+  static constexpr bool hasCustomRamp = HasAnyMode::hasCustomRamp;
+  static constexpr bool hasButtonCustomUI = HasAnyMode::hasButtonCustomUI;
+
+  // constructors
+  GroupTy() = delete;
+  GroupTy(const GroupTy&) = delete;
+  GroupTy& operator=(const GroupTy&) = delete;
+
+  /// \private Dispatch active mode to callback
+  template<typename CallBack>
+  static void LMBD_INLINE dispatch_mode(auto& ctx, CallBack&& cb) {
+    uint8_t modeId = ctx.get_active_mode(nbModes);
+
+    details::unroll<nbModes>([&](auto Idx) LMBD_INLINE {
+      if (Idx == modeId) {
+        cb(context_as<ModeAt<Idx>>(ctx));
+      }
+    });
+  }
+
+  /// \private Forward each mode to callback (if eligible)
+  template<bool systemCallbacksOnly, typename CallBack>
+  static void LMBD_INLINE foreach_mode(auto& ctx, CallBack&& cb) {
+    if constexpr (systemCallbacksOnly) {
+      details::unroll<nbModes>([&](auto Idx) LMBD_INLINE {
+        if /* TODO: constexpr */ (ModeAt<Idx>::hasSystemCallbacks) {
+          cb(context_as<ModeAt<Idx>>(ctx));
+        }
+      });
+    } else {
+      details::unroll<nbModes>([&](auto Idx) LMBD_INLINE {
+        cb(context_as<ModeAt<Idx>>(ctx));
+      });
+    }
+  }
+
+  //
+  // state
+  //
+
+  struct StateTy {
+    AllStatesTy modeStates;
+    std::array<uint8_t, nbModes> customRampMemory;
+    std::array<uint8_t, nbModes> customIndexMemory;
+  };
+
+  template <typename Mode>
+  static auto* LMBD_INLINE getStateOf(auto& manager) {
+    using StateTy = typename Mode::StateTy;
+    using OptionalTy = std::optional<StateTy>;
+
+    StateTy* substate = nullptr;
+    details::unroll<nbModes>([&](auto Idx) LMBD_INLINE {
+      using ModeHere = ModeAt<Idx>;
+      constexpr bool isHere = std::is_same_v<ModeHere, Mode>;
+
+      if constexpr (isHere) {
+        auto* state = manager.template getStateGroupOf<SelfTy>();
+        if (state) {
+          OptionalTy& opt = std::get<OptionalTy>(state->modeStates);
+          if (!opt.has_value()) {
+            opt.emplace(); // all StateTy must be default-contructible :)
+          }
+
+          StateTy& stateHere = *opt;
+          substate = &stateHere;
+        }
+      }
+    });
+
+    assert(substate != nullptr && "this should not have happened!");
+    return substate;
+  }
+
+  //
+  // navigation
+  //
+
+  static constexpr bool isGroupManager = false;
+  static constexpr bool isModeManager = true;
+
+  static void next_mode(auto& ctx) {
+    uint8_t modeIdBefore = ctx.get_active_mode(nbModes);
+
+    ctx.state.customRampMemory[modeIdBefore] = ctx.get_active_custom_ramp();
+    ctx.state.customIndexMemory[modeIdBefore] = ctx.get_active_custom_index();
+    ctx.set_active_mode(modeIdBefore + 1, nbModes);
+
+    uint8_t modeIdAfter = ctx.get_active_mode(nbModes);
+    ctx.set_active_custom_ramp(ctx.state.customRampMemory[modeIdAfter]);
+    ctx.set_active_custom_index(ctx.state.customIndexMemory[modeIdAfter]);
+
+    ctx.reset_mode();
+  }
+
+  static void reset_mode(auto& ctx) {
+    dispatch_mode(ctx, [](auto mode) { mode.reset(); });
+  }
+
+  //
+  // all the callbacks
+  //
+
+  static void loop(auto& ctx) {
+    dispatch_mode(ctx, [](auto mode) { mode.loop(); });
+  }
+
+  static void brightness_update(auto& ctx, uint8_t brightness) {
+    dispatch_mode(ctx, [&](auto mode) {
+      mode.brightness_update(brightness);
+    });
+  }
+
+  static void custom_ramp_update(auto& ctx, uint8_t rampValue) {
+    dispatch_mode(ctx, [&](auto mode) {
+      mode.custom_ramp_update(rampValue);
+    });
+  }
+
+  static bool custom_click(auto& ctx, uint8_t nbClick) {
+    bool retVal = false;
+    dispatch_mode(ctx, [&](auto mode) {
+      retVal = mode.custom_click(nbClick);
+    });
+    return retVal;
+  }
+
+  static bool custom_hold(auto& ctx,
+                          uint8_t nbClickAndHold,
+                          bool isEndOfHoldEvent,
+                          uint32_t holdDuration) {
+    bool retVal = false;
+    dispatch_mode(ctx, [&](auto mode) {
+      retVal = mode.custom_hold(nbClickAndHold,
+                                isEndOfHoldEvent,
+                                holdDuration);
+    });
+    return retVal;
+  }
+
+  static void power_on_sequence(auto& ctx) {
+    foreach_mode<true>(ctx, [](auto mode) { mode.power_on_sequence(); });
+  }
+
+  static void power_off_sequence(auto& ctx) {
+    foreach_mode<true>(ctx, [](auto mode) { mode.power_off_sequence(); });
+  }
+
+  static void write_parameters(auto& ctx) {
+    foreach_mode<true>(ctx, [](auto mode) { mode.write_parameters(); });
+  }
+
+  static void read_parameters(auto& ctx) {
+    foreach_mode<true>(ctx, [](auto mode) { mode.read_parameters(); });
+  }
+
+  static void user_thread(auto& ctx) {
+    dispatch_mode(ctx, [](auto mode) { mode.user_thread(); });
+  }
+};
+
+/** \brief Group together many different modes::BasicMode
+ *
+ * Binds all methods of the provided list of \p Modes and works together
+ * with modes::ModeManagerTy to dispatch events and switch modes
+ */
+template <typename... Modes>
+using GroupFor = GroupTy<std::tuple<Modes...>>;
+
+} // namespace modes
+
+#endif

--- a/src/modes/include/colors/palettes.hpp
+++ b/src/modes/include/colors/palettes.hpp
@@ -1,0 +1,397 @@
+#ifndef MODES_PALETTES_H
+#define MODES_PALETTES_H
+
+#include <cstdint>
+#include <array>
+
+namespace modes::colors {
+
+using PaletteTy = std::array<uint32_t, 16>;
+
+/// @brief Color temperature values
+/// @details These color values are separated into two groups: black body
+/// radiators and gaseous light sources.
+///
+/// Black body radiators emit a (relatively) continuous spectrum,
+/// and can be described as having a Kelvin 'temperature'. This includes things
+/// like candles, tungsten lightbulbs, and sunlight.
+///
+/// Gaseous light sources emit discrete spectral bands, and while we can
+/// approximate their aggregate hue with RGB values, they don't actually
+/// have a proper Kelvin temperature.
+///
+/// @see https://en.wikipedia.org/wiki/Color_temperature
+typedef enum {
+  // Black Body Radiators
+  // @{
+  /// 1900 Kelvin
+  Candle = 0xFF9329 /* 1900 K, 255, 147, 41 */,
+  /// 2600 Kelvin
+  Tungsten40W = 0xFFC58F /* 2600 K, 255, 197, 143 */,
+  /// 2850 Kelvin
+  Tungsten100W = 0xFFD6AA /* 2850 K, 255, 214, 170 */,
+  /// 3200 Kelvin
+  Halogen = 0xFFF1E0 /* 3200 K, 255, 241, 224 */,
+  /// 5200 Kelvin
+  CarbonArc = 0xFFFAF4 /* 5200 K, 255, 250, 244 */,
+  /// 5400 Kelvin
+  HighNoonSun = 0xFFFFFB /* 5400 K, 255, 255, 251 */,
+  /// 6000 Kelvin
+  DirectSunlight = 0xFFFFFF /* 6000 K, 255, 255, 255 */,
+  /// 7000 Kelvin
+  OvercastSky = 0xC9E2FF /* 7000 K, 201, 226, 255 */,
+  /// 20000 Kelvin
+  ClearBlueSky = 0x409CFF /* 20000 K, 64, 156, 255 */,
+  // @}
+
+  // Gaseous Light Sources
+  // @{
+  /// Warm (yellower) flourescent light bulbs
+  WarmFluorescent = 0xFFF4E5 /* 0 K, 255, 244, 229 */,
+  /// Standard flourescent light bulbs
+  StandardFluorescent = 0xF4FFFA /* 0 K, 244, 255, 250 */,
+  /// Cool white (bluer) flourescent light bulbs
+  CoolWhiteFluorescent = 0xD4EBFF /* 0 K, 212, 235, 255 */,
+  /// Full spectrum flourescent light bulbs
+  FullSpectrumFluorescent = 0xFFF4F2 /* 0 K, 255, 244, 242 */,
+  /// Grow light flourescent light bulbs
+  GrowLightFluorescent = 0xFFEFF7 /* 0 K, 255, 239, 247 */,
+  /// Black light flourescent light bulbs
+  BlackLightFluorescent = 0xA700FF /* 0 K, 167, 0, 255 */,
+  /// Mercury vapor light bulbs
+  MercuryVapor = 0xD8F7FF /* 0 K, 216, 247, 255 */,
+  /// Sodium vapor light bulbs
+  SodiumVapor = 0xFFD1B2 /* 0 K, 255, 209, 178 */,
+  /// Metal-halide light bulbs
+  MetalHalide = 0xF2FCFF /* 0 K, 242, 252, 255 */,
+  /// High-pressure sodium light bulbs
+  HighPressureSodium = 0xFFB74C /* 0 K, 255, 183, 76 */,
+  // @}
+
+  /// Uncorrected temperature (0xFFFFFF)
+  UncorrectedTemperature = 0xFFFFFF /* 255, 255, 255 */
+} ColorTemperature;
+
+
+typedef enum {
+  AliceBlue = 0xF0F8FF,             ///< @htmlcolorblock{F0F8FF}
+  Amethyst = 0x9966CC,              ///< @htmlcolorblock{9966CC}
+  AntiqueWhite = 0xFAEBD7,          ///< @htmlcolorblock{FAEBD7}
+  Aqua = 0x00FFFF,                  ///< @htmlcolorblock{00FFFF}
+  Aquamarine = 0x7FFFD4,            ///< @htmlcolorblock{7FFFD4}
+  Azure = 0xF0FFFF,                 ///< @htmlcolorblock{F0FFFF}
+  Beige = 0xF5F5DC,                 ///< @htmlcolorblock{F5F5DC}
+  Bisque = 0xFFE4C4,                ///< @htmlcolorblock{FFE4C4}
+  Black = 0x000000,                 ///< @htmlcolorblock{000000}
+  BlanchedAlmond = 0xFFEBCD,        ///< @htmlcolorblock{FFEBCD}
+  Blue = 0x0000FF,                  ///< @htmlcolorblock{0000FF}
+  BlueViolet = 0x8A2BE2,            ///< @htmlcolorblock{8A2BE2}
+  Brown = 0xA52A2A,                 ///< @htmlcolorblock{A52A2A}
+  BurlyWood = 0xDEB887,             ///< @htmlcolorblock{DEB887}
+  CadetBlue = 0x5F9EA0,             ///< @htmlcolorblock{5F9EA0}
+  Chartreuse = 0x7FFF00,            ///< @htmlcolorblock{7FFF00}
+  Chocolate = 0xD2691E,             ///< @htmlcolorblock{D2691E}
+  Coral = 0xFF7F50,                 ///< @htmlcolorblock{FF7F50}
+  CornflowerBlue = 0x6495ED,        ///< @htmlcolorblock{6495ED}
+  Cornsilk = 0xFFF8DC,              ///< @htmlcolorblock{FFF8DC}
+  Crimson = 0xDC143C,               ///< @htmlcolorblock{DC143C}
+  Cyan = 0x00FFFF,                  ///< @htmlcolorblock{00FFFF}
+  DarkBlue = 0x00008B,              ///< @htmlcolorblock{00008B}
+  DarkCyan = 0x008B8B,              ///< @htmlcolorblock{008B8B}
+  DarkGoldenrod = 0xB8860B,         ///< @htmlcolorblock{B8860B}
+  DarkGray = 0xA9A9A9,              ///< @htmlcolorblock{A9A9A9}
+  DarkGrey = 0xA9A9A9,              ///< @htmlcolorblock{A9A9A9}
+  DarkGreen = 0x006400,             ///< @htmlcolorblock{006400}
+  DarkKhaki = 0xBDB76B,             ///< @htmlcolorblock{BDB76B}
+  DarkMagenta = 0x8B008B,           ///< @htmlcolorblock{8B008B}
+  DarkOliveGreen = 0x556B2F,        ///< @htmlcolorblock{556B2F}
+  DarkOrange = 0xFF8C00,            ///< @htmlcolorblock{FF8C00}
+  DarkOrchid = 0x9932CC,            ///< @htmlcolorblock{9932CC}
+  DarkRed = 0x8B0000,               ///< @htmlcolorblock{8B0000}
+  DarkSalmon = 0xE9967A,            ///< @htmlcolorblock{E9967A}
+  DarkSeaGreen = 0x8FBC8F,          ///< @htmlcolorblock{8FBC8F}
+  DarkSlateBlue = 0x483D8B,         ///< @htmlcolorblock{483D8B}
+  DarkSlateGray = 0x2F4F4F,         ///< @htmlcolorblock{2F4F4F}
+  DarkSlateGrey = 0x2F4F4F,         ///< @htmlcolorblock{2F4F4F}
+  DarkTurquoise = 0x00CED1,         ///< @htmlcolorblock{00CED1}
+  DarkViolet = 0x9400D3,            ///< @htmlcolorblock{9400D3}
+  DeepPink = 0xFF1493,              ///< @htmlcolorblock{FF1493}
+  DeepSkyBlue = 0x00BFFF,           ///< @htmlcolorblock{00BFFF}
+  DimGray = 0x696969,               ///< @htmlcolorblock{696969}
+  DimGrey = 0x696969,               ///< @htmlcolorblock{696969}
+  DodgerBlue = 0x1E90FF,            ///< @htmlcolorblock{1E90FF}
+  FireBrick = 0xB22222,             ///< @htmlcolorblock{B22222}
+  FloralWhite = 0xFFFAF0,           ///< @htmlcolorblock{FFFAF0}
+  ForestGreen = 0x228B22,           ///< @htmlcolorblock{228B22}
+  Fuchsia = 0xFF00FF,               ///< @htmlcolorblock{FF00FF}
+  Gainsboro = 0xDCDCDC,             ///< @htmlcolorblock{DCDCDC}
+  GhostWhite = 0xF8F8FF,            ///< @htmlcolorblock{F8F8FF}
+  Gold = 0xFFD700,                  ///< @htmlcolorblock{FFD700}
+  Goldenrod = 0xDAA520,             ///< @htmlcolorblock{DAA520}
+  Gray = 0x808080,                  ///< @htmlcolorblock{808080}
+  Grey = 0x808080,                  ///< @htmlcolorblock{808080}
+  Green = 0x008000,                 ///< @htmlcolorblock{008000}
+  GreenYellow = 0xADFF2F,           ///< @htmlcolorblock{ADFF2F}
+  Honeydew = 0xF0FFF0,              ///< @htmlcolorblock{F0FFF0}
+  HotPink = 0xFF69B4,               ///< @htmlcolorblock{FF69B4}
+  IndianRed = 0xCD5C5C,             ///< @htmlcolorblock{CD5C5C}
+  Indigo = 0x4B0082,                ///< @htmlcolorblock{4B0082}
+  Ivory = 0xFFFFF0,                 ///< @htmlcolorblock{FFFFF0}
+  Khaki = 0xF0E68C,                 ///< @htmlcolorblock{F0E68C}
+  Lavender = 0xE6E6FA,              ///< @htmlcolorblock{E6E6FA}
+  LavenderBlush = 0xFFF0F5,         ///< @htmlcolorblock{FFF0F5}
+  LawnGreen = 0x7CFC00,             ///< @htmlcolorblock{7CFC00}
+  LemonChiffon = 0xFFFACD,          ///< @htmlcolorblock{FFFACD}
+  LightBlue = 0xADD8E6,             ///< @htmlcolorblock{ADD8E6}
+  LightCoral = 0xF08080,            ///< @htmlcolorblock{F08080}
+  LightCyan = 0xE0FFFF,             ///< @htmlcolorblock{E0FFFF}
+  LightGoldenrodYellow = 0xFAFAD2,  ///< @htmlcolorblock{FAFAD2}
+  LightGreen = 0x90EE90,            ///< @htmlcolorblock{90EE90}
+  LightGrey = 0xD3D3D3,             ///< @htmlcolorblock{D3D3D3}
+  LightPink = 0xFFB6C1,             ///< @htmlcolorblock{FFB6C1}
+  LightSalmon = 0xFFA07A,           ///< @htmlcolorblock{FFA07A}
+  LightSeaGreen = 0x20B2AA,         ///< @htmlcolorblock{20B2AA}
+  LightSkyBlue = 0x87CEFA,          ///< @htmlcolorblock{87CEFA}
+  LightSlateGray = 0x778899,        ///< @htmlcolorblock{778899}
+  LightSlateGrey = 0x778899,        ///< @htmlcolorblock{778899}
+  LightSteelBlue = 0xB0C4DE,        ///< @htmlcolorblock{B0C4DE}
+  LightYellow = 0xFFFFE0,           ///< @htmlcolorblock{FFFFE0}
+  Lime = 0x00FF00,                  ///< @htmlcolorblock{00FF00}
+  LimeGreen = 0x32CD32,             ///< @htmlcolorblock{32CD32}
+  Linen = 0xFAF0E6,                 ///< @htmlcolorblock{FAF0E6}
+  Magenta = 0xFF00FF,               ///< @htmlcolorblock{FF00FF}
+  Maroon = 0x800000,                ///< @htmlcolorblock{800000}
+  MediumAquamarine = 0x66CDAA,      ///< @htmlcolorblock{66CDAA}
+  MediumBlue = 0x0000CD,            ///< @htmlcolorblock{0000CD}
+  MediumOrchid = 0xBA55D3,          ///< @htmlcolorblock{BA55D3}
+  MediumPurple = 0x9370DB,          ///< @htmlcolorblock{9370DB}
+  MediumSeaGreen = 0x3CB371,        ///< @htmlcolorblock{3CB371}
+  MediumSlateBlue = 0x7B68EE,       ///< @htmlcolorblock{7B68EE}
+  MediumSpringGreen = 0x00FA9A,     ///< @htmlcolorblock{00FA9A}
+  MediumTurquoise = 0x48D1CC,       ///< @htmlcolorblock{48D1CC}
+  MediumVioletRed = 0xC71585,       ///< @htmlcolorblock{C71585}
+  MidnightBlue = 0x191970,          ///< @htmlcolorblock{191970}
+  MintCream = 0xF5FFFA,             ///< @htmlcolorblock{F5FFFA}
+  MistyRose = 0xFFE4E1,             ///< @htmlcolorblock{FFE4E1}
+  Moccasin = 0xFFE4B5,              ///< @htmlcolorblock{FFE4B5}
+  NavajoWhite = 0xFFDEAD,           ///< @htmlcolorblock{FFDEAD}
+  Navy = 0x000080,                  ///< @htmlcolorblock{000080}
+  OldLace = 0xFDF5E6,               ///< @htmlcolorblock{FDF5E6}
+  Olive = 0x808000,                 ///< @htmlcolorblock{808000}
+  OliveDrab = 0x6B8E23,             ///< @htmlcolorblock{6B8E23}
+  Orange = 0xFFA500,                ///< @htmlcolorblock{FFA500}
+  OrangeRed = 0xFF4500,             ///< @htmlcolorblock{FF4500}
+  Orchid = 0xDA70D6,                ///< @htmlcolorblock{DA70D6}
+  PaleGoldenrod = 0xEEE8AA,         ///< @htmlcolorblock{EEE8AA}
+  PaleGreen = 0x98FB98,             ///< @htmlcolorblock{98FB98}
+  PaleTurquoise = 0xAFEEEE,         ///< @htmlcolorblock{AFEEEE}
+  PaleVioletRed = 0xDB7093,         ///< @htmlcolorblock{DB7093}
+  PapayaWhip = 0xFFEFD5,            ///< @htmlcolorblock{FFEFD5}
+  PeachPuff = 0xFFDAB9,             ///< @htmlcolorblock{FFDAB9}
+  Peru = 0xCD853F,                  ///< @htmlcolorblock{CD853F}
+  Pink = 0xFFC0CB,                  ///< @htmlcolorblock{FFC0CB}
+  Plaid = 0xCC5533,                 ///< @htmlcolorblock{CC5533}
+  Plum = 0xDDA0DD,                  ///< @htmlcolorblock{DDA0DD}
+  PowderBlue = 0xB0E0E6,            ///< @htmlcolorblock{B0E0E6}
+  Purple = 0x800080,                ///< @htmlcolorblock{800080}
+  Red = 0xFF0000,                   ///< @htmlcolorblock{FF0000}
+  RosyBrown = 0xBC8F8F,             ///< @htmlcolorblock{BC8F8F}
+  RoyalBlue = 0x4169E1,             ///< @htmlcolorblock{4169E1}
+  SaddleBrown = 0x8B4513,           ///< @htmlcolorblock{8B4513}
+  Salmon = 0xFA8072,                ///< @htmlcolorblock{FA8072}
+  SandyBrown = 0xF4A460,            ///< @htmlcolorblock{F4A460}
+  SeaGreen = 0x2E8B57,              ///< @htmlcolorblock{2E8B57}
+  Seashell = 0xFFF5EE,              ///< @htmlcolorblock{FFF5EE}
+  Sienna = 0xA0522D,                ///< @htmlcolorblock{A0522D}
+  Silver = 0xC0C0C0,                ///< @htmlcolorblock{C0C0C0}
+  SkyBlue = 0x87CEEB,               ///< @htmlcolorblock{87CEEB}
+  SlateBlue = 0x6A5ACD,             ///< @htmlcolorblock{6A5ACD}
+  SlateGray = 0x708090,             ///< @htmlcolorblock{708090}
+  SlateGrey = 0x708090,             ///< @htmlcolorblock{708090}
+  Snow = 0xFFFAFA,                  ///< @htmlcolorblock{FFFAFA}
+  SpringGreen = 0x00FF7F,           ///< @htmlcolorblock{00FF7F}
+  SteelBlue = 0x4682B4,             ///< @htmlcolorblock{4682B4}
+  Tan = 0xD2B48C,                   ///< @htmlcolorblock{D2B48C}
+  Teal = 0x008080,                  ///< @htmlcolorblock{008080}
+  Thistle = 0xD8BFD8,               ///< @htmlcolorblock{D8BFD8}
+  Tomato = 0xFF6347,                ///< @htmlcolorblock{FF6347}
+  Turquoise = 0x40E0D0,             ///< @htmlcolorblock{40E0D0}
+  Violet = 0xEE82EE,                ///< @htmlcolorblock{EE82EE}
+  Wheat = 0xF5DEB3,                 ///< @htmlcolorblock{F5DEB3}
+  White = 0xFFFFFF,                 ///< @htmlcolorblock{FFFFFF}
+  WhiteSmoke = 0xF5F5F5,            ///< @htmlcolorblock{F5F5F5}
+  Yellow = 0xFFFF00,                ///< @htmlcolorblock{FFFF00}
+  YellowGreen = 0x9ACD32,           ///< @htmlcolorblock{9ACD32}
+
+  // LED RGB color that roughly approximates
+  // the color of incandescent fairy lights,
+  // assuming that you're using FastLED
+  // color correction on your LEDs (recommended).
+  FairyLight = 0xFFE42D,  ///< @htmlcolorblock{FFE42D}
+
+  // If you are using no color correction, use this
+  FairyLightNCC = 0xFF9D2A  ///< @htmlcolorblock{FFE42D}
+
+} HTMLColorCode;
+
+//
+// inline palette definitions
+//
+
+/// Cloudy color palette/ blue to blue-white
+static constexpr PaletteTy PaletteCloudColors = {Blue,      DarkBlue, DarkBlue,  DarkBlue,
+                                       DarkBlue,  DarkBlue, DarkBlue,  DarkBlue,
+                                       Blue,      DarkBlue, SkyBlue,   SkyBlue,
+                                       LightBlue, White,    LightBlue, SkyBlue};
+
+/// Lava color palette
+static constexpr PaletteTy PaletteLavaColors = {
+    Black,   Maroon, Black,  Maroon, DarkRed, Maroon, DarkRed, DarkRed,
+    DarkRed, Red,    Orange, White,  Orange,  Red,    DarkRed, Black};
+
+/// Fire color palette
+static constexpr PaletteTy PaletteFlameColors = {
+    Orange, Orange, Orange, Orange, Orange, Orange, Orange, Orange,
+    Orange, Orange, Orange, Orange, Candle, Orange, Orange, Gold};
+
+/// Ocean colors, blues and whites
+static constexpr PaletteTy PaletteOceanColors = {
+    MidnightBlue, DarkBlue, MidnightBlue, Navy,        DarkBlue, MediumBlue,
+    SeaGreen,     Teal,     CadetBlue,    Blue,        DarkCyan, CornflowerBlue,
+    Aquamarine,   SeaGreen, Aqua,         LightSkyBlue};
+
+/// Forest colors, greens
+static constexpr PaletteTy PaletteForestColors = {
+    DarkGreen,  DarkGreen,        DarkOliveGreen,   DarkGreen,
+    Green,      ForestGreen,      OliveDrab,        Green,
+    SeaGreen,   MediumAquamarine, LimeGreen,        YellowGreen,
+    LightGreen, LawnGreen,        MediumAquamarine, ForestGreen};
+
+/// HSV Rainbow
+static constexpr PaletteTy PaletteRainbowColors = {
+    0xFF0000, 0xD52A00, 0xAB5500, 0xAB7F00,
+    0xABAB00, 0x56D500, 0x00FF00, 0x00D52A,
+    0x00AB55, 0x0056AA, 0x0000FF, 0x2A00D5,
+    0x5500AB, 0x7F0081, 0xAB0055, 0xD5002B};
+
+// basically, HSV with no green. looks better when lighing people
+static constexpr PaletteTy PalettePartyColors = {
+    0x5500AB, 0x84007C, 0xB5004B, 0xE5001B,
+    0xE81700, 0xB84700, 0xAB7700, 0xABAB00,
+    0xAB5500, 0xDD2200, 0xF2000E, 0xC2003E,
+    0x8F0071, 0x5F00A1, 0x2F00D0, 0x0007F9};
+
+// Black body radiation
+static constexpr PaletteTy PaletteBlackBodyColors = {
+    0xff3800, 0xff5300, 0xff6500, 0xff7300, 0xff7e00, 0xff8912,
+    0xff932c, 0xff9d3f, 0xffa54f, 0xffad5e, 0xffb46b, 0xffbb78,
+    0xffc184, 0xffc78f, 0xffcc99, 0xffd1a3};
+
+static constexpr PaletteTy PaletteHeatColors = {
+    0x000000, 0x330000, 0x660000, 0x990000,
+    0xCC0000, 0xFF0000, 0xFF3300, 0xFF6600,
+    0xFF9900, 0xFFCC00, 0xFFFF00, 0xFFFF33,
+    0xFFFF66, 0xFFFF99, 0xFFFFCC};
+
+static constexpr PaletteTy PaletteAuroraColors = {
+    0x000000, 0x003300, 0x006600, 0x009900,
+    0x00cc00, 0x00ff00, 0x33ff00, 0x66ff00,
+    0x99ff00, 0xccff00, 0xffff00, 0xffcc00,
+    0xff9900, 0xff6600, 0xff3300, 0xff0000};
+
+/**
+ * \brief Return a color from a palette
+ * \param[in] index from 0 to 255, the index of color we want from the palette
+ * \param[in] palette The palette to sample from. Values are interpolated
+ * \param[in] brightness The brighness of the color, default is max at 255
+ * \return The desired color
+ */
+template <typename UIntTy = uint8_t>
+static constexpr uint32_t from_palette(UIntTy index,
+                                       const PaletteTy& palette,
+                                       uint8_t brightness = 255) {
+
+  // convert to [0; 15] (divide by 16)
+  uint8_t renormIndex = index >> 4;
+  // get least significant part for the blend factor
+  uint8_t blendIndex = index & 0x0F;
+
+  // support for uint16_t
+  if constexpr (sizeof(UIntTy) > 1) {
+    const float findex = index;
+    const float percent = (findex / ((float) UINT16_MAX)) * 16.f;
+    renormIndex = percent;
+    blendIndex = 256.f * (percent - renormIndex);
+    static_assert(std::is_same_v<UIntTy, uint16_t>, "u8 or u16");
+  }
+
+  if (renormIndex >= 16) return 0;
+  const uint32_t entry = palette[renormIndex];
+
+  // convert to rgb
+  uint8_t red1 = (entry & 0xff0000) >> 16;
+  uint8_t green1 = (entry & 0x00ff00) >> 8;
+  uint8_t blue1 = entry & 0x0000ff;
+
+  // need to blend the palette
+  if (blendIndex != 0) {
+    uint32_t nextColor = 0;
+    if (renormIndex == 15) {
+      nextColor = palette[0];
+    } else {
+      nextColor = palette[1 + renormIndex];
+    }
+
+    const uint8_t tmpF2 = blendIndex << 4;
+    const float f1 = (255 - tmpF2) / 256.0;
+    const float f2 = tmpF2 / 256.0;
+
+    const uint8_t red2 = (nextColor & 0xff0000) >> 16;
+    red1 = red1 * f1;
+    red1 += red2 * f2;
+
+    const uint8_t green2 = (nextColor & 0x00ff00) >> 8;
+    green1 = green1 * f1;
+    green1 += green2 * f2;
+
+    const uint8_t blue2 = nextColor & 0x0000ff;
+    blue1 = blue1 * f1;
+    blue1 += blue2 * f2;
+  }
+
+  if (brightness != 255) {
+    if (brightness != 0) {
+      const float adjustedBrightness =
+          (brightness + 1) / 256.0;  // adjust for rounding
+      // Now, since brightness is nonzero, we don't need the full scale8_video
+      // logic; we can just to scale8 and then add one (unless scale8 fixed) to
+      // all nonzero inputs.
+      if (red1) {
+        red1 = red1 * adjustedBrightness;
+        ++red1;
+      }
+      if (green1) {
+        green1 = green1 * adjustedBrightness;
+        ++green1;
+      }
+      if (blue1) {
+        blue1 = blue1 * adjustedBrightness;
+        ++blue1;
+      }
+    } else {
+      red1 = 0;
+      green1 = 0;
+      blue1 = 0;
+    }
+  }
+
+  // return color code
+  uint32_t outputColor = red1;
+  outputColor = (outputColor << 8) | green1;
+  outputColor = (outputColor << 8) | blue1;
+  return outputColor;
+}
+
+} // namespace modes::colors
+
+#endif

--- a/src/modes/legacy/legacy_modes.hpp
+++ b/src/modes/legacy/legacy_modes.hpp
@@ -1,0 +1,262 @@
+#ifndef LEGACY_MODES_H
+#define LEGACY_MODES_H
+
+#include "src/system/charger/charger.h"
+#include "src/system/utils/utils.h"
+#include "src/system/colors/animations.h"
+#include "src/system/colors/colors.h"
+#include "src/system/colors/palettes.h"
+#include "src/system/colors/wipes.h"
+#include "src/system/physical/fileSystem.h"
+#include "src/system/physical/IMU.h"
+#include "src/system/physical/MicroPhone.h"
+
+namespace modes::legacy {
+
+/// Just a way to highlight which modes still uses src/system
+using LegacyMode = FullMode;
+using LegacySimpleMode = BasicMode;
+
+//
+// legacy calm modes
+//
+
+namespace calm {
+
+/// Do a rainbow swirl!
+struct RainbowSwirlMode : public LegacyMode {
+  static void loop(auto& ctx) {
+    auto& state = ctx.state;
+    animations::fill(state.rainbowSwirl, ctx.strip);
+    state.rainbowSwirl.update();
+  }
+
+  static void reset(auto& ctx) {
+    ctx.state.rainbowSwirl.reset();
+  }
+
+  struct StateTy {
+    GenerateRainbowSwirl rainbowSwirl = GenerateRainbowSwirl(5000);
+  };
+};
+
+/// Fade slowly between PalettePartyColors
+struct PartyFadeMode : public LegacyMode {
+  static void loop(auto& ctx) {
+    auto& state = ctx.state;
+    state.isFinished = animations::fade_in(
+      state.palettePartyColor, 100, state.isFinished, ctx.strip);
+
+    if (state.isFinished) {
+      state.palettePartyColor.update(++state.currentIndex);
+    }
+  }
+
+  static void reset(auto& ctx) {
+    auto& state = ctx.state;
+    state.currentIndex = 0;
+    state.palettePartyColor.reset();
+  }
+
+  struct StateTy {
+    GeneratePaletteIndexed palettePartyColor = GeneratePaletteIndexed(PalettePartyColors);
+    uint8_t currentIndex = 0;
+    bool isFinished = false;
+  };
+};
+
+/** \brief Parent class for legacy noise modes
+ *
+ * Inherit from `NoiseMode<YourMode>`
+ *  - this enable all derived `StateTy` to be unique
+ */
+template <typename T>
+struct NoiseMode : public LegacyMode {
+  static void reset(auto& ctx) {
+    ctx.state.categoryChange = true;
+  }
+
+  struct StateTy {
+    void random_noise(auto& strip, const palette_t& palette) {
+      animations::random_noise(palette, strip, categoryChange, true, 3);
+      categoryChange = false;
+    }
+
+    bool categoryChange = false;
+  };
+};
+
+/// Noise from PaletteLavaColors
+struct LavaNoiseMode : public NoiseMode<LavaNoiseMode> {
+  static void loop(auto& ctx) {
+    ctx.state.random_noise(ctx.strip, PaletteLavaColors);
+  }
+};
+
+/// Noise from PaletteForestColors
+struct ForestNoiseMode : public NoiseMode<ForestNoiseMode> {
+  static void loop(auto& ctx) {
+    ctx.state.random_noise(ctx.strip, PaletteForestColors);
+  }
+};
+
+/// Noise from PaletteOceanColors
+struct OceanNoiseMode : public NoiseMode<OceanNoiseMode> {
+  static void loop(auto& ctx) {
+    ctx.state.random_noise(ctx.strip, PaletteOceanColors);
+  }
+};
+
+/// Polar lights
+struct PolarMode : public LegacyMode {
+  static void loop(auto& ctx) {
+    auto& categoryChange = ctx.state.categoryChange;
+    animations::mode_2DPolarLights(
+      255, 128, PaletteAuroraColors, categoryChange, ctx.strip);
+    categoryChange = false;
+  }
+
+  static void reset(auto& ctx) {
+    ctx.state.categoryChange = true;
+  }
+
+  struct StateTy {
+    bool categoryChange = false;
+  };
+};
+
+/// Fireplace
+struct FireMode : public LegacySimpleMode {
+  static void loop(auto& strip) {
+    animations::fire(60, 60, 255, PaletteHeatColors, strip);
+  }
+};
+
+/// Rainbow sin waves
+struct SineMode : public LegacySimpleMode {
+  static void loop(auto& strip) {
+    animations::mode_sinewave(128, 128, PaletteRainbowColors, strip);
+  }
+};
+
+/// Bubbles
+struct DriftMode : public LegacySimpleMode {
+  static void loop(auto& strip) {
+    animations::mode_2DDrift(64, 64, PaletteRainbowColors, strip);
+  }
+};
+
+/// Distortion
+struct DistMode : public LegacySimpleMode {
+  static void loop(auto& strip) {
+    animations::mode_2Ddistortionwaves(128, 128, strip);
+  }
+};
+
+} // modes::legacy::calm
+
+//
+// legacy party modes
+//
+
+namespace party {
+
+/// Wipe up and down complementary colors
+struct ColorWipeMode : public LegacyMode {
+  static void loop(auto& ctx) {
+    auto& state = ctx.state;
+    state.isFinished = state.switchMode ? (
+        animations::color_wipe_up(state.complementaryColor, 500, state.isFinished, ctx.strip)
+      ) : (
+        animations::color_wipe_down(state.complementaryColor, 500, state.isFinished, ctx.strip)
+      );
+
+    if (state.isFinished) {
+      state.switchMode = !state.switchMode;
+      state.complementaryColor.update();
+    }
+  }
+
+  static void reset(auto& ctx) {
+    ctx.state.complementaryColor.reset();
+  }
+
+  struct StateTy {
+    GenerateComplementaryColor complementaryColor = GenerateComplementaryColor(0.3);
+    bool switchMode = false;
+    bool isFinished = false;
+  };
+};
+
+/// Animated random color fill from each side
+struct RandomFillMode : public LegacyMode {
+  static void loop(auto& ctx) {
+    auto& state = ctx.state;
+    state.isFinished = animations::double_side_fill(
+      state.randomColor, 500, state.isFinished, ctx.strip);
+
+    if (state.isFinished) {
+      state.randomColor.update();
+    }
+  }
+
+  static void reset(auto& ctx) {
+    ctx.state.randomColor.reset();
+  }
+
+  struct StateTy {
+    GenerateRandomColor randomColor = GenerateRandomColor();
+    bool isFinished = false;
+  };
+};
+
+/// Animated back-and-forth with random complementary color
+struct PingPongMode : public LegacyMode {
+  static void loop(auto& ctx) {
+    auto& state = ctx.state;
+    state.isFinished = animations::dot_ping_pong(
+      state.complementaryPingPongColor, 1000, 128, state.isFinished, ctx.strip);
+
+    if (state.isFinished) {
+      state.complementaryPingPongColor.update();
+    }
+  }
+
+  static void reset(auto& ctx) {
+    ctx.state.complementaryPingPongColor.reset();
+  }
+
+  struct StateTy {
+    GenerateComplementaryColor complementaryPingPongColor = GenerateComplementaryColor(0.4);
+    bool isFinished = false;
+  };
+};
+
+} // modes::legacy::party
+
+//
+// Legacy modes groups
+//
+
+using CalmModes = modes::GroupFor<
+  calm::RainbowSwirlMode,
+  calm::PartyFadeMode,
+  calm::LavaNoiseMode,
+  calm::ForestNoiseMode,
+  calm::OceanNoiseMode,
+  calm::PolarMode,
+  calm::FireMode,
+  calm::SineMode,
+  calm::DriftMode,
+  calm::DistMode
+>;
+
+using PartyModes = modes::GroupFor<
+  party::ColorWipeMode,
+  party::RandomFillMode,
+  party::PingPongMode
+>;
+
+} // modes::legacy
+
+#endif

--- a/src/modes/manager_type.hpp
+++ b/src/modes/manager_type.hpp
@@ -1,0 +1,381 @@
+#ifndef MANAGER_TYPE_H
+#define MANAGER_TYPE_H
+
+#include <cstdint>
+#include <cassert>
+#include <utility>
+#include <tuple>
+#include <array>
+
+/** \file manager_type.h
+ *  \brief modes::ManagerFor and associated definitions
+ **/
+
+#include "src/modes/tools.hpp"
+#include "src/modes/context_type.hpp"
+
+namespace modes {
+
+/// \private Active state is designated by a 64 integer
+union ActiveIndexTy {
+  struct {
+    uint8_t groupIndex; // group id (as ordered in the manager)
+    uint8_t modeIndex; // mode id (as ordered in its group)
+    uint8_t rampIndex; // ramp value (as set by the user)
+    uint8_t customIndex; // custom (as set by the mode)
+  };
+
+  uint64_t rawIndex;
+};
+
+/// \private Contains the logic to handle a fixed-timestep range
+struct RampHandlerTy {
+  static constexpr uint32_t startPeriod = 128;
+
+  // \in stepSpeed how long to wait before incrementing (ms)
+  // \in rampSaturates does the ramp saturates, or else wrap around?
+  RampHandlerTy(uint32_t stepSpeed = 16, bool rampSaturates = false)
+    : stepSpeed{stepSpeed}, rampSaturates{rampSaturates},
+      lastTimeMeasured{1000}, isForward{true} { }
+
+  void LMBD_INLINE update_ramp(uint8_t rampValue,
+                               uint32_t holdTime,
+                               auto callback) {
+
+    // restart the rampage
+    if (holdTime < lastTimeMeasured) {
+      lastTimeMeasured = holdTime;
+
+      if (holdTime < startPeriod) {
+
+        // toggle forward / backward direction
+        isForward = !isForward;
+        if (rampSaturates) {
+          if (rampValue == 0) isForward = true;
+          if (rampValue == 255) isForward = false;
+        }
+      }
+      return;
+    }
+
+    // count how many step we advanced
+    uint32_t lastCounter = lastTimeMeasured / stepSpeed;
+    uint32_t nextCounter = holdTime / stepSpeed;
+    if (nextCounter <= lastCounter)
+      return;
+
+    // apply steps
+    for (uint32_t I = 0; I < nextCounter - lastCounter; ++I) {
+
+      // increment iff possible
+      if (isForward && (!rampSaturates || rampValue < 255))
+        rampValue += 1;
+
+      // decrement iff possible
+      if (!isForward && (!rampSaturates || rampValue > 0))
+        rampValue -= 1;
+
+      // forward value to callback
+      callback(rampValue);
+    }
+
+    lastTimeMeasured = holdTime;
+  }
+
+  uint32_t stepSpeed;
+  bool rampSaturates;
+  uint32_t lastTimeMeasured;
+  bool isForward;
+};
+
+/// \private Implementation details of modes::ManagerFor
+template <typename AllGroups>
+struct ModeManagerTy {
+
+  // tuple helpers
+  using SelfTy = ModeManagerTy<AllGroups>;
+  using AllGroupsTy = AllGroups;
+  using AllStatesTy = details::StateTyFrom<AllGroups>;
+  static constexpr uint8_t nbGroups{std::tuple_size_v<AllGroupsTy>};
+
+  template <uint8_t Idx>
+  using GroupAt = std::tuple_element_t<Idx, AllGroupsTy>;
+
+  // required to support manager-level context
+  using HasAnyGroup = details::anyOf<AllGroupsTy>;
+  static constexpr bool simpleMode = false;
+  static constexpr bool hasBrightCallback = HasAnyGroup::hasBrightCallback;
+  static constexpr bool hasSystemCallbacks = HasAnyGroup::hasSystemCallbacks;
+  static constexpr bool requireUserThread = HasAnyGroup::requireUserThread;
+  static constexpr bool hasCustomRamp = HasAnyGroup::hasCustomRamp;
+  static constexpr bool hasButtonCustomUI = HasAnyGroup::hasButtonCustomUI;
+
+  // constructors
+  ModeManagerTy(LedStrip& strip)
+    : activeIndex{{0, 0, 0, 0}}, strip{strip} { }
+
+  ModeManagerTy() = delete;
+  ModeManagerTy(const ModeManagerTy&) = delete;
+  ModeManagerTy& operator=(const ModeManagerTy&) = delete;
+
+  /// \private Get root context bound to manager
+  auto get_context() {
+    return ContextTy<SelfTy, SelfTy>(*this);
+  }
+
+  /// \private Dispatch active group to callback
+  template<typename CallBack>
+  static void LMBD_INLINE dispatch_group(auto& ctx, CallBack&& cb) {
+    uint8_t groupId = ctx.get_active_group(nbGroups);
+
+    details::unroll<nbGroups>([&](auto Idx) LMBD_INLINE {
+      if (Idx == groupId) {
+        cb(context_as<GroupAt<Idx>>(ctx));
+      }
+    });
+  }
+
+  /// \private Forward each group to callback (if eligible)
+  template<bool systemCallbacksOnly, typename CallBack>
+  static void LMBD_INLINE foreach_group(auto& ctx, CallBack&& cb) {
+    if constexpr (systemCallbacksOnly) {
+      details::unroll<nbGroups>([&](auto Idx) LMBD_INLINE {
+        using GroupHere = GroupAt<Idx>;
+        constexpr bool hasCallbacks = GroupHere::hasSystemCallbacks;
+
+        if constexpr (hasCallbacks) {
+          cb(context_as<GroupAt<Idx>>(ctx));
+        }
+      });
+    } else {
+      details::unroll<nbGroups>([&](auto Idx) LMBD_INLINE {
+        cb(context_as<GroupAt<Idx>>(ctx));
+      });
+    }
+  }
+
+  //
+  // state
+  //
+
+  struct StateTy {
+    AllStatesTy groupStates;
+    RampHandlerTy rampHandler = {16};
+    RampHandlerTy scrollHandler = {512};
+    ActiveIndexTy currentFavorite = {0, 0, 0, 0};
+    std::array<uint8_t, nbGroups> lastModeMemory = {};
+
+    // (executed before user reset_mode)
+    static void LMBD_INLINE reset_config(auto& ctx) {
+      auto& self = ctx.state;
+      self.rampHandler.rampSaturates = false;
+    }
+  };
+
+  template <typename Group>
+  StateTyOf<Group>* LMBD_INLINE getStateGroupOf() {
+    using StateTy = StateTyOf<Group>;
+    using OptionalTy = std::optional<StateTy>;
+
+    StateTy* substate = nullptr;
+    details::unroll<nbGroups>([&](auto Idx) LMBD_INLINE {
+      using GroupHere = GroupAt<Idx>;
+      constexpr bool IsHere = std::is_same_v<GroupHere, Group>;
+
+      if constexpr (IsHere) {
+        OptionalTy& opt = std::get<OptionalTy>(state.groupStates);
+        if (!opt.has_value()) {
+          opt.emplace();
+        }
+
+        StateTy& stateHere = *opt;
+        substate = &stateHere;
+      }
+    });
+    assert(substate != nullptr && "this should not have compiled at all!");
+
+    static_assert(details::ModeBelongsTo<Group, AllGroups>);
+    return substate;
+  }
+
+  template <typename Mode>
+  StateTyOf<Mode>& LMBD_INLINE getStateOf() {
+    using TargetStateTy = StateTyOf<Mode>;
+
+    // Mode is unknown / as no state, return placeholder
+    if constexpr (std::is_same_v<TargetStateTy, NoState>) {
+      return placeholder;
+
+    // Mode is ManagerTy, return our own state
+    } else if constexpr (std::is_same_v<TargetStateTy, StateTy>) {
+      return state;
+
+    // Mode is GroupTy, return the state of the group
+    } else if constexpr (details::GroupBelongsTo<Mode, AllGroups>) {
+      TargetStateTy* substate = getStateGroupOf<Mode>();
+
+      if (substate == nullptr) {
+        substate = (TargetStateTy*) &placeholder;
+        assert(false && "this code should be unreachable, but is it?");
+      }
+
+      return *substate;
+    } else {
+      static_assert(details::ModeExists<Mode, AllGroups>);
+
+      // Mode is somewhere in a group, search for it, return its state
+      TargetStateTy* substate = nullptr;
+
+      details::unroll<nbGroups>([&](auto Idx) LMBD_INLINE {
+        using Group = GroupAt<Idx>;
+        using AllModes = typename Group::AllModesTy;
+        if constexpr (details::ModeBelongsTo<Mode, AllModes>) {
+          substate = Group::template getStateOf<Mode>(*this);
+        }
+      });
+      assert(substate != nullptr && "this should not have compiled at all!");
+
+      if (substate == nullptr) {
+        substate = (TargetStateTy*) &placeholder;
+        assert(false && "this code should be unreachable, but is it?");
+      }
+
+      return *substate;
+    }
+  }
+
+  //
+  // navigation
+  //
+
+  static constexpr bool isGroupManager = true;
+  static constexpr bool isModeManager = true;
+
+  static void next_group(auto& ctx) {
+    uint8_t groupIdBefore = ctx.get_active_group(nbGroups);
+
+    ctx.state.lastModeMemory[groupIdBefore] = ctx.get_active_mode();
+    ctx.set_active_group(groupIdBefore + 1, nbGroups);
+
+    uint8_t groupIdAfter = ctx.get_active_group(nbGroups);
+    ctx.set_active_mode(ctx.state.lastModeMemory[groupIdAfter]);
+
+    ctx.reset_mode();
+  }
+
+  static void next_mode(auto& ctx) {
+    ctx.state.reset_config(ctx);
+    dispatch_group(ctx, [](auto group) { group.next_mode(); });
+  }
+
+  static void jump_to_favorite(auto& ctx) {
+    ctx.modeManager.activeIndex = ctx.state.currentFavorite;
+    ctx.reset_mode();
+  }
+
+  static void set_favorite_now(auto& ctx) {
+    ctx.state.currentFavorite = ctx.modeManager.activeIndex;
+  }
+
+  static void reset_mode(auto& ctx) {
+    ctx.state.reset_config(ctx);
+    dispatch_group(ctx, [](auto group) { group.reset_mode(); });
+  }
+
+  static uint8_t get_modes_count(auto& ctx) {
+    uint8_t value = 0;
+    dispatch_group(ctx, [&](auto group) { value = decltype(group)::LocalModeTy::nbModes; });
+    return value;
+  }
+
+  //
+  // all the callbacks
+  //
+
+  static void loop(auto& ctx) {
+    dispatch_group(ctx, [](auto group) { group.loop(); });
+  }
+
+  static void brightness_update(auto& ctx, uint8_t brightness) {
+    dispatch_group(ctx, [&](auto group) {
+      group.brightness_update(brightness);
+    });
+  }
+
+  static void power_on_sequence(auto& ctx) {
+    foreach_group<true>(ctx, [](auto group) { group.power_on_sequence(); });
+  }
+
+  static void power_off_sequence(auto& ctx) {
+    foreach_group<true>(ctx, [](auto group) { group.power_off_sequence(); });
+  }
+
+  static void write_parameters(auto& ctx) {
+    foreach_group<true>(ctx, [](auto group) { group.write_parameters(); });
+  }
+
+  static void read_parameters(auto& ctx) {
+    foreach_group<true>(ctx, [](auto group) { group.read_parameters(); });
+  }
+
+  static void user_thread(auto& ctx) {
+    dispatch_group(ctx, [](auto group) { group.user_thread(); });
+  }
+
+  static void custom_ramp_update(auto& ctx, uint8_t rampValue) {
+    dispatch_group(ctx, [&](auto group) {
+      group.custom_ramp_update(rampValue);
+    });
+  }
+
+  static bool custom_click(auto& ctx, uint8_t nbClick) {
+    bool retVal = false;
+    dispatch_group(ctx, [&](auto group) {
+      retVal = group.custom_click(nbClick);
+    });
+    return retVal;
+  }
+
+  static bool custom_hold(auto& ctx,
+                          uint8_t nbClickAndHold,
+                          bool isEndOfHoldEvent,
+                          uint32_t holdDuration) {
+    bool retVal = false;
+    dispatch_group(ctx, [&](auto group) {
+      retVal = group.custom_hold(nbClickAndHold,
+                                 isEndOfHoldEvent,
+                                 holdDuration);
+    });
+    return retVal;
+  }
+
+  //
+  // members with direct access
+  //
+
+  ActiveIndexTy activeIndex;
+  LedStrip& strip;
+
+  //
+  // private members
+  //
+
+private:
+  NoState placeholder;
+  StateTy state;
+};
+
+/** \brief Group together several mode groups defined through modes::GroupFor
+ *
+ * Binds all methods of the provided list of \p Groups and dispatch events
+ * while managing all the modes::BasicMode::StateTy states & other behaviors
+ *
+ * \remarks All enabled modes shall be enumerated in modes::GroupFor listed
+ * as inside the modes::ManagerFor modes::ModeManagerTy singleton
+ */
+template <typename... Groups>
+using ManagerFor = ModeManagerTy<std::tuple<Groups...>>;
+
+} // namespace modes
+
+#endif

--- a/src/modes/mode_type.hpp
+++ b/src/modes/mode_type.hpp
@@ -1,0 +1,249 @@
+#ifndef MODE_TYPE_H
+#define MODE_TYPE_H
+
+#include <cstdint>
+
+/** \file mode_type.hpp
+ *  \brief Basic interface types to implement custom user modes
+ **/
+
+/// Contains basic interface types to implement custom user modes
+namespace modes {
+
+/** \brief Parent object for all custom user modes
+ *
+ * Implement a custom user mode as follow:
+ *
+ * ```
+ *  // simplified user mode definition
+ *  struct MyCustomMode : public modes::BasicMode {
+ *    static void loop(LedStrip& strip) {
+ *      strip.clear();
+ *
+ *      // ... other things using strip
+ *    }
+ *  };
+ * ```
+ *
+ * It is recommended to use the full user mode definition:
+ *
+ * ```
+ *  // full user mode definition
+ *  struct MyCustomMode : public modes::FullMode {
+ *
+ *   static void loop(auto& ctx) {
+ *      auto& strip = ctx.strip;
+ *      strip.clear();
+ *
+ *      // ... other things using strip & ctx
+ *   }
+ *
+ *  };
+ * ```
+ *
+ * Once defined, you can enable the mode by adding it to indexable_functions.cpp :
+ *
+ * ```
+ *   using ManagerTy = modes::ManagerFor<
+ *     modes::GroupFor<ModeA,
+ *                     ModeB,
+ *                     ...>,
+ *     modes::GroupFor<Mode1,
+ *                     MyCustomMode, // mode available between Mode1 & Mode2
+ *                     Mode2>
+ *   >;
+ * ```
+ *
+ * You can start from the \link ./src/modes/custom/my_custom_mode.hpp mode
+ * template \endlink below where you will need to remove the unused callbacks:
+ *
+ * \include modes/custom/my_custom_mode.hpp
+ *
+ * Further examples of modes are available in `src/modes/default`
+ *
+ * \remark BasicMode and all derived user modes should never be constructed,
+ * use custom StateTy to implement stateful modes
+ */
+struct BasicMode {
+
+  /// Mode custom static state, made available through context (optional)
+  struct StateTy { };
+
+  /** \brief Simplified user mode loop function (default)
+   *
+   * Loop function with a simplified prototype, which is called instead of full
+   * loop(auto&) if BasicMode::simpleMode is True
+   *
+   * \remark To make mode stateful, define custom StateTy and use loop(auto&)
+   * to retrieve context, then retrieve the state instance from context
+   */
+  static void loop(LedStrip& strip) { return; }
+
+  /// Picks between simplified BasicMode::loop() and full BasicMode::loop(auto&)
+  static constexpr bool simpleMode = true;
+
+  /** \brief Custom user mode loop function (optional)
+   *
+   * Loop function each tick called whenever the mode is set as the currently
+   * active mode by the user
+   *
+   * \param[in] ctx The current context, providing a interface to the
+   * controller and the LED strip, as well as an access to its state
+   * \remark By default BasicMode::simpleMode is True and simplified loop() is
+   * called instead of loop(auto&)
+   */
+  static void loop(auto& ctx) { return; }
+
+  /** \brief Custom callback when mode gains focus (optional)
+   *
+   * Reset function is called once whenever mode is picked as the active mode
+   *
+   * \param[in] ctx The current context
+   */
+  static void reset(auto& ctx) { return; }
+
+  /// Toggles the use of custom BasicMode::brightness_update() callback
+  static constexpr bool hasBrightCallback = false;
+
+  /** \brief Custom callback when brightness changes (optional)
+   *
+   * Callback active only if BasicMode::hasBrightCallback is True
+   *
+   * \param[in] ctx The current context
+   * \param[in] brightness The brightness value set by the system
+   * \remark Use update_brightness() to change brightness in order for this
+   * callback to be correctly handled at runtime
+   */
+  static void brightness_update(auto& ctx, uint8_t brightness) { return; }
+
+  /// Toggles the use BasicMode::custom_ramp_update() callback
+  static constexpr bool hasCustomRamp = false;
+
+  /** \brief Custom callback when system sets user ramp (optional)
+   *
+   * This can be used to make a mode configurable through the 3H click+hold
+   * user action, which will cycle through the 0-255 values in a ~2s ramp
+   *
+   * \param[in] ctx The current context
+   * \param[in] rampValue The custom value set by the user
+   * \remark This behavior is in user::button_hold_default() and may be
+   * prevented if custom "usermode UI" via custom_hold() is enabled
+   */
+  static void custom_ramp_update(auto& ctx, uint8_t rampValue) {
+    return;
+  }
+
+  /// Toggles "usermode" button UI custom_click() and custom_hold()
+  static constexpr bool hasButtonCustomUI = false;
+
+  /** \brief Custom "usermode" button UI for "click" action (optional)
+   *
+   * Callback active only if BasicMode::hasButtonCustomUI is True
+   *
+   * \param[in] ctx The current context
+   * \param[in] nbClick The number of clicks made by the user
+   * \return Returns True if default UI action should be prevented
+   */
+  static bool custom_click(auto& ctx, uint8_t nbClick) {
+    return false;
+  }
+
+  /** \brief Custom "usermode" button UI for "click+hold" action (optional)
+   *
+   * Callback active only if BasicMode::hasButtonCustomUI is True
+   *
+   * \param[in] ctx The current context
+   * \param[in] nbClickAndHold The number of clicks made by the user
+   * \param[in] isEndOfHoldEvent True if the user just released the button
+   * \param[in] holdDuration The duration of the on-going hold event
+   * \return Returns True if default action must be prevented
+   * \remark When \p isEndOfHoldEvent is True, then \p holdDuration is zero
+   */
+  static bool custom_hold(auto& ctx,
+                          uint8_t nbClickAndHold,
+                          bool isEndOfHoldEvent,
+                          uint32_t holdDuration) {
+    return false;
+  }
+
+  /** \brief Toggles advanced system callbacks, see \link hasSystemCallbacks
+   * list here \endlink
+   *
+   * Required to use any of the following:
+   *  - BasicMode::power_on_sequence(),
+   *  - BasicMode::power_off_sequence()
+   *  - BasicMode::read_parameters()
+   *  - BasicMode::write_parameters()
+   *
+   * \remark By default, these callbacks are called for all modes (not only the
+   * active one) and thus should be kept minimal
+   */
+  static constexpr bool hasSystemCallbacks = false;
+
+  /** \brief Custom callback when the system powers on (optional)
+   *
+   * Callback active only if BasicMode::hasSystemCallbacks is True
+   *
+   * \param[in] ctx The current context
+   * \remark This must be a non-blocking function
+   */
+  static void power_on_sequence(auto& ctx) { return; }
+
+  /** \brief Custom callback when the system powers off (optional)
+   *
+   * Callback active only if BasicMode::hasSystemCallbacks is True
+   *
+   * \param[in] ctx The current context
+   * \remark This must be a non-blocking function
+   */
+  static void power_off_sequence(auto& ctx) { return; }
+
+  /** \brief Custom callback to read parameters from filesystem (optional)
+   *
+   * Callback active only if BasicMode::hasSystemCallbacks is True
+   *
+   * \param[in] ctx The current context
+   */
+  static void read_parameters(auto& ctx) { return; }
+
+  /** \brief Custom callback to write parameters to filesystem (optional)
+   *
+   * Callback active only if BasicMode::hasSystemCallbacks is True
+   *
+   * \param[in] ctx The current context
+   */
+  static void write_parameters(auto& ctx) { return; }
+
+  /** \brief Toggles the use of custom BasicMode::user_thread() callback
+   *
+   * \remark When this is enabled, default behavior is to only refresh strip in
+   * user::user_thread() after the BasicMode::user_thread() callback
+   */
+  static constexpr bool requireUserThread = false;
+
+  /** \brief Custom secondary loop, executed in another thread (optional)
+   *
+   * Called only if BasicMode::requireUserThread is True
+   *
+   * \param[in] ctx The current context
+   * \remark This is executed as prologue of user::user_thread() and hence
+   * must complete quickly in order to keep the strip responsive
+   */
+  static void user_thread(auto& ctx) {
+    return;
+  }
+
+  // modes shall not implement any constructors
+  BasicMode() = delete; ///< \private
+  BasicMode(const BasicMode&) = delete; ///< \private
+  BasicMode& operator=(const BasicMode&) = delete; ///< \private
+};
+
+  /// Alias for BasicMode with BasicMode::simpleMode to False
+  struct FullMode: public BasicMode {
+    static constexpr bool simpleMode = false;
+  };
+
+} // namespace modes
+
+#endif

--- a/src/modes/tools.hpp
+++ b/src/modes/tools.hpp
@@ -1,0 +1,190 @@
+#ifndef USER_MODE_TOOLS_H
+#define USER_MODE_TOOLS_H
+
+#include <cstdint>
+#include <utility>
+#include <optional>
+#include <tuple>
+
+#include "src/modes/mode_type.hpp"
+
+#ifndef LMBD_CPP17
+#error "File requires -DLMBD_CPP17 to explicitly enables C++17 features"
+#endif
+
+// always_inline macro
+#define LMBD_INLINE __attribute__((always_inline))
+
+// maybe_unused macro
+#define LMBD_USED [[maybe_unused]]
+
+namespace modes {
+
+struct NoState { };
+
+template <typename Mode>
+static constexpr bool isMode = std::is_base_of_v<BasicMode, Mode>;
+
+namespace details {
+
+/// \private Implements unroll<N>(callback)
+template <class CbTy, uint8_t... Indexes>
+static constexpr void LMBD_INLINE unroll_impl(
+        CbTy&& cb,
+        std::integer_sequence<uint8_t, Indexes...>) {
+  (cb(std::integral_constant<uint8_t, Indexes>{}), ...);
+}
+
+/// \private Calls \p cb with integral constants from 0 to N
+template <uint8_t N, class CbTy>
+static constexpr void LMBD_INLINE unroll(CbTy &&cb) {
+  constexpr auto Indexes = std::make_integer_sequence<uint8_t, N>();
+  unroll_impl([&](auto I) LMBD_INLINE {
+    return cb(std::integral_constant<uint8_t, decltype(I)::value>{});
+  }, Indexes);
+}
+
+/// \private Helper to perform queries on elements of \p TupleTy
+template <typename TupleTy, uint8_t TupleSz = std::tuple_size_v<TupleTy>>
+struct forEach {
+
+  /// \private Return True if any elements returns True through \p QueryStruct
+  template <template<class> class QueryStruct, bool hasError = false>
+  static constexpr bool any() {
+    bool acc = false;
+    if constexpr (!hasError) {
+      unroll<TupleSz>([&](auto Idx) {
+        acc |= QueryStruct<std::tuple_element_t<Idx, TupleTy>>::value;
+      });
+    }
+    return acc;
+  }
+
+  /// \private Return True if all elements returns True through \p QueryStruct
+  template <template<class> class QueryStruct, bool hasError = false>
+  static constexpr bool all() {
+    bool acc = true;
+    if constexpr (!hasError) {
+      unroll<TupleSz>([&](auto Idx) {
+        acc &= QueryStruct<std::tuple_element_t<Idx, TupleTy>>::value;
+      });
+    } else {
+     return false;
+    }
+    return acc;
+  }
+
+};
+
+/// \private Defined boolean is True if any \p TupleTy item has boolean True
+template <typename TupleTy, bool hasError = false>
+struct anyOf {
+
+  template <typename Ty>
+  struct QHasBright { static constexpr bool value = Ty::hasBrightCallback; };
+
+  template <typename Ty>
+  struct QCustomRamp { static constexpr bool value = Ty::hasCustomRamp; };
+
+  template <typename Ty>
+  struct QButtonUI { static constexpr bool value = Ty::hasButtonCustomUI; };
+
+  template <typename Ty>
+  struct QHasSystem { static constexpr bool value = Ty::hasSystemCallbacks; };
+
+  template <typename Ty>
+  struct QUserThread { static constexpr bool value = Ty::requireUserThread; };
+
+  // booleans we need
+  static constexpr bool simpleMode = false;
+  static constexpr bool hasBrightCallback = forEach<TupleTy>::template any<QHasBright, hasError>();
+  static constexpr bool hasCustomRamp = forEach<TupleTy>::template any<QCustomRamp, hasError>();
+  static constexpr bool hasButtonCustomUI = forEach<TupleTy>::template any<QButtonUI, hasError>();
+  static constexpr bool hasSystemCallbacks = forEach<TupleTy>::template any<QHasSystem, hasError>();
+  static constexpr bool requireUserThread = forEach<TupleTy>::template any<QUserThread, hasError>();
+};
+
+//
+// StateTyOf definition:
+//  - returns StateTy if defined
+//  - or else return EmptyState
+//
+
+template <typename Mode,
+         typename StateTy = typename Mode::StateTy,
+         bool isDefault = std::is_same_v<StateTy, BasicMode::StateTy> || (sizeof(StateTy) == 0),
+         typename RetTy = std::conditional_t<isDefault, NoState, StateTy>>
+static constexpr auto stateTyOfImpl(int) -> RetTy;
+
+template <typename>
+static constexpr auto stateTyOfImpl(...) -> NoState;
+
+/// \private Get StateTy if explicitly defined, or else EmptyState
+template <typename Mode>
+using StateTyOf = decltype(stateTyOfImpl<Mode>(0));
+
+/// \private Defined boolean is True if all \p TupleTy item has boolean True
+template <typename TupleTy, bool hasError = false>
+struct allOf {
+
+  template <typename Ty>
+  struct QIsMode { static constexpr bool value = isMode<Ty>; };
+
+  template <typename Ty>
+  struct QStateOk { static constexpr bool value = std::is_default_constructible_v<StateTyOf<Ty>>; };
+
+  static constexpr bool inheritsFromBasicMode = forEach<TupleTy>::template all<QIsMode, hasError>();
+  static constexpr bool stateDefaultConstructible = forEach<TupleTy>::template all<QStateOk, hasError>();
+};
+
+/// \private Get std::tuple<Modes::StateTy...> from Modes...
+template <typename... Modes>
+using StateTyFor = std::tuple<std::optional<StateTyOf<Modes>>...>;
+
+template <typename... Modes>
+static constexpr auto stateTyFromImpl(std::tuple<Modes...>*) -> StateTyFor<Modes...>;
+
+/// \private Get std::tuple<Mode::StateTy...> from std::tuple<Mode...>
+template <typename AsTuple>
+using StateTyFrom = decltype(stateTyFromImpl((AsTuple*) 0));
+
+template <typename Item, typename... Items>
+static constexpr bool belongsToImpl(std::tuple<Items...>*) {
+  return (std::is_same_v<Item, Items> || ...);
+};
+
+/// \private Checks if \p Mode is member of \p AllModes as tuple
+template <typename Mode, typename AllModes>
+static constexpr bool ModeBelongsTo = belongsToImpl<Mode>((AllModes*) 0);
+
+/// \private Checks if \p Group is member of \p AllGroups as tuple
+template <typename Group, typename AllGroups>
+static constexpr bool GroupBelongsTo = belongsToImpl<Group>((AllGroups*) 0);
+
+template <typename Mode, typename AllGroups>
+static constexpr bool testIfModeExistsImpl() {
+  constexpr uint8_t NbGroups{std::tuple_size_v<AllGroups>};
+
+  bool acc = false;
+  unroll<NbGroups>([&](auto Idx) {
+    using GroupHere = std::tuple_element_t<Idx, AllGroups>;
+    using AllModes = typename GroupHere::AllModesTy;
+    acc |= ModeBelongsTo<Mode, AllModes>;
+  });
+
+  return acc;
+}
+
+/// \private Checks if \p Mode exists in the set of \p AllGroups
+template <typename Mode, typename AllGroups>
+static constexpr bool ModeExists = testIfModeExistsImpl<Mode, AllGroups>();
+
+} // namespace details
+
+/// \private see details::StateTyOf
+template <typename Mode>
+using StateTyOf = details::StateTyOf<Mode>;
+
+} // namespace modes
+
+#endif

--- a/src/user/functions.h
+++ b/src/user/functions.h
@@ -1,7 +1,7 @@
 #ifndef USER_FUNCTIONS_H
 #define USER_FUNCTIONS_H
 
-/** \file user_functions.h
+/** \file functions.h
  *  \brief Custom user mode functions for indexable strips
  **/
 
@@ -50,7 +50,6 @@ void read_parameters();
 /** \brief Called to handle button click events for default user mode behaviors
  *
  * Default behavior is the "default UI" navigation mode, that supports:
- *  - **WIP: this is YET to be implemented!**
  *  - 2 clicks: next user mode
  *  - 3 clicks: next mode group
  *  - 4 clicks: jump to favorite
@@ -65,9 +64,8 @@ void button_clicked_default(const uint8_t clicks);
 /** \brief Called to handle button click+hold events for user mode behaviors
  *
  * Default behavior is the "default UI" navigation mode, that supports:
- *  - **WIP: this is YET to be implemented!**
- *  - 3 click+hold: switch between user modes / custom user ramp
- *  - 4 click+hold: switch between mode groups
+ *  - 3 click+hold: configure custom user ramp
+ *  - 4 click+hold: scroll across modes and groups
  *  - 5 click+hold (3s): configure favorite modes
  *
  * Event 1H/2H (brightness) is handled by

--- a/src/user/indexable_functions.cpp
+++ b/src/user/indexable_functions.cpp
@@ -3,501 +3,93 @@
 #include <cstdint>
 
 #include "src/system/behavior.h"
-#include "src/system/charger/charger.h"
-#include "src/system/colors/animations.h"
-#include "src/system/colors/colors.h"
-#include "src/system/colors/palettes.h"
-#include "src/system/colors/wipes.h"
-#include "src/system/physical/fileSystem.h"
-#include "src/system/physical/IMU.h"
-#include "src/system/physical/MicroPhone.h"
-#include "src/system/utils/utils.h"
-
 #include "src/user/functions.h"
+
+//
+// code below requires c++17
+//
+
+#ifdef LMBD_CPP17
+
+#include "src/modes/tools.hpp"
+#include "src/modes/group_type.hpp"
+#include "src/modes/manager_type.hpp"
+
+#include "src/modes/default/fixed_modes.hpp"
+#include "src/modes/legacy/legacy_modes.hpp"
 
 namespace user {
 
+//
+// list your groups & modes here
+//
+
+using ManagerTy = modes::ManagerFor<
+    modes::FixedModes,
+    // modes::MiscFixedModes,
+    modes::legacy::CalmModes,
+    modes::legacy::PartyModes
+  >;
+
+//
+// implementation details
+//
+
+namespace _private {
+
 LedStrip strip(AD0);
+ManagerTy modeManager(strip);
 
-constexpr uint32_t LED_POWER_PIN = AD1;
+} // namespace _private
 
-bool modeChange = true;      // signal a color mode change
-bool categoryChange = true;  // signal a color category change
-
-uint8_t colorMode = 0;  // color mode: main wheel of the color mode
-constexpr uint32_t colorModeKey = utils::hash("colorMode");
-
-uint8_t colorState = 0;  // color state: subwheel of the current color mode
-constexpr uint32_t colorStateKey = utils::hash("colorState");
-
-uint8_t colorCodeIndex = 0;  // color code index, used for color indexion
-uint8_t lastColorCodeIndex = colorCodeIndex;
-
-uint8_t colorCodeIndexForWarmLight =
-    0;  // color code index, used for color indexion of warm to white
-constexpr uint32_t colorCodeIndexForWarmLightKey = utils::hash("warmLight");
-
-uint8_t colorCodeIndexForColoredLight =
-    0;  // color code index, used for color indexion of RGB
-constexpr uint32_t colorCodeIndexForColoredLightKey = utils::hash("colorLight");
-
-bool isFinished = true;
-bool switchMode = true;
-
-void reset_globals() {
-  isFinished = true;
-  switchMode = false;
-  colorCodeIndex = 0;
-  lastColorCodeIndex = 0;
+static auto get_context() {
+  return user::_private::modeManager.get_context();
 }
 
-void increment_color_mode() {
-  colorMode += 1;
-  modeChange = true;
+static constexpr uint32_t LED_POWER_PIN = AD1;
 
-  // reset color state
-  colorState = 0;
-  categoryChange = true;
+//
+// indexable lamp is implemented in another castle
+//
 
-  reset_globals();
-
-  strip.clear();
-}
-
-void decrement_color_mode() {
-  colorMode -= 1;
-  modeChange = true;
-
-  // reset color state
-  colorState = 0;
-  categoryChange = true;
-
-  reset_globals();
-
-  strip.clear();
-}
-
-void increment_color_state() {
-  colorState += 1;
-
-  // signal a change of category
-  categoryChange = true;
-
-  reset_globals();
-
-  strip.clear();
-}
-
-void decrement_color_state() {
-  colorState -= 1;
-
-  // signal a change of category
-  categoryChange = true;
-
-  reset_globals();
-
-  strip.clear();
-}
-
-uint8_t clamp_state_values(uint8_t& state, const uint8_t maxValue) {
-  // incrmeent one too much, loop around
-  if (state == maxValue + 1) state = 0;
-
-  // default return value
-  else if (state <= maxValue)
-    return state;
-
-  // got below 0, set to max value
-  else if (state > maxValue)
-    state = maxValue;
-
-  return state;
-}
-
-void gradient_mode_update() {
-  static auto lastColorStep = colorCodeIndex;
-
-  constexpr uint8_t maxGradientColorState = 1;
-  switch (clamp_state_values(colorState, maxGradientColorState)) {
-    case 0:  // kelvin mode
-      static auto paletteHeatColor =
-          GeneratePaletteIndexed(PaletteBlackBodyColors);
-      if (categoryChange) {
-        lastColorStep = 1;
-        colorCodeIndex = colorCodeIndexForWarmLight;
-        lastColorCodeIndex = colorCodeIndexForWarmLight;
-        paletteHeatColor.reset();
-      }
-
-      if (colorCodeIndex != lastColorStep) {
-        lastColorStep = colorCodeIndex;
-        colorCodeIndexForWarmLight = colorCodeIndex;
-        paletteHeatColor.update(colorCodeIndex);
-      }
-      animations::fill(paletteHeatColor, strip);
-      break;
-
-    case 1:  // rainbow mode
-      static auto rainbowIndex = GenerateRainbowIndex(
-          UINT8_MAX);  // pulse around a rainbow, with a certain color division
-      if (categoryChange) {
-        lastColorStep = 1;
-        colorCodeIndex = colorCodeIndexForColoredLight;
-        lastColorCodeIndex = colorCodeIndexForColoredLight;
-        rainbowIndex.reset();
-      }
-
-      if (colorCodeIndex != lastColorStep) {
-        lastColorStep = colorCodeIndex;
-        colorCodeIndexForColoredLight = colorCodeIndex;
-        rainbowIndex.update(colorCodeIndex);
-      }
-      animations::fill(rainbowIndex, strip);
-      break;
-
-    default:  // error
-      colorState = 0;
-      colorCodeIndex = 0;
-      strip.clear();
-      break;
-  }
-
-  // reset category change
-  categoryChange = false;
-}
-
-void calm_mode_update() {
-  constexpr uint8_t maxCalmColorState = 9;
-  switch (clamp_state_values(colorState, maxCalmColorState)) {
-    case 0:  // rainbow swirl animation
-    {        // display a color animation
-      static GenerateRainbowSwirl rainbowSwirl =
-          GenerateRainbowSwirl(5000);  // swirl animation (5 seconds)
-      if (categoryChange) rainbowSwirl.reset();
-
-      animations::fill(rainbowSwirl, strip);
-
-      rainbowSwirl.update();
-      break;
-    }
-    case 1:  // party wheel
-    {
-      static auto palettePartyColor =
-          GeneratePaletteIndexed(PalettePartyColors);
-      static uint8_t currentIndex = 0;
-      if (categoryChange) {
-        currentIndex = 0;
-        palettePartyColor.reset();
-      }
-
-      isFinished =
-          animations::fade_in(palettePartyColor, 100, isFinished, strip);
-      if (isFinished) {
-        currentIndex++;
-        palettePartyColor.update(currentIndex);
-      }
-      break;
-    }
-    case 2: {
-      animations::random_noise(PaletteLavaColors, strip, categoryChange, true,
-                               3);
-      break;
-    }
-    case 3: {
-      animations::random_noise(PaletteForestColors, strip, categoryChange, true,
-                               3);
-      break;
-    }
-    case 4: {
-      animations::random_noise(PaletteOceanColors, strip, categoryChange, true,
-                               3);
-      break;
-    }
-    case 5: {  // polar light
-      animations::mode_2DPolarLights(255, 128, PaletteAuroraColors,
-                                     categoryChange, strip);
-      break;
-    }
-    case 6: {
-      animations::fire(60, 60, 255, PaletteHeatColors, strip);
-      break;
-    }
-    case 7: {
-      animations::mode_sinewave(128, 128, PaletteRainbowColors, strip);
-      break;
-    }
-    case 8: {
-      animations::mode_2DDrift(64, 64, PaletteRainbowColors, strip);
-      break;
-    }
-    case 9: {
-      animations::mode_2Ddistortionwaves(128, 128, strip);
-      break;
-    }
-
-    default:  // error
-    {
-      colorState = 0;
-      strip.clear();
-      break;
-    }
-  }
-
-  // reset category change
-  categoryChange = false;
-}
-
-void party_mode_update() {
-  constexpr uint8_t maxPartyState = 2;
-  switch (clamp_state_values(colorState, maxPartyState)) {
-    case 0:
-      static GenerateComplementaryColor complementaryColor =
-          GenerateComplementaryColor(0.3);
-      if (categoryChange) complementaryColor.reset();
-
-      isFinished = switchMode ? animations::color_wipe_up(
-                                    complementaryColor, 500, isFinished, strip)
-                              : animations::color_wipe_down(
-                                    complementaryColor, 500, isFinished, strip);
-      if (isFinished) {
-        switchMode = !switchMode;
-        complementaryColor.update();  // update color
-      }
-      break;
-
-    case 1:
-      // random solid color
-      static GenerateRandomColor randomColor = GenerateRandomColor();
-      if (categoryChange) randomColor.reset();
-
-      isFinished =
-          animations::double_side_fill(randomColor, 500, isFinished, strip);
-      if (isFinished) randomColor.update();  // update color
-      break;
-
-    case 2:
-      static GenerateComplementaryColor complementaryPingPongColor =
-          GenerateComplementaryColor(0.4);
-      if (categoryChange) complementaryPingPongColor.reset();
-
-      // ping pong a color for infinity
-      isFinished = animations::dot_ping_pong(complementaryPingPongColor, 1000.0,
-                                             128, isFinished, strip);
-      if (isFinished) complementaryPingPongColor.update();  // update color
-      break;
-
-    default:  // error
-      colorState = 0;
-      strip.clear();
-      break;
-  }
-
-  // reset category change
-  categoryChange = false;
-}
-
-void sound_mode_update() {
-  constexpr uint8_t maxSoundState = 0;
-  switch (clamp_state_values(colorState, maxSoundState)) {
-    default:  // error
-      colorState = 0;
-      strip.clear();
-      break;
-  }
-
-  // reset category change
-  categoryChange = false;
-}
-
-void sirenes_mode_update() {
-  constexpr uint8_t maxGyroState = 0;
-  switch (clamp_state_values(colorState, maxGyroState)) {
-    case 0:
-      animations::police(500, false, strip);
-      break;
-
-    default:  // error
-      colorState = 0;
-      strip.clear();
-      break;
-  }
-
-  // reset category change
-  categoryChange = false;
-}
-
-void color_mode_update() {
-  constexpr uint8_t maxColorMode = 4;
-  switch (clamp_state_values(colorMode, maxColorMode)) {
-    case 0:  // Fixed colors, that the user can change
-      gradient_mode_update();
-      break;
-
-    case 1:  // slow changing animations, nice to look at
-      calm_mode_update();
-      break;
-
-    case 2:
-      // fast pacing animations
-      party_mode_update();
-      break;
-
-      /*
-        case 3:  // sound reacting mode
-          sound_mode_update();
-          break;
-      */
-
-      /*
-      case 4:  // diverse alerts (police, firefighters etc)
-        sirenes_mode_update();
-        break;
-      */
-
-    default:
-      colorMode = 0;
-      break;
-  }
-
-  // reset mode change
-  modeChange = false;
-}
-
-void power_on_sequence() {
-  pinMode(LED_POWER_PIN, OUTPUT);
-  digitalWrite(LED_POWER_PIN, HIGH);
-
-  // initialize the strip object
-  strip.begin();
-  strip.clear();
-  strip.show();  // Turn OFF all pixels ASAP
-  strip.setBrightness(BRIGHTNESS);
-}
-
-void power_off_sequence() {
-  strip.clear();
-  strip.show();  // Clear all pixels
-
-  digitalWrite(LED_POWER_PIN, LOW);
-  // high drive input (5mA)
-  // The only way to discharge the DC-DC pin...
-  pinMode(LED_POWER_PIN, OUTPUT_H0H1);
-
-#ifdef LMBD_CPP17
-  ensure_build_canary();  // (no-op) internal symbol used during build
-#endif
-}
-
-void brightness_update(const uint8_t brightness) {
-  strip.setBrightness(brightness);
-}
-
-void write_parameters() {
-  fileSystem::set_value(colorModeKey, colorMode);
-  fileSystem::set_value(colorStateKey, colorState);
-  fileSystem::set_value(colorCodeIndexForWarmLightKey,
-                        colorCodeIndexForWarmLight);
-  fileSystem::set_value(colorCodeIndexForColoredLightKey,
-                        colorCodeIndexForColoredLight);
-}
-
-void read_parameters() {
-  uint32_t mode = 0;
-  if (fileSystem::get_value(colorModeKey, mode)) {
-    colorMode = mode;
-  }
-
-  uint32_t state = 0;
-  if (fileSystem::get_value(colorStateKey, state)) {
-    colorState = state;
-  }
-
-  uint32_t warmLight = 0;
-  if (fileSystem::get_value(colorCodeIndexForWarmLightKey, warmLight)) {
-    colorCodeIndexForWarmLight = warmLight;
-  }
-
-  uint32_t coloredLight = 0;
-  if (fileSystem::get_value(colorCodeIndexForColoredLightKey, coloredLight)) {
-    colorCodeIndexForColoredLight = coloredLight;
-  }
-}
-
-void button_clicked_default(const uint8_t clicks) {
-  switch (clicks) {
-    case 2:  // 2 clicks: increment color state
-      increment_color_state();
-      break;
-
-    case 3:  // 3 clicks: decrement color state
-      decrement_color_state();
-      break;
-
-    case 4:  // 4 clicks: increment color mode
-      increment_color_mode();
-      break;
-
-    case 5:  // 5 clicks: decrement color mode
-      decrement_color_mode();
-      break;
-  }
-}
-
-void button_hold_default(const uint8_t clicks,
-                         const bool isEndOfHoldEvent,
-                         const uint32_t holdDuration) {
-  switch (clicks) {
-    case 3: // 3+hold: color wheel forward
-      if (isEndOfHoldEvent) {
-        lastColorCodeIndex = colorCodeIndex;
-      } else {
-        constexpr uint32_t colorStepDuration_ms = 6000;
-        const uint32_t timeShift =
-            (colorStepDuration_ms * lastColorCodeIndex) / 255;
-        const uint32_t colorStep =
-            (holdDuration + timeShift) % colorStepDuration_ms;
-        colorCodeIndex = map(colorStep, 0, colorStepDuration_ms, 0, UINT8_MAX);
-      }
-      break;
-
-    case 4: // 4+hold: color wheel backward
-      if (isEndOfHoldEvent) {
-        lastColorCodeIndex = colorCodeIndex;
-      } else {
-        constexpr uint32_t colorStepDuration_ms = 6000;
-        const uint32_t timeShift =
-            (colorStepDuration_ms * lastColorCodeIndex) / 255;
-
-        uint32_t buttonHoldDuration = holdDuration;
-        if (holdDuration < timeShift) {
-          buttonHoldDuration =
-              colorStepDuration_ms - (timeShift - holdDuration);
-        } else {
-          buttonHoldDuration -= timeShift;
-        }
-        const uint32_t colorStep = buttonHoldDuration % colorStepDuration_ms;
-        colorCodeIndex = map(colorStep, 0, colorStepDuration_ms, UINT8_MAX, 0);
-      }
-      break;
-  }
-}
-
-bool button_clicked_usermode(const uint8_t) {
-  return usermodeDefaultsToLockdown;
-}
-
-bool button_hold_usermode(const uint8_t, const bool, const uint32_t) {
-  return usermodeDefaultsToLockdown;
-}
-
-void loop() { color_mode_update(); }
-
-bool should_spawn_thread() { return true; }
-
-void user_thread() {
-  strip.show();  // show at the end of the loop (only does it if needed)}
-}
+#include "src/modes/behavior_manager.hpp"
 
 }  // namespace user
 
-#endif
+#else
+#warning "This file requires --std=gnu++17 or higher to build!*"
+//
+// *if you got this warning, check Makefile to see how to build project
+
+//
+// no c++17 support -- placeholder implementation
+//
+
+namespace user {
+
+void power_on_sequence() { }
+void power_off_sequence() { }
+
+void brightness_update(const uint8_t) { }
+void write_parameters() { }
+void read_parameters() { }
+void button_clicked_default(const uint8_t) { }
+void button_hold_default(const uint8_t, const bool, const uint32_t) { }
+
+bool button_clicked_usermode(const uint8_t) {
+    return false;
+}
+
+bool button_hold_usermode(const uint8_t, const bool, const uint32_t) {
+  return false;
+}
+
+void loop() { }
+bool should_spawn_thread() { return false; }
+void user_thread() { }
+
+}
+
+#endif // LMBD_CPP17
+
+#endif // LMBD_LAMP_TYPE__INDEXABLE


### PR DESCRIPTION
This is two contributions:
1. one that expand simulator to support most of the `user/functions.h` behaviors
2. one that rewrites all the "indexable" modes using a "mode manager" -- see `user/indexable_functions.cpp`

This goes towards separating the software from the hardware and is thus fully testable with `make simulator`

(note that the simulator uses the space bar as lamp button interaction)

-----------

There is some preliminary documentation written, but not exhaustive:

![2024-11-14_18-36](https://github.com/user-attachments/assets/5bbbfcbb-fac4-4715-b6bb-371cee3eddd3)
![2024-11-14_18-30](https://github.com/user-attachments/assets/63b9414c-36ff-4cc7-8fa3-f7fb6bbda1d8)
![2024-11-14_18-30_1](https://github.com/user-attachments/assets/cac82cde-bd6d-4857-b4db-da68104f70c4)

The overall abstraction, is that each mode have callbacks defined in a similar fashion to `user/functions.h`:
```c++
#ifndef MY_CUSTOM_MODE_H
#define MY_CUSTOM_MODE_H
 
struct [MyCustomMode](https://github.com/BaptisteHudyma/Lamp-Da/compare/structMyCustomMode.html) : public [modes::FullMode](https://github.com/BaptisteHudyma/Lamp-Da/compare/structmodes_1_1FullMode.html) {
 
  static void loop(auto& ctx) { }
  static void reset(auto& ctx) { }
 
  // only if hasBrightCallback
  static void brightness_update(auto& ctx, uint8_t brightness) { }
 
  // only if hasCustomRamp
  static void custom_ramp_update(auto& ctx, uint8_t rampValue) { }
 
  // only if hasButtonCustomUI
  static bool custom_click(auto& ctx, uint8_t nbClick) {
    return false;
  }
 
  static bool custom_hold(auto& ctx,
                          uint8_t nbClickAndHold,
                          bool isEndOfHoldEvent,
                          uint32_t holdDuration) {
    return false;
  }
 
  // only if hasSystemCallbacks
  static void power_on_sequence(auto& ctx) { }
  static void power_off_sequence(auto& ctx) { }
  static void read_parameters(auto& ctx) { }
  static void write_parameters(auto& ctx) { }
 
  // only if requireUserThread
  static void user_thread(auto& ctx) { }
 
  // keep only if customized
  struct StateTy { };
 
  // keep only the ones you need (= true)
  static constexpr bool hasBrightCallback = false;
  static constexpr bool hasCustomRamp = false;
  static constexpr bool hasButtonCustomUI = false;
  static constexpr bool hasSystemCallbacks = false;
  static constexpr bool requireUserThread = false;
}
 
#endif
```

This enable short definitions of modes, such as:
```c++
/// Rainbow fixed colors ramp mode
struct RainbowMode : public modes::FullMode {
  static void loop(auto& ctx) {
    const float index = ctx.get_active_custom_ramp();
    const float hue = (index / 256.f) * 360.f;
    uint32_t color = utils::hue_to_rgb_sinus(hue);

    ctx.fill(color);
  }
};
```

Modes to be listed inside a « mode group » as in the example below:
```c++
using FixedModes = modes::GroupFor<
  fixed::KelvinMode,
  fixed::RainbowMode
>;
```

Groups to be listed inside a global « mode manager » as in the example below:
```c++
#include "src/modes/default/fixed_modes.h"
#include "src/modes/legacy/legacy_modes.h"

using ManagerTy = modes::ManagerFor<
    modes::FixedModes,
    modes::legacy::CalmModes,
    modes::legacy::PartyModes
  >;
```

Which is used to implement `user/indexable_functions.cpp` callbacks.

---------------

As feature, there is new user actions such as:
- scrolling through all modes & groups (4H)
- jumping to a « favorite mode » (4C) that can be configured (5H+2s)

There is also late-initialization of `StateTy` state structure of modes, meaning it is build only on the first instantiation of the mode (and not on the initialization of the program).

---------------

There is still on-going works, to be completed in further pull requests:
 - no filesystem interaction has been done yet, causing the lamp to "forget" about things after a reboot
 - there should be a defined interface between modes and hardware, and more work is needed here
 
 Note that the long-term goal is to move user-purpose (non-hardware related code) away from `src/system` to `src/modes/include` to fully delimit software from hardware, but this will need incremental work.