### PR TITLE
Add modes::hardware::LampTy

### DIFF
--- a/.pre-commit
+++ b/.pre-commit
@@ -1,0 +1,47 @@
+#!/bin/sh
+# To enable this hook, copy this file to ".git/pre-commit"
+#   cp .pre-commit .git/hook/pre-commit
+
+# check if format is good
+make format-verify || exit 1
+
+#
+# default content of .git/pre-commit.sample
+#
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=false
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff-index --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+exec git diff-index --check --cached $against --

--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,16 @@ format:
 	find src/ -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format --style=file -i
 	find simulator/ -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format --style=file -i
 
+format-hook:
+	cp .pre-commit .git/hooks/pre-commit
+
+format-verify:
+	@which clang-format > /dev/null \
+		|| (echo; echo Install clang / clang-format to verify format!)
+	@find LampColorControler.ino | xargs clang-format --style=file --dry-run --Werror
+	@find src/ -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format --style=file --dry-run -Werror
+	@find simulator/ -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format --style=file --dry-run -Werror
+	# format is ok :)
 
 #
 # verify artifact
@@ -473,9 +483,8 @@ verify-type(%):
 	@echo; echo Building with LMBD_LAMP_TYPE=$% to verify artifact...; echo
 	LMBD_LAMP_TYPE=$% make build verify
 
-verify-all: verify-all-simulator
+verify-all: format-verify verify-all-simulator
 	@echo; echo " --- $@"
-	make format
 	# verify that all lamp types build & validates
 	make clean 'verify-type(indexable)'
 	@touch $(BUILD_DIR)/.skip-simple-clean # (re-use indexable setup)

--- a/README.md
+++ b/README.md
@@ -235,6 +235,44 @@ cd LampColorControler
 make mr_proper
 ```
 
+## Contributing code
+
+If `clang` is installed on your platform, automatic format will be available:
+
+```sh
+# this format all files using clang-format
+cd LampColorControler
+make format
+```
+
+You can verify that all files are properly formatted with:
+
+```sh
+# this fails if some files are not properly formatted
+cd LampColorControler
+make format-verify
+```
+
+You can add this verification as a [git pre-commit
+hook](https://git-scm.com/book/ms/v2/Customizing-Git-Git-Hooks) with:
+
+```sh
+# before every "git commit" checks if formatting is good
+cd LampColorControler
+make format-hook
+git commit # will implictly run "make format-verify"
+```
+
+You can check that all files still build after your change using:
+
+```sh
+# clean then build everything, including all lamp type
+cd LampColorControler
+make verify-all
+```
+
+Note that simulator files are build only if all dependencies are available.
+
 ## How the build system works?
 
 We are relying on Arduino and Adafruit's integrations to do a lot of things.

--- a/doxygen.conf
+++ b/doxygen.conf
@@ -289,7 +289,7 @@ TAB_SIZE               = 2
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                =
+ALIASES                = "htmlcolorblock{1}=<div style='background:#\1;width:4em;height:4em;'></div>"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -548,7 +548,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,

--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -9,8 +9,9 @@ BUILD_DIR=${SIMU_BUILD_DIR}
 CXX=$(shell which c++)
 CXX_INCLUDE_DIRECTORIES=-I$(ROOT_DIR) -I$(SRC_DIR)include
 CXX_LDFLAGS=-lsfml-graphics -lsfml-window -lsfml-audio -lsfml-system
+CXX_LAMP_FLAGS=-DLMBD_MISSING_DEFINE -DLMBD_LAMP_TYPE__INDEXABLE
 CXX_EXTRA_FLAGS=-fconcepts -DLMBD_CPP17 -ftemplate-backtrace-limit=1 #-Wall -Wextra -pedantic
-CXX_BUILD_FLAGS=--std=c++17 -O3 $(CXX_EXTRA_FLAGS) $(CXX_INCLUDE_DIRECTORIES)
+CXX_BUILD_FLAGS=--std=c++17 -O3 $(CXX_LAMP_FLAGS) $(CXX_EXTRA_FLAGS) $(CXX_INCLUDE_DIRECTORIES)
 
 ALL_TARGETS=$(shell ls $(SRC_DIR)/src|grep -Eo '^[^-]*-simulator.cpp'|sed 's/.cpp$$//g')
 

--- a/simulator/include/Arduino.h
+++ b/simulator/include/Arduino.h
@@ -14,8 +14,8 @@
 // constants
 using String = std::string;
 
-#define PI 3.1415926535897
-#define TWO_PI 6.2831853071795
+#define PI      3.1415926535897
+#define TWO_PI  6.2831853071795
 #define HALF_PI 1.5707963267948
 
 //
@@ -30,29 +30,22 @@ using String = std::string;
 
 using byte = uint8_t;
 
-template <typename T, typename U>
-T random(T min, U max) {
+template<typename T, typename U> T random(T min, U max)
+{
   uint32_t n = random();
   // bad random, but who cares?
   return (n % (max - min)) + min;
 }
 
-template <typename T>
-T random(T max) {
-  return random(0, max);
-}
+template<typename T> T random(T max) { return random(0, max); }
 
 //
 // ambiguous min/fmin/max/fmax/abs
 //
 
-static constexpr double min(double a, double b) {
-  return fmin(a, b);
-}
+static constexpr double min(double a, double b) { return fmin(a, b); }
 
-static constexpr double max(double a, double b) {
-  return fmax(a, b);
-}
+static constexpr double max(double a, double b) { return fmax(a, b); }
 
 using std::abs;
 
@@ -60,21 +53,22 @@ using std::abs;
 // misc functions
 //
 
-float radians(float degrees) {
-  return (degrees / 180.f) * PI;
-}
+float radians(float degrees) { return (degrees / 180.f) * PI; }
 
-template <typename T, typename V, typename U>
-static constexpr T constrain(const T& a, const V& mini, const U& maxi) {
-  if (a <= mini) return mini;
-  if (a >= maxi) return maxi;
+template<typename T, typename V, typename U> static constexpr T constrain(const T& a, const V& mini, const U& maxi)
+{
+  if (a <= mini)
+    return mini;
+  if (a >= maxi)
+    return maxi;
   return a;
 }
 
-template <typename T, typename V>
-static constexpr T pow(const T& a, const V& b) {
+template<typename T, typename V> static constexpr T pow(const T& a, const V& b)
+{
   T acc = 1;
-  for (V i = 0; i < b; ++i) {
+  for (V i = 0; i < b; ++i)
+  {
     acc *= a;
   }
   return acc;
@@ -86,8 +80,6 @@ static constexpr T pow(const T& a, const V& b) {
 
 static uint64_t globalMillis;
 
-uint64_t millis() {
-  return globalMillis;
-}
+uint64_t millis() { return globalMillis; }
 
 #endif

--- a/simulator/include/behavior_simulator.h
+++ b/simulator/include/behavior_simulator.h
@@ -1,24 +1,24 @@
-#ifndef BUTTON_SIMULATOR_H
-#define BUTTON_SIMULATOR_H
+#ifndef BEHAVIOR_SIMULATOR_H
+#define BEHAVIOR_SIMULATOR_H
 
 // prevent inclusion of colliding src/system/behavior.h
 #define BEHAVIOR_HPP
 
-void pinMode(auto, auto) { }
-#define OUTPUT              0x1021
-#define OUTPUT_H0H1         0x1022
-#define INPUT_PULLUP_SENSE  0x1023
-#define CHANGE              0x1024
-#define LOW                 0x1025
-#define HIGH                0x1026
-#define LED_POWER_PIN       0x1027
+void pinMode(auto, auto) {}
+#define OUTPUT             0x1021
+#define OUTPUT_H0H1        0x1022
+#define INPUT_PULLUP_SENSE 0x1023
+#define CHANGE             0x1024
+#define LOW                0x1025
+#define HIGH               0x1026
+#define LED_POWER_PIN      0x1027
 
-void ensure_build_canary() { }
+void ensure_build_canary() {}
 int digitalPinToInterrupt(auto) { return 0; }
-void attachInterrupt(auto, auto, auto) { }
+void attachInterrupt(auto, auto, auto) {}
 int digitalRead(auto) { return 0; }
-void digitalWrite(auto, auto) { }
-void analogWrite(auto, auto) { }
+void digitalWrite(auto, auto) {}
+void analogWrite(auto, auto) {}
 
 #define UTILS_H
 #define CONSTANTS_H
@@ -35,10 +35,10 @@ static uint8_t BRIGHTNESS = 255;
 static uint8_t MaxBrightnessLimit = 255;
 
 #define BRIGHTNESS_RAMP_DURATION_MS 2000
-#define MIN_BRIGHTNESS 5
-#define MAX_BRIGHTNESS 255
-#define EARLY_ACTIONS_LIMIT_MS 2000
-#define EARLY_ACTIONS_HOLD_MS 2000
+#define MIN_BRIGHTNESS              5
+#define MAX_BRIGHTNESS              255
+#define EARLY_ACTIONS_LIMIT_MS      2000
+#define EARLY_ACTIONS_HOLD_MS       2000
 
 static bool deferredBrightnessCallback = false;
 
@@ -73,7 +73,8 @@ void power_on_behavior(auto& simu)
   simu.read_parameters();
 }
 
-void power_off_behavior(auto& simu) {
+void power_off_behavior(auto& simu)
+{
   isShutdown = true;
   fprintf(stderr, "shutdown\n");
 
@@ -81,22 +82,28 @@ void power_off_behavior(auto& simu) {
   simu.power_off_sequence();
 }
 
-void click_behavior(auto& simu, uint8_t consecutiveButtonCheck) {
-  if (consecutiveButtonCheck == 0) return;
+void click_behavior(auto& simu, uint8_t consecutiveButtonCheck)
+{
+  if (consecutiveButtonCheck == 0)
+    return;
   fprintf(stderr, "clicked %d\n", consecutiveButtonCheck);
 
   // guard blocking other actions than "turning it on" if is_shutdown
-  if (isShutdown) {
-    if (consecutiveButtonCheck == 1) {
+  if (isShutdown)
+  {
+    if (consecutiveButtonCheck == 1)
+    {
       power_on_behavior(simu); // fake start
     }
     return;
   }
 
   // extended "button usermode" bypass
-  if (isButtonUsermodeEnabled) {
+  if (isButtonUsermodeEnabled)
+  {
     // user mode may return "True" to skip default action
-    if (simu.button_clicked_usermode(consecutiveButtonCheck)) {
+    if (simu.button_clicked_usermode(consecutiveButtonCheck))
+    {
       return;
     }
   }
@@ -105,8 +112,8 @@ void click_behavior(auto& simu, uint8_t consecutiveButtonCheck) {
   //  - 1 click: on/off
   //  - 7+ clicks: shutdown immediately (if DEBUG_MODE wait for watchdog)
   //
-  switch (consecutiveButtonCheck) {
-
+  switch (consecutiveButtonCheck)
+  {
     // 1 click: shutdown
     case 1:
       power_off_behavior(simu); // fake stop
@@ -116,7 +123,8 @@ void click_behavior(auto& simu, uint8_t consecutiveButtonCheck) {
     default:
 
       // 7+ clicks: force shutdown (or safety reset if DEBUG_MODE)
-      if (consecutiveButtonCheck >= 7) {
+      if (consecutiveButtonCheck >= 7)
+      {
         fprintf(stderr, "(force-shutdown)\n");
         power_off_behavior(simu); // fake stop
         return;
@@ -129,29 +137,35 @@ void click_behavior(auto& simu, uint8_t consecutiveButtonCheck) {
 
 static constexpr float brightnessDivider = 1.0 / float(MAX_BRIGHTNESS - MIN_BRIGHTNESS);
 
-void hold_behavior(auto& simu,
-                   uint8_t consecutiveButtonCheck,
-                   uint32_t buttonHoldDuration) {
-  if (consecutiveButtonCheck == 0) return;
-  if (isShutdown) return;
+void hold_behavior(auto& simu, uint8_t consecutiveButtonCheck, uint32_t buttonHoldDuration)
+{
+  if (consecutiveButtonCheck == 0)
+    return;
+  if (isShutdown)
+    return;
 
   fprintf(stderr, "hold %d %d\n", consecutiveButtonCheck, buttonHoldDuration);
 
   const bool isEndOfHoldEvent = (buttonHoldDuration <= 1);
-  const uint32_t holdDuration = (buttonHoldDuration > HOLD_BUTTON_MIN_MS)
-      ? (buttonHoldDuration - HOLD_BUTTON_MIN_MS) : 0;
+  const uint32_t holdDuration =
+          (buttonHoldDuration > HOLD_BUTTON_MIN_MS) ? (buttonHoldDuration - HOLD_BUTTON_MIN_MS) : 0;
 
   uint32_t realStartTime = millis() - lastStartupSequence;
-  if (realStartTime > holdDuration) {
+  if (realStartTime > holdDuration)
+  {
     realStartTime -= holdDuration;
   }
 
-  if (realStartTime < EARLY_ACTIONS_LIMIT_MS) {
-    if (isEndOfHoldEvent && consecutiveButtonCheck > 2) return;
+  if (realStartTime < EARLY_ACTIONS_LIMIT_MS)
+  {
+    if (isEndOfHoldEvent && consecutiveButtonCheck > 2)
+      return;
 
     // 3+hold (3s): turn it on, with button usermode enabled
-    if (consecutiveButtonCheck == 3) {
-      if (holdDuration > EARLY_ACTIONS_HOLD_MS) {
+    if (consecutiveButtonCheck == 3)
+    {
+      if (holdDuration > EARLY_ACTIONS_HOLD_MS)
+      {
         fprintf(stderr, "button usermode enabled\n");
         isButtonUsermodeEnabled = true;
         return;
@@ -159,15 +173,20 @@ void hold_behavior(auto& simu,
     }
 
     // 4+hold (3s): turn it on, with bluetooth advertising
-    if (consecutiveButtonCheck == 4) {
-      if (holdDuration > EARLY_ACTIONS_HOLD_MS) {
-        if (!isBluetoothAdvertising) {
+    if (consecutiveButtonCheck == 4)
+    {
+      if (holdDuration > EARLY_ACTIONS_HOLD_MS)
+      {
+        if (!isBluetoothAdvertising)
+        {
           fprintf(stderr, "bluetooth advertising\n");
         }
 
         isBluetoothAdvertising = true;
         return;
-      } else {
+      }
+      else
+      {
         isBluetoothAdvertising = false;
       }
     }
@@ -177,20 +196,21 @@ void hold_behavior(auto& simu,
   // "button usermode" bypass
   //
 
-  if (isButtonUsermodeEnabled) {
-
+  if (isButtonUsermodeEnabled)
+  {
     // 5+hold (5s): always exit, can't be bypassed
-    if (consecutiveButtonCheck == 5) {
-      if (holdDuration > 5000 - HOLD_BUTTON_MIN_MS) {
+    if (consecutiveButtonCheck == 5)
+    {
+      if (holdDuration > 5000 - HOLD_BUTTON_MIN_MS)
+      {
         power_off_behavior(simu);
         return;
       }
     }
 
     // user mode may return "True" to skip default action
-    if (simu.button_hold_usermode(consecutiveButtonCheck,
-                                  isEndOfHoldEvent,
-                                  holdDuration)) {
+    if (simu.button_hold_usermode(consecutiveButtonCheck, isEndOfHoldEvent, holdDuration))
+    {
       return;
     }
   }
@@ -203,24 +223,26 @@ void hold_behavior(auto& simu,
   //  - 1+hold: increase brightness
   //  - 2+hold: decrease brightness
   //
-  switch (consecutiveButtonCheck) {
-
+  switch (consecutiveButtonCheck)
+  {
     // 1+hold: increase brightness
     case 1:
-      if (isEndOfHoldEvent) {
+      if (isEndOfHoldEvent)
+      {
         currentBrightness = BRIGHTNESS;
         fprintf(stderr, "brightness set to %d\n", BRIGHTNESS);
+      }
+      else
+      {
+        const float percentOfTimeToGoUp = float(MAX_BRIGHTNESS - currentBrightness) * brightnessDivider;
+        if (percentOfTimeToGoUp == 0)
+          return;
 
-      } else {
-        const float percentOfTimeToGoUp =
-            float(MAX_BRIGHTNESS - currentBrightness) * brightnessDivider;
-        if (percentOfTimeToGoUp == 0) return;
-
-        const float newBrightness =
-            map(min(holdDuration,
-                    BRIGHTNESS_RAMP_DURATION_MS * percentOfTimeToGoUp),
-                0, BRIGHTNESS_RAMP_DURATION_MS * percentOfTimeToGoUp,
-                currentBrightness, MAX_BRIGHTNESS);
+        const float newBrightness = map(min(holdDuration, BRIGHTNESS_RAMP_DURATION_MS * percentOfTimeToGoUp),
+                                        0,
+                                        BRIGHTNESS_RAMP_DURATION_MS * percentOfTimeToGoUp,
+                                        currentBrightness,
+                                        MAX_BRIGHTNESS);
 
         BRIGHTNESS = newBrightness;
         fprintf(stderr, "brightness up %f\n", newBrightness);
@@ -231,20 +253,22 @@ void hold_behavior(auto& simu,
 
     // 2+hold: decrease brightness
     case 2:
-      if (isEndOfHoldEvent) {
+      if (isEndOfHoldEvent)
+      {
         currentBrightness = BRIGHTNESS;
         fprintf(stderr, "brightness set to %d\n", BRIGHTNESS);
+      }
+      else
+      {
+        const double percentOfTimeToGoDown = float(currentBrightness - MIN_BRIGHTNESS) * brightnessDivider;
+        if (percentOfTimeToGoDown == 0)
+          return;
 
-      } else {
-        const double percentOfTimeToGoDown =
-            float(currentBrightness - MIN_BRIGHTNESS) * brightnessDivider;
-        if (percentOfTimeToGoDown == 0) return;
-
-        const float newBrightness =
-            map(min(holdDuration,
-                    BRIGHTNESS_RAMP_DURATION_MS * percentOfTimeToGoDown),
-                0, BRIGHTNESS_RAMP_DURATION_MS * percentOfTimeToGoDown,
-                currentBrightness, MIN_BRIGHTNESS);
+        const float newBrightness = map(min(holdDuration, BRIGHTNESS_RAMP_DURATION_MS * percentOfTimeToGoDown),
+                                        0,
+                                        BRIGHTNESS_RAMP_DURATION_MS * percentOfTimeToGoDown,
+                                        currentBrightness,
+                                        MIN_BRIGHTNESS);
 
         BRIGHTNESS = newBrightness;
         fprintf(stderr, "brightness down %f\n", newBrightness);
@@ -259,6 +283,5 @@ void hold_behavior(auto& simu,
       break;
   }
 }
-
 
 #endif

--- a/simulator/include/simulator.h
+++ b/simulator/include/simulator.h
@@ -24,7 +24,7 @@ constexpr int ledH = stripYCoordinates;
 namespace {
 #include "src/system/utils/utils.h"
 #include "src/system/utils/colorspace.cpp"
-}
+} // namespace
 using utils::map;
 
 #include "src/system/utils/coordinates.cpp"
@@ -35,7 +35,8 @@ using utils::map;
 // led strip fake struct
 //
 
-struct LedStrip {
+struct LedStrip
+{
   uint32_t leds[LED_COUNT];
 
   uint8_t _buffer8b[LED_COUNT];
@@ -43,21 +44,22 @@ struct LedStrip {
 
   std::unique_ptr<sf::RectangleShape> shapes[LED_COUNT];
 
-  LedStrip() {
-    for (size_t I = 0; I < LED_COUNT; ++I) {
+  LedStrip()
+  {
+    for (size_t I = 0; I < LED_COUNT; ++I)
+    {
       leds[I] = 0;
       shapes[I] = std::make_unique<sf::RectangleShape>();
     }
   }
 
-  void show() { }
-  void begin() { }
+  void show() {}
+  void begin() {}
 
-  uint8_t getBrightness() {
-    return BRIGHTNESS;
-  }
+  uint8_t getBrightness() { return BRIGHTNESS; }
 
-  uint8_t setBrightness(uint8_t brightnessValue) {
+  uint8_t setBrightness(uint8_t brightnessValue)
+  {
     BRIGHTNESS = brightnessValue;
     currentBrightness = brightnessValue;
     return BRIGHTNESS;
@@ -65,8 +67,8 @@ struct LedStrip {
 
   void setPixelColorXY(uint8_t X, uint8_t Y, uint8_t r, uint8_t g, uint8_t b);
 
-  template <typename T>
-  void setPixelColorXY(uint8_t X, uint8_t Y, T cc) {
+  template<typename T> void setPixelColorXY(uint8_t X, uint8_t Y, T cc)
+  {
     uint32_t c;
     memcpy(&c, &cc, sizeof(c));
     uint64_t r = ((c >> 16) & 0xff);
@@ -75,27 +77,36 @@ struct LedStrip {
     setPixelColorXY(X, Y, r, g, b);
   }
 
-  void setPixelColor(uint16_t led, uint8_t r, uint8_t g, uint8_t b) {
-
+  void setPixelColor(uint16_t led, uint8_t r, uint8_t g, uint8_t b)
+  {
 #ifndef LMBD_SIMU_REALCOLORS
     // non-linear scale for better display
-    if (r < 64) r *= 4;
-    if (g < 64) g *= 4;
-    if (b < 64) b *= 4;
-    if (r < 32) r *= 4;
-    if (g < 32) g *= 4;
-    if (b < 32) b *= 4;
-    if (r < 16) r *= 4;
-    if (g < 16) g *= 4;
-    if (b < 16) b *= 4;
+    if (r < 64)
+      r *= 4;
+    if (g < 64)
+      g *= 4;
+    if (b < 64)
+      b *= 4;
+    if (r < 32)
+      r *= 4;
+    if (g < 32)
+      g *= 4;
+    if (b < 32)
+      b *= 4;
+    if (r < 16)
+      r *= 4;
+    if (g < 16)
+      g *= 4;
+    if (b < 16)
+      b *= 4;
 #endif
 
     leds[led] = (r << 16) | (g << 8) | b;
     return;
   }
 
-  template <typename T>
-  void setPixelColor(uint16_t led, T cc) {
+  template<typename T> void setPixelColor(uint16_t led, T cc)
+  {
     uint32_t c;
     memcpy(&c, &cc, sizeof(c));
     uint64_t r = ((c >> 16) & 0xff);
@@ -104,8 +115,10 @@ struct LedStrip {
     setPixelColor(led, r, g, b);
   }
 
-  void fadeToBlackBy(uint8_t amount) {
-    for (size_t I = 0; I < LED_COUNT; ++I) {
+  void fadeToBlackBy(uint8_t amount)
+  {
+    for (size_t I = 0; I < LED_COUNT; ++I)
+    {
       uint64_t b = (leds[I] & 0xff);
       uint64_t g = ((leds[I] >> 8) & 0xff);
       uint64_t r = ((leds[I] >> 16) & 0xff);
@@ -122,49 +135,40 @@ struct LedStrip {
     }
   }
 
-  void fill(uint32_t c, uint16_t start, uint16_t end) {
-    for (size_t I = start; I < end; ++I) {
+  void fill(uint32_t c, uint16_t start, uint16_t end)
+  {
+    for (size_t I = start; I < end; ++I)
+    {
       leds[I] = c;
     }
   }
 
-  void clear() {
-    fill(0, 0, LED_COUNT);
-  }
+  void clear() { fill(0, 0, LED_COUNT); }
 
-  static uint32_t Color(uint8_t r, uint8_t g, uint8_t b) {
-    return (r << 16) | (g << 8) | b;
-  }
+  static uint32_t Color(uint8_t r, uint8_t g, uint8_t b) { return (r << 16) | (g << 8) | b; }
 
   static uint32_t ColorHSV(double h, double s = 255, double v = 255);
 
-  uint32_t* get_buffer_ptr(int) {
-    return leds;
-  }
+  uint32_t* get_buffer_ptr(int) { return leds; }
 
-  uint32_t getPixelColor(uint16_t idx) {
-    return leds[idx];
-  }
+  uint32_t getPixelColor(uint16_t idx) { return leds[idx]; }
 
-  void buffer_current_colors(int) { }; // TODO: implement
-  void blur(int) { } // TODO: implement
+  void buffer_current_colors(int) {}; // TODO: implement
+  void blur(int) {}                   // TODO: implement
 
-  Cartesian get_lamp_coordinates(int i) {
-    return to_lamp(i);
-  }
+  Cartesian get_lamp_coordinates(int i) { return to_lamp(i); }
 };
 
 //
 // LedStrip hacks
 //
 
-void LedStrip::setPixelColorXY(uint8_t X, uint8_t Y, uint8_t r, uint8_t g, uint8_t b) {
+void LedStrip::setPixelColorXY(uint8_t X, uint8_t Y, uint8_t r, uint8_t g, uint8_t b)
+{
   setPixelColor(to_strip(X, Y), r, g, b);
 }
 
-uint32_t LedStrip::ColorHSV(double h, double s, double v) {
-  return utils::ColorSpace::HSV(h, s, v).get_rgb().color;
-}
+uint32_t LedStrip::ColorHSV(double h, double s, double v) { return utils::ColorSpace::HSV(h, s, v).get_rgb().color; }
 
 //
 // basic microphone emulation
@@ -177,7 +181,8 @@ static constexpr float highLevelDb = 80;
 
 constexpr uint8_t numberOfFFtChanels = 25;
 
-struct SoundStruct {
+struct SoundStruct
+{
   bool isValid = false;
 
   float fftMajorPeakFrequency_Hz = 0.0;
@@ -192,13 +197,15 @@ float get_sound_level_Db() { return sound_level; }
 SoundStruct get_fft() { return soundStruct; }
 
 // to hook microphone & measure levelDb
-class LevelRecorder : public sf::SoundRecorder {
+class LevelRecorder : public sf::SoundRecorder
+{
   virtual bool onStart() { return true; }
 
-  virtual bool onProcessSamples(const sf::Int16* samples,
-                                std::size_t sampleCount) {
+  virtual bool onProcessSamples(const sf::Int16* samples, std::size_t sampleCount)
+  {
     float sumOfAll = 0;
-    for (std::size_t i = 0; i < sampleCount; i++) {
+    for (std::size_t i = 0; i < sampleCount; i++)
+    {
       sumOfAll += powf(samples[i] / (float)1024.0, 2.0);
     }
 
@@ -207,13 +214,13 @@ class LevelRecorder : public sf::SoundRecorder {
     return true;
   }
 
-    virtual void onStop() { }
+  virtual void onStop() {}
 
 public:
-    ~LevelRecorder() { stop(); }
+  ~LevelRecorder() { stop(); }
 };
 
-}
+} // namespace microphone
 
 //
 // lampda-specific code
@@ -233,21 +240,20 @@ namespace {
 #include "src/system/utils/utils.cpp"
 }
 
-
 using namespace microphone;
 
 //
 // simulator core loop
 //
 
-template <typename T>
-struct simulator {
+template<typename T> struct simulator
+{
   static constexpr float screenWidth = 1920;
   static constexpr float screenHeight = 1080;
   static constexpr char title[] = "lampda simulator";
 
-  static int run() {
-
+  static int run()
+  {
     // time
     sf::Clock clock;
 
@@ -274,24 +280,27 @@ struct simulator {
     bool shouldSpawnThread = simu.should_spawn_thread();
 
     uint64_t skipframe = 0;
-    while (window.isOpen()){
-
+    while (window.isOpen())
+    {
       // handle button simulation (with fake millis())
       globalMillis = clock.getElapsedTime().asMilliseconds() * 0.75;
 
       button::treat_button_pressed(
-        sf::Keyboard::isKeyPressed(sf::Keyboard::Space), // button is Space
+              sf::Keyboard::isKeyPressed(sf::Keyboard::Space), // button is Space
 
-        [&](uint8_t clicks) {
-          click_behavior(simu, clicks);
-        }, [&](uint8_t clicks, uint32_t hold) {
-          hold_behavior(simu, clicks, hold);
-        });
+              [&](uint8_t clicks) {
+                click_behavior(simu, clicks);
+              },
+              [&](uint8_t clicks, uint32_t hold) {
+                hold_behavior(simu, clicks, hold);
+              });
 
       // other events
       sf::Event event;
-      while (window.pollEvent(event)) {
-        if (event.type == sf::Event::Closed) {
+      while (window.pollEvent(event))
+      {
+        if (event.type == sf::Event::Closed)
+        {
           window.close();
           recorder.stop();
         }
@@ -316,17 +325,22 @@ struct simulator {
       float dt = clock.getElapsedTime().asMilliseconds() - globalMillis;
 
       // re-execute immediately if faster fps needed
-      if (simu.fps > 250) {
+      if (simu.fps > 250)
+      {
         skipframe += 1;
-        if (skipframe % (((uint64_t) simu.fps) - 250) != 0)
+        if (skipframe % (((uint64_t)simu.fps) - 250) != 0)
           continue;
       }
 
       // faster fps if "F" key is pressed
-      if (simu.fps < 1000 && dt < 1000.f && simu.fps > 0) {
-        if (sf::Keyboard::isKeyPressed(sf::Keyboard::F)) {
+      if (simu.fps < 1000 && dt < 1000.f && simu.fps > 0)
+      {
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::F))
+        {
           sf::sleep(sf::milliseconds((1000.f - dt) / (simu.fps * 3)));
-        } else {
+        }
+        else
+        {
           sf::sleep(sf::milliseconds((1000.f - dt) / simu.fps));
         }
       }
@@ -335,17 +349,21 @@ struct simulator {
       window.clear();
 
       // fake shutdown lamp
-      if (isShutdown) {
+      if (isShutdown)
+      {
         window.display();
         continue;
       }
 
-      for (int fXpos = -simu.fakeXorigin; fXpos < ledW - simu.fakeXend; ++fXpos) {
-        for (int Ypos = 0; Ypos < ledH; ++Ypos) {
+      for (int fXpos = -simu.fakeXorigin; fXpos < ledW - simu.fakeXend; ++fXpos)
+      {
+        for (int Ypos = 0; Ypos < ledH; ++Ypos)
+        {
           int Yoff = 0;
 
           int Xpos = fXpos;
-          if (fXpos < 0) {
+          if (fXpos < 0)
+          {
             Xpos = ledW + fXpos;
             Yoff = 1;
           }
@@ -360,8 +378,7 @@ struct simulator {
 
           int rXpos = fXpos + simu.fakeXorigin;
           int rYpos = Ypos + Yoff;
-          shape.setPosition(ledSz + rXpos * ledPadSz + ledOffset * (Ypos % 2) - Yoff * ledOffset,
-                            rYpos * ledPadSz);
+          shape.setPosition(ledSz + rXpos * ledPadSz + ledOffset * (Ypos % 2) - Yoff * ledOffset, rYpos * ledPadSz);
 
           float b = (strip.leds[I] & 0xff);
           float g = ((strip.leds[I] >> 8) & 0xff);
@@ -385,5 +402,4 @@ struct simulator {
 
     return 0;
   }
-
 };

--- a/simulator/src/default_simulation.h
+++ b/simulator/src/default_simulation.h
@@ -11,10 +11,10 @@ struct defaultSimulation {
   float fakeXorigin = 0; // start strip N led to the left
   float fakeXend = 0; // remove N led from right
 
-  defaultSimulation(LedStrip& strip) { }
+  defaultSimulation(LampTy& strip) {}
 
-  void loop(LedStrip& strip) { }
-  void customEventHandler(sf::Event& event) { };
+  void loop(LampTy& strip) {}
+  void customEventHandler(sf::Event& event) {};
 
   void button_clicked_default(const uint8_t clicks) { }
   void button_hold_default(const uint8_t clicks,

--- a/simulator/src/default_simulation.h
+++ b/simulator/src/default_simulation.h
@@ -1,38 +1,37 @@
 #ifndef LMBD_DEFAULT_SIMULATION_H
 #define LMBD_DEFAULT_SIMULATION_H
 
-struct defaultSimulation {
+struct defaultSimulation
+{
   float fps = 60.f; // how fast animation is
 
-  float ledSizePx = 24.f; // square size to represent one LED (in pixels)
+  float ledSizePx = 24.f;   // square size to represent one LED (in pixels)
   float ledPaddingPx = 4.f; // padding between two LEDs (in pixels)
   float ledOffsetPx = 12.f; // how much LED offsets diagonally (in pixels)
 
-  float fakeXorigin = 0; // start strip N led to the left
-  float fakeXend = 0; // remove N led from right
+  float fakeXorigin = 0; // start lamp N led to the left
+  float fakeXend = 0;    // remove N led from right
 
   defaultSimulation(LampTy& strip) {}
 
   void loop(LampTy& strip) {}
   void customEventHandler(sf::Event& event) {};
 
-  void button_clicked_default(const uint8_t clicks) { }
-  void button_hold_default(const uint8_t clicks,
-                           const bool isEndOfHoldEvent,
-                           const uint32_t holdDuration) { }
+  void button_clicked_default(const uint8_t clicks) {}
+  void button_hold_default(const uint8_t clicks, const bool isEndOfHoldEvent, const uint32_t holdDuration) {}
 
   bool button_clicked_usermode(const uint8_t) { return false; }
   bool button_hold_usermode(const uint8_t, const bool, const uint32_t) { return false; }
 
-  void brightness_update(const uint8_t) { }
+  void brightness_update(const uint8_t) {}
 
-  void power_on_sequence() { }
-  void power_off_sequence() { }
-  void write_parameters() { }
-  void read_parameters() { }
+  void power_on_sequence() {}
+  void power_off_sequence() {}
+  void write_parameters() {}
+  void read_parameters() {}
 
   bool should_spawn_thread() { return false; }
-  void user_thread() { }
+  void user_thread() {}
 };
 
 #endif

--- a/simulator/src/distort-simulator.cpp
+++ b/simulator/src/distort-simulator.cpp
@@ -67,10 +67,7 @@ void mode_2Ddistortionwaves(const uint8_t scale, const uint8_t speed,
 struct distortSimulation : public defaultSimulation {
   float fps = 20.f;
 
-  void loop(LedStrip& strip) {
-    mode_2Ddistortionwaves(128, 128, strip);
-  }
-
+  void loop(LampTy& lamp) { mode_2Ddistortionwaves(128, 128, lamp.getLegacyStrip()); }
 };
 
 int main() {

--- a/simulator/src/distort-simulator.cpp
+++ b/simulator/src/distort-simulator.cpp
@@ -2,8 +2,8 @@
 
 #include "default_simulation.h"
 
-void mode_2Ddistortionwaves(const uint8_t scale, const uint8_t speed,
-                            LedStrip& strip) {
+void mode_2Ddistortionwaves(const uint8_t scale, const uint8_t speed, LedStrip& strip)
+{
   const uint16_t cols = ceil(stripXCoordinates);
   const uint16_t rows = ceil(stripYCoordinates);
 
@@ -24,36 +24,23 @@ void mode_2Ddistortionwaves(const uint8_t scale, const uint8_t speed,
   uint16_t cy2 = beatsin8(14 - _speed, 0, rows - 1) * _scale;
 
   uint16_t xoffs = 0;
-  for (int x = 0; x < cols; x++) {
+  for (int x = 0; x < cols; x++)
+  {
     xoffs += _scale;
     uint16_t yoffs = 0;
 
-    for (int y = 0; y < rows; y++) {
+    for (int y = 0; y < rows; y++)
+    {
       yoffs += _scale;
 
-      byte rdistort =
-          cos8((cos8(((x << 3) + a) & 255) + cos8(((y << 3) - a2) & 255) + a3) &
-               255) >>
-          1;
-      byte gdistort = cos8((cos8(((x << 3) - a2) & 255) +
-                            cos8(((y << 3) + a3) & 255) + a + 32) &
-                           255) >>
-                      1;
-      byte bdistort = cos8((cos8(((x << 3) + a3) & 255) +
-                            cos8(((y << 3) - a) & 255) + a2 + 64) &
-                           255) >>
-                      1;
+      byte rdistort = cos8((cos8(((x << 3) + a) & 255) + cos8(((y << 3) - a2) & 255) + a3) & 255) >> 1;
+      byte gdistort = cos8((cos8(((x << 3) - a2) & 255) + cos8(((y << 3) + a3) & 255) + a + 32) & 255) >> 1;
+      byte bdistort = cos8((cos8(((x << 3) + a3) & 255) + cos8(((y << 3) - a) & 255) + a2 + 64) & 255) >> 1;
 
       COLOR c;
-      c.red = rdistort + w * (a - (((xoffs - cx) * (xoffs - cx) +
-                                    (yoffs - cy) * (yoffs - cy)) >>
-                                   7));
-      c.green = gdistort + w * (a2 - (((xoffs - cx1) * (xoffs - cx1) +
-                                       (yoffs - cy1) * (yoffs - cy1)) >>
-                                      7));
-      c.blue = bdistort + w * (a3 - (((xoffs - cx2) * (xoffs - cx2) +
-                                      (yoffs - cy2) * (yoffs - cy2)) >>
-                                     7));
+      c.red = rdistort + w * (a - (((xoffs - cx) * (xoffs - cx) + (yoffs - cy) * (yoffs - cy)) >> 7));
+      c.green = gdistort + w * (a2 - (((xoffs - cx1) * (xoffs - cx1) + (yoffs - cy1) * (yoffs - cy1)) >> 7));
+      c.blue = bdistort + w * (a3 - (((xoffs - cx2) * (xoffs - cx2) + (yoffs - cy2) * (yoffs - cy2)) >> 7));
 
       c.red = utils::gamma8(cos8(c.red));
       c.green = utils::gamma8(cos8(c.green));
@@ -64,13 +51,11 @@ void mode_2Ddistortionwaves(const uint8_t scale, const uint8_t speed,
   }
 }
 
-struct distortSimulation : public defaultSimulation {
+struct distortSimulation : public defaultSimulation
+{
   float fps = 20.f;
 
   void loop(LampTy& lamp) { mode_2Ddistortionwaves(128, 128, lamp.getLegacyStrip()); }
 };
 
-int main() {
-  return simulator<distortSimulation>::run();
-}
-
+int main() { return simulator<distortSimulation>::run(); }

--- a/simulator/src/fire-simulator.cpp
+++ b/simulator/src/fire-simulator.cpp
@@ -2,32 +2,31 @@
 
 #include "default_simulation.h"
 
-void fire(const uint8_t scalex, const uint8_t scaley, const uint8_t speed,
-          const palette_t& palette, LedStrip& strip) {
+void fire(const uint8_t scalex, const uint8_t scaley, const uint8_t speed, const palette_t& palette, LedStrip& strip)
+{
   static uint32_t step = 0;
   uint16_t zSpeed = step / (256 - speed);
   uint16_t ySpeed = millis() / (256 - speed);
-  for (int i = 0; i < ceil(stripXCoordinates); i++) {
-    for (int j = 0; j < ceil(stripYCoordinates); j++) {
+  for (int i = 0; i < ceil(stripXCoordinates); i++)
+  {
+    for (int j = 0; j < ceil(stripYCoordinates); j++)
+    {
       strip.setPixelColorXY(
-          stripXCoordinates - i, j,
-          get_color_from_palette(
-              qsub8(noise8::inoise(i * scalex, j * scaley + ySpeed, zSpeed),
-                    abs8(j - (stripXCoordinates - 1)) * 255 /
-                        (stripXCoordinates - 1)),
-              palette));
+              stripXCoordinates - i,
+              j,
+              get_color_from_palette(qsub8(noise8::inoise(i * scalex, j * scaley + ySpeed, zSpeed),
+                                           abs8(j - (stripXCoordinates - 1)) * 255 / (stripXCoordinates - 1)),
+                                     palette));
     }
   }
   step++;
 }
 
-struct fireSimulation : public defaultSimulation {
+struct fireSimulation : public defaultSimulation
+{
   float fps = 20.f;
 
   void loop(LampTy& lamp) { fire(60, 60, 255, PaletteHeatColors, lamp.getLegacyStrip()); }
 };
 
-int main() {
-  return simulator<fireSimulation>::run();
-}
-
+int main() { return simulator<fireSimulation>::run(); }

--- a/simulator/src/fire-simulator.cpp
+++ b/simulator/src/fire-simulator.cpp
@@ -24,10 +24,7 @@ void fire(const uint8_t scalex, const uint8_t scaley, const uint8_t speed,
 struct fireSimulation : public defaultSimulation {
   float fps = 20.f;
 
-  void loop(LedStrip& strip) {
-    fire(60, 60, 255, PaletteHeatColors, strip);
-  }
-
+  void loop(LampTy& lamp) { fire(60, 60, 255, PaletteHeatColors, lamp.getLegacyStrip()); }
 };
 
 int main() {

--- a/simulator/src/indexable-simulator.cpp
+++ b/simulator/src/indexable-simulator.cpp
@@ -24,9 +24,7 @@ struct modeSimulation : public defaultSimulation {
 
   auto get_context() { return modeManager.get_context(); }
 
-  modeSimulation(LedStrip& strip)
-      : defaultSimulation(strip),
-        modeManager(strip) { }
+  modeSimulation(LampTy& lamp) : defaultSimulation(lamp), modeManager(lamp) {}
 
   void loop(auto&) { loop(); }
 

--- a/simulator/src/indexable-simulator.cpp
+++ b/simulator/src/indexable-simulator.cpp
@@ -8,18 +8,21 @@
 #include "src/modes/default/fixed_modes.hpp"
 #include "src/modes/legacy/legacy_modes.hpp"
 
-struct MyCustomConfig : public modes::DefaultManagerConfig {
+struct MyCustomConfig : public modes::DefaultManagerConfig
+{
   static constexpr uint32_t defaultCustomRampStepSpeedMs = 8;
   static constexpr uint32_t scrollRampStepSpeedMs = 256;
 };
 
-using ManagerTy =
-    modes::ManagerForConfig<MyCustomConfig, modes::FixedModes,
-                            modes::MiscFixedModes, modes::legacy::CalmModes,
-                            modes::legacy::PartyModes,
-                            modes::legacy::SoundModes>;
+using ManagerTy = modes::ManagerForConfig<MyCustomConfig,
+                                          modes::FixedModes,
+                                          modes::MiscFixedModes,
+                                          modes::legacy::CalmModes,
+                                          modes::legacy::PartyModes,
+                                          modes::legacy::SoundModes>;
 
-struct modeSimulation : public defaultSimulation {
+struct modeSimulation : public defaultSimulation
+{
   float fps = 60.f;
 
   auto get_context() { return modeManager.get_context(); }
@@ -34,7 +37,4 @@ private:
   ManagerTy modeManager;
 };
 
-int main() {
-  return simulator<modeSimulation>::run();
-}
-
+int main() { return simulator<modeSimulation>::run(); }

--- a/src/modes/custom/my_custom_config.hpp
+++ b/src/modes/custom/my_custom_config.hpp
@@ -3,13 +3,13 @@
 
 // uncomment only what you need to override
 //
-struct MyCustomConfig : public modes::DefaultManagerConfig {
+struct MyCustomConfig : public modes::DefaultManagerConfig
+{
   // static constexpr bool defaultRampSaturates = true;
   // static constexpr bool defaultClearStripOnModeChange = false;
   // static constexpr uint32_t defaultCustomRampStepSpeedMs = 32;
 };
 
-template <typename... Groups>
-using CustomManagerFor = modes::ManagerForConfig<MyCustomConfig, Groups...>;
+template<typename... Groups> using CustomManagerFor = modes::ManagerForConfig<MyCustomConfig, Groups...>;
 
 #endif

--- a/src/modes/custom/my_custom_mode.hpp
+++ b/src/modes/custom/my_custom_mode.hpp
@@ -1,10 +1,10 @@
 #ifndef MY_CUSTOM_MODE_H
 #define MY_CUSTOM_MODE_H
 
-struct MyCustomMode : public modes::FullMode {
-
-  static void loop(auto& ctx) { }
-  static void reset(auto& ctx) { }
+struct MyCustomMode : public modes::BasicMode
+{
+  static void loop(auto& ctx) {}
+  static void reset(auto& ctx) {}
 
   // only if hasBrightCallback
   static void brightness_update(auto& ctx, uint8_t brightness) { }

--- a/src/modes/custom/my_custom_mode.hpp
+++ b/src/modes/custom/my_custom_mode.hpp
@@ -7,34 +7,32 @@ struct MyCustomMode : public modes::BasicMode
   static void reset(auto& ctx) {}
 
   // only if hasBrightCallback
-  static void brightness_update(auto& ctx, uint8_t brightness) { }
+  static void brightness_update(auto& ctx, uint8_t brightness) {}
 
   // only if hasCustomRamp
-  static void custom_ramp_update(auto& ctx, uint8_t rampValue) { }
+  static void custom_ramp_update(auto& ctx, uint8_t rampValue) {}
 
   // only if hasButtonCustomUI
-  static bool custom_click(auto& ctx, uint8_t nbClick) {
-    return false;
-  }
+  static bool custom_click(auto& ctx, uint8_t nbClick) { return false; }
 
-  static bool custom_hold(auto& ctx,
-                          uint8_t nbClickAndHold,
-                          bool isEndOfHoldEvent,
-                          uint32_t holdDuration) {
+  static bool custom_hold(auto& ctx, uint8_t nbClickAndHold, bool isEndOfHoldEvent, uint32_t holdDuration)
+  {
     return false;
   }
 
   // only if hasSystemCallbacks
-  static void power_on_sequence(auto& ctx) { }
-  static void power_off_sequence(auto& ctx) { }
-  static void read_parameters(auto& ctx) { }
-  static void write_parameters(auto& ctx) { }
+  static void power_on_sequence(auto& ctx) {}
+  static void power_off_sequence(auto& ctx) {}
+  static void read_parameters(auto& ctx) {}
+  static void write_parameters(auto& ctx) {}
 
   // only if requireUserThread
-  static void user_thread(auto& ctx) { }
+  static void user_thread(auto& ctx) {}
 
   // keep only if customized
-  struct StateTy { };
+  struct StateTy
+  {
+  };
 
   // keep only the ones you need (= true)
   static constexpr bool hasBrightCallback = false;

--- a/src/modes/default/fixed_modes.hpp
+++ b/src/modes/default/fixed_modes.hpp
@@ -80,17 +80,10 @@ struct PaletteOceanMode : public PaletteMode
 // Fixed modes groups
 //
 
-using FixedModes = modes::GroupFor<
-  fixed::KelvinMode,
-  fixed::RainbowMode
->;
+using FixedModes = modes::GroupFor<fixed::KelvinMode, fixed::RainbowMode>;
 
-using MiscFixedModes = modes::GroupFor<
-  fixed::PalettePartyMode,
-  fixed::PaletteForestMode,
-  fixed::PaletteOceanMode
->;
+using MiscFixedModes = modes::GroupFor<fixed::PalettePartyMode, fixed::PaletteForestMode, fixed::PaletteOceanMode>;
 
-} // modes
+} // namespace modes
 
 #endif

--- a/src/modes/default/fixed_modes.hpp
+++ b/src/modes/default/fixed_modes.hpp
@@ -7,40 +7,29 @@ namespace modes {
 
 namespace fixed {
 
-/// Single-color mode for indexable strips with palette ramp
-struct FixedMode : public modes::FullMode {
-  static void loop(auto& ctx) {
-    uint32_t color = modes::colors::from_palette(
-      ctx.get_active_custom_ramp(),
-      ctx.state.palette);
-    ctx.fill(color);
-  }
-};
-
 //
 // main lightning modes
 //
 
 /// Black-body fixed colors ramp mode
-struct KelvinMode : public FixedMode {
-  struct StateTy {
-    static constexpr modes::colors::PaletteTy palette = modes::colors::PaletteBlackBodyColors;
-  };
+struct KelvinMode : public modes::BasicMode
+{
+  static void loop(auto& ctx) { ctx.lamp.setLightTemp(ctx.get_active_custom_ramp()); }
 
-  // (enable the ramp to saturates, instead of wrapping ramp around)
-  static void reset(auto& ctx) {
-    ctx.template set_config_bool<ConfigKeys::rampSaturates>(true);
-  }
+  // (force ramp to saturates, instead of wrapping ramp around)
+  static void reset(auto& ctx) { ctx.template set_config_bool<ConfigKeys::rampSaturates>(true); }
 };
 
 /// Rainbow fixed colors ramp mode
-struct RainbowMode : public modes::FullMode {
-  static void loop(auto& ctx) {
+struct RainbowMode : public modes::BasicMode
+{
+  static void loop(auto& ctx)
+  {
     const float index = ctx.get_active_custom_ramp();
     const float hue = (index / 256.f) * 360.f;
-    uint32_t color = utils::hue_to_rgb_sinus(hue);
+    uint32_t color = colors::fromAngleHue(hue);
 
-    ctx.fill(color);
+    ctx.lamp.fill(color);
   }
 };
 
@@ -48,28 +37,44 @@ struct RainbowMode : public modes::FullMode {
 // optional "miscellaneous" group of other gradients
 //
 
+/// Single-color mode for indexable strips with palette ramp
+struct PaletteMode : public modes::BasicMode
+{
+  static void loop(auto& ctx)
+  {
+    uint32_t color = modes::colors::from_palette(ctx.get_active_custom_ramp(), ctx.state.palette);
+    ctx.lamp.fill(color);
+  }
+};
+
 /// Party fixed colors ramp mode
-struct PalettePartyMode : public FixedMode {
-  struct StateTy {
+struct PalettePartyMode : public PaletteMode
+{
+  struct StateTy
+  {
     static constexpr modes::colors::PaletteTy palette = modes::colors::PalettePartyColors;
   };
 };
 
 /// Forest fixed colors ramp mode
-struct PaletteForestMode : public FixedMode {
-  struct StateTy {
+struct PaletteForestMode : public PaletteMode
+{
+  struct StateTy
+  {
     static constexpr modes::colors::PaletteTy palette = modes::colors::PaletteForestColors;
   };
 };
 
 /// Ocean fixed colors ramp mode
-struct PaletteOceanMode : public FixedMode {
-  struct StateTy {
+struct PaletteOceanMode : public PaletteMode
+{
+  struct StateTy
+  {
     static constexpr modes::colors::PaletteTy palette = modes::colors::PaletteOceanColors;
   };
 };
 
-} // modes::fixed
+} // namespace fixed
 
 //
 // Fixed modes groups

--- a/src/modes/include/colors/palettes.hpp
+++ b/src/modes/include/colors/palettes.hpp
@@ -1,11 +1,17 @@
 #ifndef MODES_PALETTES_H
 #define MODES_PALETTES_H
 
+/** \file
+ *
+ *  \brief Manipulate color palettes
+ */
+
 #include <cstdint>
 #include <array>
 
 namespace modes::colors {
 
+/// Palette types
 using PaletteTy = std::array<uint32_t, 16>;
 
 /// @brief Color temperature values
@@ -21,7 +27,8 @@ using PaletteTy = std::array<uint32_t, 16>;
 /// have a proper Kelvin temperature.
 ///
 /// @see https://en.wikipedia.org/wiki/Color_temperature
-typedef enum {
+typedef enum
+{
   // Black Body Radiators
   // @{
   /// 1900 Kelvin
@@ -72,165 +79,165 @@ typedef enum {
   UncorrectedTemperature = 0xFFFFFF /* 255, 255, 255 */
 } ColorTemperature;
 
-
-typedef enum {
-  AliceBlue = 0xF0F8FF,             ///< @htmlcolorblock{F0F8FF}
-  Amethyst = 0x9966CC,              ///< @htmlcolorblock{9966CC}
-  AntiqueWhite = 0xFAEBD7,          ///< @htmlcolorblock{FAEBD7}
-  Aqua = 0x00FFFF,                  ///< @htmlcolorblock{00FFFF}
-  Aquamarine = 0x7FFFD4,            ///< @htmlcolorblock{7FFFD4}
-  Azure = 0xF0FFFF,                 ///< @htmlcolorblock{F0FFFF}
-  Beige = 0xF5F5DC,                 ///< @htmlcolorblock{F5F5DC}
-  Bisque = 0xFFE4C4,                ///< @htmlcolorblock{FFE4C4}
-  Black = 0x000000,                 ///< @htmlcolorblock{000000}
-  BlanchedAlmond = 0xFFEBCD,        ///< @htmlcolorblock{FFEBCD}
-  Blue = 0x0000FF,                  ///< @htmlcolorblock{0000FF}
-  BlueViolet = 0x8A2BE2,            ///< @htmlcolorblock{8A2BE2}
-  Brown = 0xA52A2A,                 ///< @htmlcolorblock{A52A2A}
-  BurlyWood = 0xDEB887,             ///< @htmlcolorblock{DEB887}
-  CadetBlue = 0x5F9EA0,             ///< @htmlcolorblock{5F9EA0}
-  Chartreuse = 0x7FFF00,            ///< @htmlcolorblock{7FFF00}
-  Chocolate = 0xD2691E,             ///< @htmlcolorblock{D2691E}
-  Coral = 0xFF7F50,                 ///< @htmlcolorblock{FF7F50}
-  CornflowerBlue = 0x6495ED,        ///< @htmlcolorblock{6495ED}
-  Cornsilk = 0xFFF8DC,              ///< @htmlcolorblock{FFF8DC}
-  Crimson = 0xDC143C,               ///< @htmlcolorblock{DC143C}
-  Cyan = 0x00FFFF,                  ///< @htmlcolorblock{00FFFF}
-  DarkBlue = 0x00008B,              ///< @htmlcolorblock{00008B}
-  DarkCyan = 0x008B8B,              ///< @htmlcolorblock{008B8B}
-  DarkGoldenrod = 0xB8860B,         ///< @htmlcolorblock{B8860B}
-  DarkGray = 0xA9A9A9,              ///< @htmlcolorblock{A9A9A9}
-  DarkGrey = 0xA9A9A9,              ///< @htmlcolorblock{A9A9A9}
-  DarkGreen = 0x006400,             ///< @htmlcolorblock{006400}
-  DarkKhaki = 0xBDB76B,             ///< @htmlcolorblock{BDB76B}
-  DarkMagenta = 0x8B008B,           ///< @htmlcolorblock{8B008B}
-  DarkOliveGreen = 0x556B2F,        ///< @htmlcolorblock{556B2F}
-  DarkOrange = 0xFF8C00,            ///< @htmlcolorblock{FF8C00}
-  DarkOrchid = 0x9932CC,            ///< @htmlcolorblock{9932CC}
-  DarkRed = 0x8B0000,               ///< @htmlcolorblock{8B0000}
-  DarkSalmon = 0xE9967A,            ///< @htmlcolorblock{E9967A}
-  DarkSeaGreen = 0x8FBC8F,          ///< @htmlcolorblock{8FBC8F}
-  DarkSlateBlue = 0x483D8B,         ///< @htmlcolorblock{483D8B}
-  DarkSlateGray = 0x2F4F4F,         ///< @htmlcolorblock{2F4F4F}
-  DarkSlateGrey = 0x2F4F4F,         ///< @htmlcolorblock{2F4F4F}
-  DarkTurquoise = 0x00CED1,         ///< @htmlcolorblock{00CED1}
-  DarkViolet = 0x9400D3,            ///< @htmlcolorblock{9400D3}
-  DeepPink = 0xFF1493,              ///< @htmlcolorblock{FF1493}
-  DeepSkyBlue = 0x00BFFF,           ///< @htmlcolorblock{00BFFF}
-  DimGray = 0x696969,               ///< @htmlcolorblock{696969}
-  DimGrey = 0x696969,               ///< @htmlcolorblock{696969}
-  DodgerBlue = 0x1E90FF,            ///< @htmlcolorblock{1E90FF}
-  FireBrick = 0xB22222,             ///< @htmlcolorblock{B22222}
-  FloralWhite = 0xFFFAF0,           ///< @htmlcolorblock{FFFAF0}
-  ForestGreen = 0x228B22,           ///< @htmlcolorblock{228B22}
-  Fuchsia = 0xFF00FF,               ///< @htmlcolorblock{FF00FF}
-  Gainsboro = 0xDCDCDC,             ///< @htmlcolorblock{DCDCDC}
-  GhostWhite = 0xF8F8FF,            ///< @htmlcolorblock{F8F8FF}
-  Gold = 0xFFD700,                  ///< @htmlcolorblock{FFD700}
-  Goldenrod = 0xDAA520,             ///< @htmlcolorblock{DAA520}
-  Gray = 0x808080,                  ///< @htmlcolorblock{808080}
-  Grey = 0x808080,                  ///< @htmlcolorblock{808080}
-  Green = 0x008000,                 ///< @htmlcolorblock{008000}
-  GreenYellow = 0xADFF2F,           ///< @htmlcolorblock{ADFF2F}
-  Honeydew = 0xF0FFF0,              ///< @htmlcolorblock{F0FFF0}
-  HotPink = 0xFF69B4,               ///< @htmlcolorblock{FF69B4}
-  IndianRed = 0xCD5C5C,             ///< @htmlcolorblock{CD5C5C}
-  Indigo = 0x4B0082,                ///< @htmlcolorblock{4B0082}
-  Ivory = 0xFFFFF0,                 ///< @htmlcolorblock{FFFFF0}
-  Khaki = 0xF0E68C,                 ///< @htmlcolorblock{F0E68C}
-  Lavender = 0xE6E6FA,              ///< @htmlcolorblock{E6E6FA}
-  LavenderBlush = 0xFFF0F5,         ///< @htmlcolorblock{FFF0F5}
-  LawnGreen = 0x7CFC00,             ///< @htmlcolorblock{7CFC00}
-  LemonChiffon = 0xFFFACD,          ///< @htmlcolorblock{FFFACD}
-  LightBlue = 0xADD8E6,             ///< @htmlcolorblock{ADD8E6}
-  LightCoral = 0xF08080,            ///< @htmlcolorblock{F08080}
-  LightCyan = 0xE0FFFF,             ///< @htmlcolorblock{E0FFFF}
-  LightGoldenrodYellow = 0xFAFAD2,  ///< @htmlcolorblock{FAFAD2}
-  LightGreen = 0x90EE90,            ///< @htmlcolorblock{90EE90}
-  LightGrey = 0xD3D3D3,             ///< @htmlcolorblock{D3D3D3}
-  LightPink = 0xFFB6C1,             ///< @htmlcolorblock{FFB6C1}
-  LightSalmon = 0xFFA07A,           ///< @htmlcolorblock{FFA07A}
-  LightSeaGreen = 0x20B2AA,         ///< @htmlcolorblock{20B2AA}
-  LightSkyBlue = 0x87CEFA,          ///< @htmlcolorblock{87CEFA}
-  LightSlateGray = 0x778899,        ///< @htmlcolorblock{778899}
-  LightSlateGrey = 0x778899,        ///< @htmlcolorblock{778899}
-  LightSteelBlue = 0xB0C4DE,        ///< @htmlcolorblock{B0C4DE}
-  LightYellow = 0xFFFFE0,           ///< @htmlcolorblock{FFFFE0}
-  Lime = 0x00FF00,                  ///< @htmlcolorblock{00FF00}
-  LimeGreen = 0x32CD32,             ///< @htmlcolorblock{32CD32}
-  Linen = 0xFAF0E6,                 ///< @htmlcolorblock{FAF0E6}
-  Magenta = 0xFF00FF,               ///< @htmlcolorblock{FF00FF}
-  Maroon = 0x800000,                ///< @htmlcolorblock{800000}
-  MediumAquamarine = 0x66CDAA,      ///< @htmlcolorblock{66CDAA}
-  MediumBlue = 0x0000CD,            ///< @htmlcolorblock{0000CD}
-  MediumOrchid = 0xBA55D3,          ///< @htmlcolorblock{BA55D3}
-  MediumPurple = 0x9370DB,          ///< @htmlcolorblock{9370DB}
-  MediumSeaGreen = 0x3CB371,        ///< @htmlcolorblock{3CB371}
-  MediumSlateBlue = 0x7B68EE,       ///< @htmlcolorblock{7B68EE}
-  MediumSpringGreen = 0x00FA9A,     ///< @htmlcolorblock{00FA9A}
-  MediumTurquoise = 0x48D1CC,       ///< @htmlcolorblock{48D1CC}
-  MediumVioletRed = 0xC71585,       ///< @htmlcolorblock{C71585}
-  MidnightBlue = 0x191970,          ///< @htmlcolorblock{191970}
-  MintCream = 0xF5FFFA,             ///< @htmlcolorblock{F5FFFA}
-  MistyRose = 0xFFE4E1,             ///< @htmlcolorblock{FFE4E1}
-  Moccasin = 0xFFE4B5,              ///< @htmlcolorblock{FFE4B5}
-  NavajoWhite = 0xFFDEAD,           ///< @htmlcolorblock{FFDEAD}
-  Navy = 0x000080,                  ///< @htmlcolorblock{000080}
-  OldLace = 0xFDF5E6,               ///< @htmlcolorblock{FDF5E6}
-  Olive = 0x808000,                 ///< @htmlcolorblock{808000}
-  OliveDrab = 0x6B8E23,             ///< @htmlcolorblock{6B8E23}
-  Orange = 0xFFA500,                ///< @htmlcolorblock{FFA500}
-  OrangeRed = 0xFF4500,             ///< @htmlcolorblock{FF4500}
-  Orchid = 0xDA70D6,                ///< @htmlcolorblock{DA70D6}
-  PaleGoldenrod = 0xEEE8AA,         ///< @htmlcolorblock{EEE8AA}
-  PaleGreen = 0x98FB98,             ///< @htmlcolorblock{98FB98}
-  PaleTurquoise = 0xAFEEEE,         ///< @htmlcolorblock{AFEEEE}
-  PaleVioletRed = 0xDB7093,         ///< @htmlcolorblock{DB7093}
-  PapayaWhip = 0xFFEFD5,            ///< @htmlcolorblock{FFEFD5}
-  PeachPuff = 0xFFDAB9,             ///< @htmlcolorblock{FFDAB9}
-  Peru = 0xCD853F,                  ///< @htmlcolorblock{CD853F}
-  Pink = 0xFFC0CB,                  ///< @htmlcolorblock{FFC0CB}
-  Plaid = 0xCC5533,                 ///< @htmlcolorblock{CC5533}
-  Plum = 0xDDA0DD,                  ///< @htmlcolorblock{DDA0DD}
-  PowderBlue = 0xB0E0E6,            ///< @htmlcolorblock{B0E0E6}
-  Purple = 0x800080,                ///< @htmlcolorblock{800080}
-  Red = 0xFF0000,                   ///< @htmlcolorblock{FF0000}
-  RosyBrown = 0xBC8F8F,             ///< @htmlcolorblock{BC8F8F}
-  RoyalBlue = 0x4169E1,             ///< @htmlcolorblock{4169E1}
-  SaddleBrown = 0x8B4513,           ///< @htmlcolorblock{8B4513}
-  Salmon = 0xFA8072,                ///< @htmlcolorblock{FA8072}
-  SandyBrown = 0xF4A460,            ///< @htmlcolorblock{F4A460}
-  SeaGreen = 0x2E8B57,              ///< @htmlcolorblock{2E8B57}
-  Seashell = 0xFFF5EE,              ///< @htmlcolorblock{FFF5EE}
-  Sienna = 0xA0522D,                ///< @htmlcolorblock{A0522D}
-  Silver = 0xC0C0C0,                ///< @htmlcolorblock{C0C0C0}
-  SkyBlue = 0x87CEEB,               ///< @htmlcolorblock{87CEEB}
-  SlateBlue = 0x6A5ACD,             ///< @htmlcolorblock{6A5ACD}
-  SlateGray = 0x708090,             ///< @htmlcolorblock{708090}
-  SlateGrey = 0x708090,             ///< @htmlcolorblock{708090}
-  Snow = 0xFFFAFA,                  ///< @htmlcolorblock{FFFAFA}
-  SpringGreen = 0x00FF7F,           ///< @htmlcolorblock{00FF7F}
-  SteelBlue = 0x4682B4,             ///< @htmlcolorblock{4682B4}
-  Tan = 0xD2B48C,                   ///< @htmlcolorblock{D2B48C}
-  Teal = 0x008080,                  ///< @htmlcolorblock{008080}
-  Thistle = 0xD8BFD8,               ///< @htmlcolorblock{D8BFD8}
-  Tomato = 0xFF6347,                ///< @htmlcolorblock{FF6347}
-  Turquoise = 0x40E0D0,             ///< @htmlcolorblock{40E0D0}
-  Violet = 0xEE82EE,                ///< @htmlcolorblock{EE82EE}
-  Wheat = 0xF5DEB3,                 ///< @htmlcolorblock{F5DEB3}
-  White = 0xFFFFFF,                 ///< @htmlcolorblock{FFFFFF}
-  WhiteSmoke = 0xF5F5F5,            ///< @htmlcolorblock{F5F5F5}
-  Yellow = 0xFFFF00,                ///< @htmlcolorblock{FFFF00}
-  YellowGreen = 0x9ACD32,           ///< @htmlcolorblock{9ACD32}
+typedef enum
+{
+  AliceBlue = 0xF0F8FF,            ///< @htmlcolorblock{F0F8FF}
+  Amethyst = 0x9966CC,             ///< @htmlcolorblock{9966CC}
+  AntiqueWhite = 0xFAEBD7,         ///< @htmlcolorblock{FAEBD7}
+  Aqua = 0x00FFFF,                 ///< @htmlcolorblock{00FFFF}
+  Aquamarine = 0x7FFFD4,           ///< @htmlcolorblock{7FFFD4}
+  Azure = 0xF0FFFF,                ///< @htmlcolorblock{F0FFFF}
+  Beige = 0xF5F5DC,                ///< @htmlcolorblock{F5F5DC}
+  Bisque = 0xFFE4C4,               ///< @htmlcolorblock{FFE4C4}
+  Black = 0x000000,                ///< @htmlcolorblock{000000}
+  BlanchedAlmond = 0xFFEBCD,       ///< @htmlcolorblock{FFEBCD}
+  Blue = 0x0000FF,                 ///< @htmlcolorblock{0000FF}
+  BlueViolet = 0x8A2BE2,           ///< @htmlcolorblock{8A2BE2}
+  Brown = 0xA52A2A,                ///< @htmlcolorblock{A52A2A}
+  BurlyWood = 0xDEB887,            ///< @htmlcolorblock{DEB887}
+  CadetBlue = 0x5F9EA0,            ///< @htmlcolorblock{5F9EA0}
+  Chartreuse = 0x7FFF00,           ///< @htmlcolorblock{7FFF00}
+  Chocolate = 0xD2691E,            ///< @htmlcolorblock{D2691E}
+  Coral = 0xFF7F50,                ///< @htmlcolorblock{FF7F50}
+  CornflowerBlue = 0x6495ED,       ///< @htmlcolorblock{6495ED}
+  Cornsilk = 0xFFF8DC,             ///< @htmlcolorblock{FFF8DC}
+  Crimson = 0xDC143C,              ///< @htmlcolorblock{DC143C}
+  Cyan = 0x00FFFF,                 ///< @htmlcolorblock{00FFFF}
+  DarkBlue = 0x00008B,             ///< @htmlcolorblock{00008B}
+  DarkCyan = 0x008B8B,             ///< @htmlcolorblock{008B8B}
+  DarkGoldenrod = 0xB8860B,        ///< @htmlcolorblock{B8860B}
+  DarkGray = 0xA9A9A9,             ///< @htmlcolorblock{A9A9A9}
+  DarkGrey = 0xA9A9A9,             ///< @htmlcolorblock{A9A9A9}
+  DarkGreen = 0x006400,            ///< @htmlcolorblock{006400}
+  DarkKhaki = 0xBDB76B,            ///< @htmlcolorblock{BDB76B}
+  DarkMagenta = 0x8B008B,          ///< @htmlcolorblock{8B008B}
+  DarkOliveGreen = 0x556B2F,       ///< @htmlcolorblock{556B2F}
+  DarkOrange = 0xFF8C00,           ///< @htmlcolorblock{FF8C00}
+  DarkOrchid = 0x9932CC,           ///< @htmlcolorblock{9932CC}
+  DarkRed = 0x8B0000,              ///< @htmlcolorblock{8B0000}
+  DarkSalmon = 0xE9967A,           ///< @htmlcolorblock{E9967A}
+  DarkSeaGreen = 0x8FBC8F,         ///< @htmlcolorblock{8FBC8F}
+  DarkSlateBlue = 0x483D8B,        ///< @htmlcolorblock{483D8B}
+  DarkSlateGray = 0x2F4F4F,        ///< @htmlcolorblock{2F4F4F}
+  DarkSlateGrey = 0x2F4F4F,        ///< @htmlcolorblock{2F4F4F}
+  DarkTurquoise = 0x00CED1,        ///< @htmlcolorblock{00CED1}
+  DarkViolet = 0x9400D3,           ///< @htmlcolorblock{9400D3}
+  DeepPink = 0xFF1493,             ///< @htmlcolorblock{FF1493}
+  DeepSkyBlue = 0x00BFFF,          ///< @htmlcolorblock{00BFFF}
+  DimGray = 0x696969,              ///< @htmlcolorblock{696969}
+  DimGrey = 0x696969,              ///< @htmlcolorblock{696969}
+  DodgerBlue = 0x1E90FF,           ///< @htmlcolorblock{1E90FF}
+  FireBrick = 0xB22222,            ///< @htmlcolorblock{B22222}
+  FloralWhite = 0xFFFAF0,          ///< @htmlcolorblock{FFFAF0}
+  ForestGreen = 0x228B22,          ///< @htmlcolorblock{228B22}
+  Fuchsia = 0xFF00FF,              ///< @htmlcolorblock{FF00FF}
+  Gainsboro = 0xDCDCDC,            ///< @htmlcolorblock{DCDCDC}
+  GhostWhite = 0xF8F8FF,           ///< @htmlcolorblock{F8F8FF}
+  Gold = 0xFFD700,                 ///< @htmlcolorblock{FFD700}
+  Goldenrod = 0xDAA520,            ///< @htmlcolorblock{DAA520}
+  Gray = 0x808080,                 ///< @htmlcolorblock{808080}
+  Grey = 0x808080,                 ///< @htmlcolorblock{808080}
+  Green = 0x008000,                ///< @htmlcolorblock{008000}
+  GreenYellow = 0xADFF2F,          ///< @htmlcolorblock{ADFF2F}
+  Honeydew = 0xF0FFF0,             ///< @htmlcolorblock{F0FFF0}
+  HotPink = 0xFF69B4,              ///< @htmlcolorblock{FF69B4}
+  IndianRed = 0xCD5C5C,            ///< @htmlcolorblock{CD5C5C}
+  Indigo = 0x4B0082,               ///< @htmlcolorblock{4B0082}
+  Ivory = 0xFFFFF0,                ///< @htmlcolorblock{FFFFF0}
+  Khaki = 0xF0E68C,                ///< @htmlcolorblock{F0E68C}
+  Lavender = 0xE6E6FA,             ///< @htmlcolorblock{E6E6FA}
+  LavenderBlush = 0xFFF0F5,        ///< @htmlcolorblock{FFF0F5}
+  LawnGreen = 0x7CFC00,            ///< @htmlcolorblock{7CFC00}
+  LemonChiffon = 0xFFFACD,         ///< @htmlcolorblock{FFFACD}
+  LightBlue = 0xADD8E6,            ///< @htmlcolorblock{ADD8E6}
+  LightCoral = 0xF08080,           ///< @htmlcolorblock{F08080}
+  LightCyan = 0xE0FFFF,            ///< @htmlcolorblock{E0FFFF}
+  LightGoldenrodYellow = 0xFAFAD2, ///< @htmlcolorblock{FAFAD2}
+  LightGreen = 0x90EE90,           ///< @htmlcolorblock{90EE90}
+  LightGrey = 0xD3D3D3,            ///< @htmlcolorblock{D3D3D3}
+  LightPink = 0xFFB6C1,            ///< @htmlcolorblock{FFB6C1}
+  LightSalmon = 0xFFA07A,          ///< @htmlcolorblock{FFA07A}
+  LightSeaGreen = 0x20B2AA,        ///< @htmlcolorblock{20B2AA}
+  LightSkyBlue = 0x87CEFA,         ///< @htmlcolorblock{87CEFA}
+  LightSlateGray = 0x778899,       ///< @htmlcolorblock{778899}
+  LightSlateGrey = 0x778899,       ///< @htmlcolorblock{778899}
+  LightSteelBlue = 0xB0C4DE,       ///< @htmlcolorblock{B0C4DE}
+  LightYellow = 0xFFFFE0,          ///< @htmlcolorblock{FFFFE0}
+  Lime = 0x00FF00,                 ///< @htmlcolorblock{00FF00}
+  LimeGreen = 0x32CD32,            ///< @htmlcolorblock{32CD32}
+  Linen = 0xFAF0E6,                ///< @htmlcolorblock{FAF0E6}
+  Magenta = 0xFF00FF,              ///< @htmlcolorblock{FF00FF}
+  Maroon = 0x800000,               ///< @htmlcolorblock{800000}
+  MediumAquamarine = 0x66CDAA,     ///< @htmlcolorblock{66CDAA}
+  MediumBlue = 0x0000CD,           ///< @htmlcolorblock{0000CD}
+  MediumOrchid = 0xBA55D3,         ///< @htmlcolorblock{BA55D3}
+  MediumPurple = 0x9370DB,         ///< @htmlcolorblock{9370DB}
+  MediumSeaGreen = 0x3CB371,       ///< @htmlcolorblock{3CB371}
+  MediumSlateBlue = 0x7B68EE,      ///< @htmlcolorblock{7B68EE}
+  MediumSpringGreen = 0x00FA9A,    ///< @htmlcolorblock{00FA9A}
+  MediumTurquoise = 0x48D1CC,      ///< @htmlcolorblock{48D1CC}
+  MediumVioletRed = 0xC71585,      ///< @htmlcolorblock{C71585}
+  MidnightBlue = 0x191970,         ///< @htmlcolorblock{191970}
+  MintCream = 0xF5FFFA,            ///< @htmlcolorblock{F5FFFA}
+  MistyRose = 0xFFE4E1,            ///< @htmlcolorblock{FFE4E1}
+  Moccasin = 0xFFE4B5,             ///< @htmlcolorblock{FFE4B5}
+  NavajoWhite = 0xFFDEAD,          ///< @htmlcolorblock{FFDEAD}
+  Navy = 0x000080,                 ///< @htmlcolorblock{000080}
+  OldLace = 0xFDF5E6,              ///< @htmlcolorblock{FDF5E6}
+  Olive = 0x808000,                ///< @htmlcolorblock{808000}
+  OliveDrab = 0x6B8E23,            ///< @htmlcolorblock{6B8E23}
+  Orange = 0xFFA500,               ///< @htmlcolorblock{FFA500}
+  OrangeRed = 0xFF4500,            ///< @htmlcolorblock{FF4500}
+  Orchid = 0xDA70D6,               ///< @htmlcolorblock{DA70D6}
+  PaleGoldenrod = 0xEEE8AA,        ///< @htmlcolorblock{EEE8AA}
+  PaleGreen = 0x98FB98,            ///< @htmlcolorblock{98FB98}
+  PaleTurquoise = 0xAFEEEE,        ///< @htmlcolorblock{AFEEEE}
+  PaleVioletRed = 0xDB7093,        ///< @htmlcolorblock{DB7093}
+  PapayaWhip = 0xFFEFD5,           ///< @htmlcolorblock{FFEFD5}
+  PeachPuff = 0xFFDAB9,            ///< @htmlcolorblock{FFDAB9}
+  Peru = 0xCD853F,                 ///< @htmlcolorblock{CD853F}
+  Pink = 0xFFC0CB,                 ///< @htmlcolorblock{FFC0CB}
+  Plaid = 0xCC5533,                ///< @htmlcolorblock{CC5533}
+  Plum = 0xDDA0DD,                 ///< @htmlcolorblock{DDA0DD}
+  PowderBlue = 0xB0E0E6,           ///< @htmlcolorblock{B0E0E6}
+  Purple = 0x800080,               ///< @htmlcolorblock{800080}
+  Red = 0xFF0000,                  ///< @htmlcolorblock{FF0000}
+  RosyBrown = 0xBC8F8F,            ///< @htmlcolorblock{BC8F8F}
+  RoyalBlue = 0x4169E1,            ///< @htmlcolorblock{4169E1}
+  SaddleBrown = 0x8B4513,          ///< @htmlcolorblock{8B4513}
+  Salmon = 0xFA8072,               ///< @htmlcolorblock{FA8072}
+  SandyBrown = 0xF4A460,           ///< @htmlcolorblock{F4A460}
+  SeaGreen = 0x2E8B57,             ///< @htmlcolorblock{2E8B57}
+  Seashell = 0xFFF5EE,             ///< @htmlcolorblock{FFF5EE}
+  Sienna = 0xA0522D,               ///< @htmlcolorblock{A0522D}
+  Silver = 0xC0C0C0,               ///< @htmlcolorblock{C0C0C0}
+  SkyBlue = 0x87CEEB,              ///< @htmlcolorblock{87CEEB}
+  SlateBlue = 0x6A5ACD,            ///< @htmlcolorblock{6A5ACD}
+  SlateGray = 0x708090,            ///< @htmlcolorblock{708090}
+  SlateGrey = 0x708090,            ///< @htmlcolorblock{708090}
+  Snow = 0xFFFAFA,                 ///< @htmlcolorblock{FFFAFA}
+  SpringGreen = 0x00FF7F,          ///< @htmlcolorblock{00FF7F}
+  SteelBlue = 0x4682B4,            ///< @htmlcolorblock{4682B4}
+  Tan = 0xD2B48C,                  ///< @htmlcolorblock{D2B48C}
+  Teal = 0x008080,                 ///< @htmlcolorblock{008080}
+  Thistle = 0xD8BFD8,              ///< @htmlcolorblock{D8BFD8}
+  Tomato = 0xFF6347,               ///< @htmlcolorblock{FF6347}
+  Turquoise = 0x40E0D0,            ///< @htmlcolorblock{40E0D0}
+  Violet = 0xEE82EE,               ///< @htmlcolorblock{EE82EE}
+  Wheat = 0xF5DEB3,                ///< @htmlcolorblock{F5DEB3}
+  White = 0xFFFFFF,                ///< @htmlcolorblock{FFFFFF}
+  WhiteSmoke = 0xF5F5F5,           ///< @htmlcolorblock{F5F5F5}
+  Yellow = 0xFFFF00,               ///< @htmlcolorblock{FFFF00}
+  YellowGreen = 0x9ACD32,          ///< @htmlcolorblock{9ACD32}
 
   // LED RGB color that roughly approximates
   // the color of incandescent fairy lights,
   // assuming that you're using FastLED
   // color correction on your LEDs (recommended).
-  FairyLight = 0xFFE42D,  ///< @htmlcolorblock{FFE42D}
+  FairyLight = 0xFFE42D, ///< @htmlcolorblock{FFE42D}
 
   // If you are using no color correction, use this
-  FairyLightNCC = 0xFF9D2A  ///< @htmlcolorblock{FFE42D}
+  FairyLightNCC = 0xFF9D2A ///< @htmlcolorblock{FFE42D}
 
 } HTMLColorCode;
 
@@ -239,93 +246,208 @@ typedef enum {
 //
 
 /// Cloudy color palette/ blue to blue-white
-static constexpr PaletteTy PaletteCloudColors = {Blue,      DarkBlue, DarkBlue,  DarkBlue,
-                                       DarkBlue,  DarkBlue, DarkBlue,  DarkBlue,
-                                       Blue,      DarkBlue, SkyBlue,   SkyBlue,
-                                       LightBlue, White,    LightBlue, SkyBlue};
+static constexpr PaletteTy PaletteCloudColors = {Blue,
+                                                 DarkBlue,
+                                                 DarkBlue,
+                                                 DarkBlue,
+                                                 DarkBlue,
+                                                 DarkBlue,
+                                                 DarkBlue,
+                                                 DarkBlue,
+                                                 Blue,
+                                                 DarkBlue,
+                                                 SkyBlue,
+                                                 SkyBlue,
+                                                 LightBlue,
+                                                 White,
+                                                 LightBlue,
+                                                 SkyBlue};
 
 /// Lava color palette
-static constexpr PaletteTy PaletteLavaColors = {
-    Black,   Maroon, Black,  Maroon, DarkRed, Maroon, DarkRed, DarkRed,
-    DarkRed, Red,    Orange, White,  Orange,  Red,    DarkRed, Black};
+static constexpr PaletteTy PaletteLavaColors = {Black,
+                                                Maroon,
+                                                Black,
+                                                Maroon,
+                                                DarkRed,
+                                                Maroon,
+                                                DarkRed,
+                                                DarkRed,
+                                                DarkRed,
+                                                Red,
+                                                Orange,
+                                                White,
+                                                Orange,
+                                                Red,
+                                                DarkRed,
+                                                Black};
 
 /// Fire color palette
-static constexpr PaletteTy PaletteFlameColors = {
-    Orange, Orange, Orange, Orange, Orange, Orange, Orange, Orange,
-    Orange, Orange, Orange, Orange, Candle, Orange, Orange, Gold};
+static constexpr PaletteTy PaletteFlameColors = {Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Orange,
+                                                 Candle,
+                                                 Orange,
+                                                 Orange,
+                                                 Gold};
 
 /// Ocean colors, blues and whites
-static constexpr PaletteTy PaletteOceanColors = {
-    MidnightBlue, DarkBlue, MidnightBlue, Navy,        DarkBlue, MediumBlue,
-    SeaGreen,     Teal,     CadetBlue,    Blue,        DarkCyan, CornflowerBlue,
-    Aquamarine,   SeaGreen, Aqua,         LightSkyBlue};
+static constexpr PaletteTy PaletteOceanColors = {MidnightBlue,
+                                                 DarkBlue,
+                                                 MidnightBlue,
+                                                 Navy,
+                                                 DarkBlue,
+                                                 MediumBlue,
+                                                 SeaGreen,
+                                                 Teal,
+                                                 CadetBlue,
+                                                 Blue,
+                                                 DarkCyan,
+                                                 CornflowerBlue,
+                                                 Aquamarine,
+                                                 SeaGreen,
+                                                 Aqua,
+                                                 LightSkyBlue};
 
 /// Forest colors, greens
-static constexpr PaletteTy PaletteForestColors = {
-    DarkGreen,  DarkGreen,        DarkOliveGreen,   DarkGreen,
-    Green,      ForestGreen,      OliveDrab,        Green,
-    SeaGreen,   MediumAquamarine, LimeGreen,        YellowGreen,
-    LightGreen, LawnGreen,        MediumAquamarine, ForestGreen};
+static constexpr PaletteTy PaletteForestColors = {DarkGreen,
+                                                  DarkGreen,
+                                                  DarkOliveGreen,
+                                                  DarkGreen,
+                                                  Green,
+                                                  ForestGreen,
+                                                  OliveDrab,
+                                                  Green,
+                                                  SeaGreen,
+                                                  MediumAquamarine,
+                                                  LimeGreen,
+                                                  YellowGreen,
+                                                  LightGreen,
+                                                  LawnGreen,
+                                                  MediumAquamarine,
+                                                  ForestGreen};
 
 /// HSV Rainbow
-static constexpr PaletteTy PaletteRainbowColors = {
-    0xFF0000, 0xD52A00, 0xAB5500, 0xAB7F00,
-    0xABAB00, 0x56D500, 0x00FF00, 0x00D52A,
-    0x00AB55, 0x0056AA, 0x0000FF, 0x2A00D5,
-    0x5500AB, 0x7F0081, 0xAB0055, 0xD5002B};
+static constexpr PaletteTy PaletteRainbowColors = {0xFF0000,
+                                                   0xD52A00,
+                                                   0xAB5500,
+                                                   0xAB7F00,
+                                                   0xABAB00,
+                                                   0x56D500,
+                                                   0x00FF00,
+                                                   0x00D52A,
+                                                   0x00AB55,
+                                                   0x0056AA,
+                                                   0x0000FF,
+                                                   0x2A00D5,
+                                                   0x5500AB,
+                                                   0x7F0081,
+                                                   0xAB0055,
+                                                   0xD5002B};
 
 // basically, HSV with no green. looks better when lighing people
-static constexpr PaletteTy PalettePartyColors = {
-    0x5500AB, 0x84007C, 0xB5004B, 0xE5001B,
-    0xE81700, 0xB84700, 0xAB7700, 0xABAB00,
-    0xAB5500, 0xDD2200, 0xF2000E, 0xC2003E,
-    0x8F0071, 0x5F00A1, 0x2F00D0, 0x0007F9};
+static constexpr PaletteTy PalettePartyColors = {0x5500AB,
+                                                 0x84007C,
+                                                 0xB5004B,
+                                                 0xE5001B,
+                                                 0xE81700,
+                                                 0xB84700,
+                                                 0xAB7700,
+                                                 0xABAB00,
+                                                 0xAB5500,
+                                                 0xDD2200,
+                                                 0xF2000E,
+                                                 0xC2003E,
+                                                 0x8F0071,
+                                                 0x5F00A1,
+                                                 0x2F00D0,
+                                                 0x0007F9};
 
 // Black body radiation
-static constexpr PaletteTy PaletteBlackBodyColors = {
-    0xff3800, 0xff5300, 0xff6500, 0xff7300, 0xff7e00, 0xff8912,
-    0xff932c, 0xff9d3f, 0xffa54f, 0xffad5e, 0xffb46b, 0xffbb78,
-    0xffc184, 0xffc78f, 0xffcc99, 0xffd1a3};
+static constexpr PaletteTy PaletteBlackBodyColors = {0xff3800,
+                                                     0xff5300,
+                                                     0xff6500,
+                                                     0xff7300,
+                                                     0xff7e00,
+                                                     0xff8912,
+                                                     0xff932c,
+                                                     0xff9d3f,
+                                                     0xffa54f,
+                                                     0xffad5e,
+                                                     0xffb46b,
+                                                     0xffbb78,
+                                                     0xffc184,
+                                                     0xffc78f,
+                                                     0xffcc99,
+                                                     0xffd1a3};
 
-static constexpr PaletteTy PaletteHeatColors = {
-    0x000000, 0x330000, 0x660000, 0x990000,
-    0xCC0000, 0xFF0000, 0xFF3300, 0xFF6600,
-    0xFF9900, 0xFFCC00, 0xFFFF00, 0xFFFF33,
-    0xFFFF66, 0xFFFF99, 0xFFFFCC};
+static constexpr PaletteTy PaletteHeatColors = {0x000000,
+                                                0x330000,
+                                                0x660000,
+                                                0x990000,
+                                                0xCC0000,
+                                                0xFF0000,
+                                                0xFF3300,
+                                                0xFF6600,
+                                                0xFF9900,
+                                                0xFFCC00,
+                                                0xFFFF00,
+                                                0xFFFF33,
+                                                0xFFFF66,
+                                                0xFFFF99,
+                                                0xFFFFCC};
 
-static constexpr PaletteTy PaletteAuroraColors = {
-    0x000000, 0x003300, 0x006600, 0x009900,
-    0x00cc00, 0x00ff00, 0x33ff00, 0x66ff00,
-    0x99ff00, 0xccff00, 0xffff00, 0xffcc00,
-    0xff9900, 0xff6600, 0xff3300, 0xff0000};
+static constexpr PaletteTy PaletteAuroraColors = {0x000000,
+                                                  0x003300,
+                                                  0x006600,
+                                                  0x009900,
+                                                  0x00cc00,
+                                                  0x00ff00,
+                                                  0x33ff00,
+                                                  0x66ff00,
+                                                  0x99ff00,
+                                                  0xccff00,
+                                                  0xffff00,
+                                                  0xffcc00,
+                                                  0xff9900,
+                                                  0xff6600,
+                                                  0xff3300,
+                                                  0xff0000};
 
-/**
- * \brief Return a color from a palette
+/** \brief Return a color from a palette
  * \param[in] index from 0 to 255, the index of color we want from the palette
  * \param[in] palette The palette to sample from. Values are interpolated
  * \param[in] brightness The brighness of the color, default is max at 255
  * \return The desired color
  */
-template <typename UIntTy = uint8_t>
-static constexpr uint32_t from_palette(UIntTy index,
-                                       const PaletteTy& palette,
-                                       uint8_t brightness = 255) {
-
+template<bool PaletteLoops = true, typename UIntTy = uint8_t>
+static constexpr uint32_t from_palette(UIntTy index, const PaletteTy& palette, uint8_t brightness = 255)
+{
   // convert to [0; 15] (divide by 16)
   uint8_t renormIndex = index >> 4;
   // get least significant part for the blend factor
   uint8_t blendIndex = index & 0x0F;
 
   // support for uint16_t
-  if constexpr (sizeof(UIntTy) > 1) {
+  if constexpr (sizeof(UIntTy) > 1)
+  {
     const float findex = index;
-    const float percent = (findex / ((float) UINT16_MAX)) * 16.f;
+    const float percent = (findex / ((float)UINT16_MAX)) * 16.f;
     renormIndex = percent;
     blendIndex = 256.f * (percent - renormIndex);
     static_assert(std::is_same_v<UIntTy, uint16_t>, "u8 or u16");
   }
 
-  if (renormIndex >= 16) return 0;
+  if (renormIndex >= 16)
+    return 0;
   const uint32_t entry = palette[renormIndex];
 
   // convert to rgb
@@ -334,11 +456,15 @@ static constexpr uint32_t from_palette(UIntTy index,
   uint8_t blue1 = entry & 0x0000ff;
 
   // need to blend the palette
-  if (blendIndex != 0) {
+  if (blendIndex != 0)
+  {
     uint32_t nextColor = 0;
-    if (renormIndex == 15) {
-      nextColor = palette[0];
-    } else {
+    if (renormIndex == 15)
+    {
+      nextColor = PaletteLoops ? palette[0] : palette[15];
+    }
+    else
+    {
       nextColor = palette[1 + renormIndex];
     }
 
@@ -359,26 +485,32 @@ static constexpr uint32_t from_palette(UIntTy index,
     blue1 += blue2 * f2;
   }
 
-  if (brightness != 255) {
-    if (brightness != 0) {
-      const float adjustedBrightness =
-          (brightness + 1) / 256.0;  // adjust for rounding
+  if (brightness != 255)
+  {
+    if (brightness != 0)
+    {
+      const float adjustedBrightness = (brightness + 1) / 256.0; // adjust for rounding
       // Now, since brightness is nonzero, we don't need the full scale8_video
       // logic; we can just to scale8 and then add one (unless scale8 fixed) to
       // all nonzero inputs.
-      if (red1) {
+      if (red1)
+      {
         red1 = red1 * adjustedBrightness;
         ++red1;
       }
-      if (green1) {
+      if (green1)
+      {
         green1 = green1 * adjustedBrightness;
         ++green1;
       }
-      if (blue1) {
+      if (blue1)
+      {
         blue1 = blue1 * adjustedBrightness;
         ++blue1;
       }
-    } else {
+    }
+    else
+    {
       red1 = 0;
       green1 = 0;
       blue1 = 0;

--- a/src/modes/include/colors/utils.hpp
+++ b/src/modes/include/colors/utils.hpp
@@ -1,0 +1,67 @@
+#ifndef MODES_COLORS_UTILS_HPP
+#define MODES_COLORS_UTILS_HPP
+
+/** \file
+ *
+ *  \brief Manipulate color representations
+ */
+
+#include "src/modes/include/compile.hpp"
+#include "src/modes/include/colors/palettes.hpp"
+
+//
+// Color utilities likely already defined elsewhere
+//  (but this time in pure constexpr-able INLINE c++)
+//
+
+/// Tools to manipulate colors and their representation
+namespace modes::colors {
+
+/// Return color (r, g, b) as a single uint32_t integer
+static constexpr LMBD_INLINE uint32_t fromRGB(uint8_t r, uint8_t g, uint8_t b)
+{
+  uint32_t rx = r;
+  uint32_t gx = g;
+  return (rx << 16) | (gx << 8) | b;
+}
+
+static constexpr uint8_t colorRotation[360] = {
+        0,   0,   0,   0,   0,   1,   1,   2,   2,   3,   4,   5,   6,   7,   8,   9,   11,  12,  13,  15,  17,  18,
+        20,  22,  24,  26,  28,  30,  32,  35,  37,  39,  42,  44,  47,  49,  52,  55,  58,  60,  63,  66,  69,  72,
+        75,  78,  81,  85,  88,  91,  94,  97,  101, 104, 107, 111, 114, 117, 121, 124, 127, 131, 134, 137, 141, 144,
+        147, 150, 154, 157, 160, 163, 167, 170, 173, 176, 179, 182, 185, 188, 191, 194, 197, 200, 202, 205, 208, 210,
+        213, 215, 217, 220, 222, 224, 226, 229, 231, 232, 234, 236, 238, 239, 241, 242, 244, 245, 246, 248, 249, 250,
+        251, 251, 252, 253, 253, 254, 254, 255, 255, 255, 255, 255, 255, 255, 254, 254, 253, 253, 252, 251, 251, 250,
+        249, 248, 246, 245, 244, 242, 241, 239, 238, 236, 234, 232, 231, 229, 226, 224, 222, 220, 217, 215, 213, 210,
+        208, 205, 202, 200, 197, 194, 191, 188, 185, 182, 179, 176, 173, 170, 167, 163, 160, 157, 154, 150, 147, 144,
+        141, 137, 134, 131, 127, 124, 121, 117, 114, 111, 107, 104, 101, 97,  94,  91,  88,  85,  81,  78,  75,  72,
+        69,  66,  63,  60,  58,  55,  52,  49,  47,  44,  42,  39,  37,  35,  32,  30,  28,  26,  24,  22,  20,  18,
+        17,  15,  13,  12,  11,  9,   8,   7,   6,   5,   4,   3,   2,   2,   1,   1,   0,   0,   0,   0,   0,   0,
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+        0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+        0,   0,   0,   0,   0,   0,   0,   0};
+
+/// Given a 360 degrees angle, return a corresponding color as an integer
+static constexpr LMBD_INLINE uint32_t fromAngleHue(uint16_t angleDegrees)
+{
+  uint8_t r = colorRotation[(angleDegrees + 120) % 360];
+  uint8_t g = colorRotation[angleDegrees % 360];
+  uint8_t b = colorRotation[(angleDegrees + 240) % 360];
+  return fromRGB(r, g, b);
+}
+
+/** \brief Given a 0-255 value, return a color approximating a kelvin temperature
+ *
+ * See modes::colors::PaletteBlackBodyColors
+ */
+static constexpr LMBD_INLINE uint32_t fromTemp(uint8_t temp)
+{
+  return from_palette<false>(temp, PaletteBlackBodyColors);
+}
+
+} // namespace modes::colors
+
+#endif

--- a/src/modes/include/compile.hpp
+++ b/src/modes/include/compile.hpp
@@ -1,0 +1,15 @@
+#ifndef MODES_INCLUDE_COMPILE_HPP
+#define MODES_INCLUDE_COMPILE_HPP
+
+/** \file
+ *
+ * \brief Contains shorthand macro definitions
+ */
+
+// always_inline macro
+#define LMBD_INLINE __attribute__((always_inline))
+
+// maybe_unused macro
+#define LMBD_USED [[maybe_unused]]
+
+#endif

--- a/src/modes/include/context_type.hpp
+++ b/src/modes/include/context_type.hpp
@@ -1,13 +1,15 @@
 #ifndef CONTEXT_TYPE_H
 #define CONTEXT_TYPE_H
 
-#include <cstdint>
-#include <type_traits>
-
-/** \file context_type.h
+/** \file
+ *
  *  \brief ContextTy and associated definitions
  **/
 
+#include <cstdint>
+#include <type_traits>
+
+#include "src/modes/include/hardware/lamp_type.hpp"
 #include "src/modes/include/tools.hpp"
 #include "src/modes/include/default_config.hpp"
 
@@ -17,14 +19,11 @@ namespace modes {
 ///
 /// \param[in] ctx Local context to bind to \p NewLocalMode
 /// \return A new context instance bound to the provided modes::BasicMode
-template <typename NewLocalMode>
-static auto context_as(auto& ctx) {
-  return ctx.template context_as<NewLocalMode>();
-}
+template<typename NewLocalMode> static auto context_as(auto& ctx) { return ctx.template context_as<NewLocalMode>(); }
 
 /// Local context exposing system features to active BasicMode
-template <typename LocalBasicMode, typename ModeManager>
-struct ContextTy {
+template<typename LocalBasicMode, typename ModeManager> struct ContextTy
+{
   friend ModeManager;
 
   using SelfTy = ContextTy<LocalBasicMode, ModeManager>;
@@ -37,19 +36,21 @@ struct ContextTy {
   //
 
   /// Get the same context, but for another mode, see modes::context_as()
-  template <typename NewLocalMode>
-  auto LMBD_INLINE context_as() {
+  template<typename NewLocalMode> auto LMBD_INLINE context_as()
+  {
     return ContextTy<NewLocalMode, ModeManagerTy>(modeManager);
   }
 
   /// \private Use ModeManagerTy::get_context() to construct context
-  ContextTy(ModeManagerTy& modeManager)
-      : strip{modeManager.strip},
-        state{modeManager.template getStateOf<LocalModeTy>()},
-        modeManager{modeManager} { }
+  ContextTy(ModeManagerTy& modeManager) :
+    state {modeManager.template getStateOf<LocalModeTy>()},
+    lamp {modeManager.lamp},
+    modeManager {modeManager}
+  {
+  }
 
-  ContextTy() = delete; ///< \private
-  ContextTy(const ContextTy&) = delete; ///< \private
+  ContextTy() = delete;                            ///< \private
+  ContextTy(const ContextTy&) = delete;            ///< \private
   ContextTy& operator=(const ContextTy&) = delete; ///< \private
 
   //
@@ -57,66 +58,87 @@ struct ContextTy {
   //
 
   /// \private Jump to next group
-  auto LMBD_INLINE next_group() {
-    if constexpr (LocalModeTy::isGroupManager) {
+  auto LMBD_INLINE next_group()
+  {
+    if constexpr (LocalModeTy::isGroupManager)
+    {
       LocalModeTy::next_group(*this);
-    } else {
+    }
+    else
+    {
       auto& manager = modeManager.get_context();
       return manager.next_group();
     }
   }
 
   /// \private Jump to next mode
-  auto LMBD_INLINE next_mode() {
-    if constexpr (LocalModeTy::isModeManager) {
+  auto LMBD_INLINE next_mode()
+  {
+    if constexpr (LocalModeTy::isModeManager)
+    {
       LocalModeTy::next_mode(*this);
-    } else {
+    }
+    else
+    {
       auto& manager = modeManager.get_context();
       return manager.next_mode();
     }
   }
 
   /// \private Jump to favorite mode
-  auto LMBD_INLINE jump_to_favorite() {
-    if constexpr (LocalModeTy::isModeManager) {
+  auto LMBD_INLINE jump_to_favorite()
+  {
+    if constexpr (LocalModeTy::isModeManager)
+    {
       LocalModeTy::jump_to_favorite(*this);
-    } else {
+    }
+    else
+    {
       auto& manager = modeManager.get_context();
       return manager.jump_to_favorite();
     }
   }
 
   /// \private Set active favorite now
-  auto LMBD_INLINE set_favorite_now() {
-    if constexpr (LocalModeTy::isModeManager) {
+  auto LMBD_INLINE set_favorite_now()
+  {
+    if constexpr (LocalModeTy::isModeManager)
+    {
       LocalModeTy::set_favorite_now(*this);
-    } else {
+    }
+    else
+    {
       auto& manager = modeManager.get_context();
       return manager.set_favorite_now();
     }
   }
 
-
   /// \private Get number of groups available
-  auto LMBD_INLINE get_groups_count() {
-    return modeManager.nbGroups;
-  }
+  auto LMBD_INLINE get_groups_count() { return modeManager.nbGroups; }
 
   /// \private Get number of modes available
-  auto LMBD_INLINE get_modes_count() {
-    if constexpr (LocalModeTy::isModeManager) {
+  auto LMBD_INLINE get_modes_count()
+  {
+    if constexpr (LocalModeTy::isModeManager)
+    {
       return modeManager.get_modes_count(*this);
-    } else {
+    }
+    else
+    {
       auto& manager = modeManager.get_context();
       return manager.get_modes_count();
     }
   }
 
   /// \private Reset active mode
-  auto LMBD_INLINE reset_mode() {
-    if constexpr (LocalModeTy::isModeManager) {
+  auto LMBD_INLINE reset_mode()
+  {
+    if constexpr (LocalModeTy::isModeManager)
+    {
       LocalModeTy::reset_mode(*this);
-    } else {
+    }
+    else
+    {
       auto& manager = modeManager.get_context();
       return manager.reset_mode();
     }
@@ -127,27 +149,33 @@ struct ContextTy {
   //
 
   /// (getter) Get active group index
-  uint8_t LMBD_INLINE get_active_group(uint8_t maxValueWrap = 255) const {
+  uint8_t LMBD_INLINE get_active_group(uint8_t maxValueWrap = 255) const
+  {
     uint8_t groupIndex = modeManager.activeIndex.groupIndex;
     return (groupIndex + 1) > maxValueWrap ? 0 : groupIndex;
   }
 
   /// (setter) Set active group index
-  uint8_t LMBD_INLINE set_active_group(uint8_t value, uint8_t maxValueWrap = 255) {
-    if (value + 1 > maxValueWrap) value = 0;
+  uint8_t LMBD_INLINE set_active_group(uint8_t value, uint8_t maxValueWrap = 255)
+  {
+    if (value + 1 > maxValueWrap)
+      value = 0;
     modeManager.activeIndex.groupIndex = value;
     return value;
   }
 
   /// (getter) Get active mode index (as numbered in local group)
-  uint8_t LMBD_INLINE get_active_mode(uint8_t maxValueWrap = 255) const {
+  uint8_t LMBD_INLINE get_active_mode(uint8_t maxValueWrap = 255) const
+  {
     uint8_t modeIndex = modeManager.activeIndex.modeIndex;
     return (modeIndex + 1) > maxValueWrap ? 0 : modeIndex;
   }
 
   /// (setter) Set active mode index (as numbered in local group)
-  uint8_t LMBD_INLINE set_active_mode(uint8_t value, uint8_t maxValueWrap = 255) {
-    if (value + 1 > maxValueWrap) value = 0;
+  uint8_t LMBD_INLINE set_active_mode(uint8_t value, uint8_t maxValueWrap = 255)
+  {
+    if (value + 1 > maxValueWrap)
+      value = 0;
     modeManager.activeIndex.modeIndex = value;
     return value;
   }
@@ -156,15 +184,14 @@ struct ContextTy {
    *
    * \see BasicMode::custom_ramp_update()
    */
-  uint8_t LMBD_INLINE get_active_custom_ramp() const {
-    return modeManager.activeIndex.rampIndex;
-  }
+  uint8_t LMBD_INLINE get_active_custom_ramp() const { return modeManager.activeIndex.rampIndex; }
 
   /** \brief (setter) Set active custom ramp value (overrides user choice)
    *
    * \see BasicMode::custom_ramp_update()
    */
-  uint8_t LMBD_INLINE set_active_custom_ramp(uint8_t value) {
+  uint8_t LMBD_INLINE set_active_custom_ramp(uint8_t value)
+  {
     modeManager.activeIndex.rampIndex = value;
     return value;
   }
@@ -173,10 +200,11 @@ struct ContextTy {
    *
    * See modes::ConfigKeys for documentation of configurable booleans.
    */
-  template <ConfigKeys key>
-  void LMBD_INLINE set_config_bool(bool value) {
+  template<ConfigKeys key> void LMBD_INLINE set_config_bool(bool value)
+  {
     auto ctx = modeManager.get_context();
-    switch (key) {
+    switch (key)
+    {
       case ConfigKeys::rampSaturates:
         ctx.state.rampHandler.rampSaturates = value;
         break;
@@ -193,10 +221,11 @@ struct ContextTy {
    *
    * See modes::ConfigKeys for documentation of configurable (u32) integers.
    */
-  template <ConfigKeys key>
-  void LMBD_INLINE set_config_u32(uint32_t value) {
+  template<ConfigKeys key> void LMBD_INLINE set_config_u32(uint32_t value)
+  {
     auto ctx = modeManager.get_context();
-    switch (key) {
+    switch (key)
+    {
       case ConfigKeys::customRampStepSpeedMs:
         ctx.state.rampHandler.stepSpeed = value;
         break;
@@ -207,12 +236,11 @@ struct ContextTy {
   }
 
   /// (getter) Get active custom index (recalled when jumping favorites)
-  uint8_t LMBD_INLINE get_active_custom_index() const {
-    return modeManager.activeIndex.customIndex;
-  }
+  uint8_t LMBD_INLINE get_active_custom_index() const { return modeManager.activeIndex.customIndex; }
 
   /// (setter) Set active custom index (recalled when jumping favorites)
-  uint8_t LMBD_INLINE set_active_custom_index(uint8_t value) {
+  uint8_t LMBD_INLINE set_active_custom_index(uint8_t value)
+  {
     modeManager.activeIndex.customIndex = value;
     return value;
   }
@@ -222,65 +250,41 @@ struct ContextTy {
   //
 
   /// (getter) Return current brightness value
-  uint8_t LMBD_INLINE get_brightness() {
-    return BRIGHTNESS;
-  }
-
-  //
-  // strip interaction (indexable only)
-  //
-
-#ifdef LMBD_LAMP_TYPE__INDEXABLE
-  //
-  // TODO: better interface with hardware / indexable strip
-
-  void LMBD_INLINE fill(uint32_t color) {
-    for (uint16_t I = 0; I < LED_COUNT; ++I)
-      strip.setPixelColor(I, color);
-  }
-
-  void LMBD_INLINE fill(uint32_t color, uint16_t start, uint16_t end) {
-    for (uint16_t I = start; I < end; ++I)
-      strip.setPixelColor(I, color);
-  }
-
-#endif
+  uint8_t LMBD_INLINE get_brightness() { return BRIGHTNESS; }
 
   //
   // quick bindings to \p LocalModeTy
   //
 
   /// Binds to local BasicMode::loop()
-  void LMBD_INLINE loop() {
-    if constexpr (LocalModeTy::simpleMode) {
-      LocalModeTy::loop(this->strip);
-    } else {
-      LocalModeTy::loop(*this);
-    }
-  }
+  void LMBD_INLINE loop() { LocalModeTy::loop(*this); }
 
   /// Binds to local BasicMode::reset()
-  void LMBD_INLINE reset() {
-    LocalModeTy::reset(*this);
-  }
+  void LMBD_INLINE reset() { LocalModeTy::reset(*this); }
 
   /// Binds to local BasicMode::brightness_update()
-  void LMBD_INLINE brightness_update(LMBD_USED uint8_t brightness) {
-    if constexpr (LocalModeTy::hasBrightCallback) {
+  void LMBD_INLINE brightness_update(LMBD_USED uint8_t brightness)
+  {
+    if constexpr (LocalModeTy::hasBrightCallback)
+    {
       LocalModeTy::brightness_update(*this, brightness);
     }
   }
 
   /// Binds to local BasicMode::custom_ramp_update()
-  void LMBD_INLINE custom_ramp_update(LMBD_USED uint8_t rampValue) {
-    if constexpr (LocalModeTy::hasCustomRamp) {
+  void LMBD_INLINE custom_ramp_update(LMBD_USED uint8_t rampValue)
+  {
+    if constexpr (LocalModeTy::hasCustomRamp)
+    {
       LocalModeTy::custom_ramp_update(*this, rampValue);
     }
   }
 
   /// Binds to local BasicMode::custom_click()
-  bool LMBD_INLINE custom_click(LMBD_USED uint8_t nbClick) {
-    if constexpr (LocalModeTy::hasButtonCustomUI) {
+  bool LMBD_INLINE custom_click(LMBD_USED uint8_t nbClick)
+  {
+    if constexpr (LocalModeTy::hasButtonCustomUI)
+    {
       return LocalModeTy::custom_click(*this, nbClick);
     }
 
@@ -290,53 +294,60 @@ struct ContextTy {
   /// Binds to local BasicMode::custom_hold()
   bool LMBD_INLINE custom_hold(LMBD_USED uint8_t nbClickAndHold,
                                LMBD_USED bool isEndOfHoldEvent,
-                               LMBD_USED uint32_t holdDuration) {
-    if constexpr (LocalModeTy::hasButtonCustomUI) {
-      return LocalModeTy::custom_hold(*this,
-                                      nbClickAndHold,
-                                      isEndOfHoldEvent,
-                                      holdDuration);
+                               LMBD_USED uint32_t holdDuration)
+  {
+    if constexpr (LocalModeTy::hasButtonCustomUI)
+    {
+      return LocalModeTy::custom_hold(*this, nbClickAndHold, isEndOfHoldEvent, holdDuration);
     }
 
     return false;
   }
 
   /// Binds to local BasicMode::power_on_sequence()
-  void LMBD_INLINE power_on_sequence() {
-    if constexpr (LocalModeTy::hasSystemCallbacks) {
+  void LMBD_INLINE power_on_sequence()
+  {
+    if constexpr (LocalModeTy::hasSystemCallbacks)
+    {
       LocalModeTy::power_on_sequence(*this);
     }
   }
 
   /// Binds to local BasicMode::power_off_sequence()
-  void LMBD_INLINE power_off_sequence() {
-    if constexpr (LocalModeTy::hasSystemCallbacks) {
+  void LMBD_INLINE power_off_sequence()
+  {
+    if constexpr (LocalModeTy::hasSystemCallbacks)
+    {
       LocalModeTy::power_off_sequence(*this);
     }
   }
 
   /// Binds to local BasicMode::write_parameters()
-  void LMBD_INLINE write_parameters() {
-    if constexpr (LocalModeTy::hasSystemCallbacks) {
+  void LMBD_INLINE write_parameters()
+  {
+    if constexpr (LocalModeTy::hasSystemCallbacks)
+    {
       LocalModeTy::write_parameters(*this);
     }
   }
 
   /// Binds to local BasicMode::read_parameters()
-  void LMBD_INLINE read_parameters() {
-    if constexpr (LocalModeTy::hasSystemCallbacks) {
+  void LMBD_INLINE read_parameters()
+  {
+    if constexpr (LocalModeTy::hasSystemCallbacks)
+    {
       LocalModeTy::read_parameters(*this);
     }
   }
 
   /// Returns BasicMode::requireUserThread
-  bool LMBD_INLINE should_spawn_thread() {
-    return LocalModeTy::requireUserThread;
-  }
+  bool LMBD_INLINE should_spawn_thread() { return LocalModeTy::requireUserThread; }
 
   /// Binds to local BasicMode::user_thread()
-  void LMBD_INLINE user_thread() {
-    if constexpr (LocalModeTy::requireUserThread) {
+  void LMBD_INLINE user_thread()
+  {
+    if constexpr (LocalModeTy::requireUserThread)
+    {
       LocalModeTy::user_thread(*this);
     }
   }
@@ -345,8 +356,9 @@ struct ContextTy {
   // context members for direct access
   //
 
-  LedStrip& strip;
+  hardware::LampTy& lamp;
   StateTy& state;
+
 private:
   ModeManagerTy& modeManager;
 };

--- a/src/modes/include/default_config.hpp
+++ b/src/modes/include/default_config.hpp
@@ -38,11 +38,11 @@ namespace modes {
  *
  * See also modes::ConfigKeys for runtime configuration.
  */
-struct DefaultManagerConfig {
-
-//
-// useful config
-//
+struct DefaultManagerConfig
+{
+  //
+  // useful config
+  //
 
   /// By default, will custom ramp saturates, or else wrap around?
   static constexpr bool defaultRampSaturates = false;
@@ -53,9 +53,9 @@ struct DefaultManagerConfig {
   /// By default, how slow custom ramp changes value (milliseconds)
   static constexpr uint32_t defaultCustomRampStepSpeedMs = 16;
 
-//
-// misc config
-//
+  //
+  // misc config
+  //
 
   /// (misc) Override how slow mode & group scroll goes (milliseconds)
   static constexpr uint32_t scrollRampStepSpeedMs = 512;
@@ -97,10 +97,11 @@ struct DefaultManagerConfig {
  * All these values are reset to their default counterpart before each mode
  * change, see modes::DefaultManagerConfig on how to override these defaults.
  */
-enum class ConfigKeys : uint8_t {
-  rampSaturates, ///< (bool) Mode saturates on custom ramp, or else wrap?
+enum class ConfigKeys : uint8_t
+{
+  rampSaturates,          ///< (bool) Mode saturates on custom ramp, or else wrap?
   clearStripOnModeChange, ///< (bool) Mode clear strip after reset, or else do nothing?
-  customRampStepSpeedMs, ///< (u32) Mode time step for incrementing custom ramp (ms)
+  customRampStepSpeedMs,  ///< (u32) Mode time step for incrementing custom ramp (ms)
 };
 
 } // namespace modes

--- a/src/modes/include/group_type.hpp
+++ b/src/modes/include/group_type.hpp
@@ -1,16 +1,17 @@
 #ifndef MODE_GROUP_H
 #define MODE_GROUP_H
 
+/** \file
+ *
+ *  \brief modes::GroupFor and associated definitions
+ **/
+
 #include <cstdint>
 #include <cassert>
 #include <utility>
 #include <optional>
 #include <tuple>
 #include <array>
-
-/** \file group_type.h
- *  \brief modes::GroupFor and associated definitions
- **/
 
 #include "src/modes/include/context_type.hpp"
 #include "src/modes/include/manager_type.hpp"
@@ -20,39 +21,35 @@
 namespace modes {
 
 /// \private Return true if a mode failed verification to prevent extra errors
-template <typename AllModes>
-static constexpr bool verifyGroup() {
-    constexpr bool inheritsFromBasicMode = details::allOf<AllModes>::inheritsFromBasicMode;
-    static_assert(inheritsFromBasicMode, "All modes must inherit from modes::BasicMode!");
+template<typename AllModes> static constexpr bool verifyGroup()
+{
+  constexpr bool inheritsFromBasicMode = details::allOf<AllModes>::inheritsFromBasicMode;
+  static_assert(inheritsFromBasicMode, "All modes must inherit from modes::BasicMode!");
 
-    constexpr bool stateDefaultConstructible = details::allOf<AllModes>::stateDefaultConstructible;
-    static_assert(stateDefaultConstructible, "All states must be default constructible!");
+  constexpr bool stateDefaultConstructible = details::allOf<AllModes>::stateDefaultConstructible;
+  static_assert(stateDefaultConstructible, "All states must be default constructible!");
 
-    bool acc = false;
-    acc |= !inheritsFromBasicMode;
-    acc |= !stateDefaultConstructible;
-    return acc ;
+  bool acc = false;
+  acc |= !inheritsFromBasicMode;
+  acc |= !stateDefaultConstructible;
+  return acc;
 }
 
 /// \private Implementation details of modes::GroupFor
-template <typename AllModes, bool earlyFail = verifyGroup<AllModes>()>
-struct GroupTy {
-
+template<typename AllModes, bool earlyFail = verifyGroup<AllModes>()> struct GroupTy
+{
   // tuple helper
   using SelfTy = GroupTy<AllModes>;
   using AllModesTy = AllModes;
   using AllStatesTy = details::StateTyFrom<AllModes>;
-  static constexpr uint8_t nbModes{std::tuple_size_v<AllModesTy>};
+  static constexpr uint8_t nbModes {std::tuple_size_v<AllModesTy>};
 
-  template <uint8_t Idx>
-  using ModeAtRaw = std::tuple_element_t<Idx, AllModesTy>;
+  template<uint8_t Idx> using ModeAtRaw = std::tuple_element_t<Idx, AllModesTy>;
 
-  template <uint8_t Idx>
-  using ModeAt = std::conditional_t<!earlyFail, ModeAtRaw<Idx>, BasicMode>;
+  template<uint8_t Idx> using ModeAt = std::conditional_t<!earlyFail, ModeAtRaw<Idx>, BasicMode>;
 
   // required to support group-level context
   using HasAnyMode = details::anyOf<AllModesTy, earlyFail>;
-  static constexpr bool simpleMode = false;
   static constexpr bool hasBrightCallback = HasAnyMode::hasBrightCallback;
   static constexpr bool hasSystemCallbacks = HasAnyMode::hasSystemCallbacks;
   static constexpr bool requireUserThread = HasAnyMode::requireUserThread;
@@ -65,27 +62,32 @@ struct GroupTy {
   GroupTy& operator=(const GroupTy&) = delete;
 
   /// \private Dispatch active mode to callback
-  template<typename CallBack>
-  static void LMBD_INLINE dispatch_mode(auto& ctx, CallBack&& cb) {
+  template<typename CallBack> static void LMBD_INLINE dispatch_mode(auto& ctx, CallBack&& cb)
+  {
     uint8_t modeId = ctx.get_active_mode(nbModes);
 
     details::unroll<nbModes>([&](auto Idx) LMBD_INLINE {
-      if (Idx == modeId) {
+      if (Idx == modeId)
+      {
         cb(context_as<ModeAt<Idx>>(ctx));
       }
     });
   }
 
   /// \private Forward each mode to callback (if eligible)
-  template<bool systemCallbacksOnly, typename CallBack>
-  static void LMBD_INLINE foreach_mode(auto& ctx, CallBack&& cb) {
-    if constexpr (systemCallbacksOnly) {
+  template<bool systemCallbacksOnly, typename CallBack> static void LMBD_INLINE foreach_mode(auto& ctx, CallBack&& cb)
+  {
+    if constexpr (systemCallbacksOnly)
+    {
       details::unroll<nbModes>([&](auto Idx) LMBD_INLINE {
-        if /* TODO: constexpr */ (ModeAt<Idx>::hasSystemCallbacks) {
+        if /* TODO: constexpr */ (ModeAt<Idx>::hasSystemCallbacks)
+        {
           cb(context_as<ModeAt<Idx>>(ctx));
         }
       });
-    } else {
+    }
+    else
+    {
       details::unroll<nbModes>([&](auto Idx) LMBD_INLINE {
         cb(context_as<ModeAt<Idx>>(ctx));
       });
@@ -96,14 +98,15 @@ struct GroupTy {
   // state
   //
 
-  struct StateTy {
+  struct StateTy
+  {
     AllStatesTy modeStates;
     std::array<uint8_t, nbModes> customRampMemory;
     std::array<uint8_t, nbModes> customIndexMemory;
   };
 
-  template <typename Mode>
-  static auto* LMBD_INLINE getStateOf(auto& manager) {
+  template<typename Mode> static auto* LMBD_INLINE getStateOf(auto& manager)
+  {
     using StateTy = typename Mode::StateTy;
     using OptionalTy = std::optional<StateTy>;
 
@@ -112,11 +115,14 @@ struct GroupTy {
       using ModeHere = ModeAt<Idx>;
       constexpr bool isHere = std::is_same_v<ModeHere, Mode>;
 
-      if constexpr (isHere) {
+      if constexpr (isHere)
+      {
         auto* state = manager.template getStateGroupOf<SelfTy>();
-        if (state) {
+        if (state)
+        {
           OptionalTy& opt = std::get<OptionalTy>(state->modeStates);
-          if (!opt.has_value()) {
+          if (!opt.has_value())
+          {
             opt.emplace(); // all StateTy must be default-contructible :)
           }
 
@@ -137,7 +143,8 @@ struct GroupTy {
   static constexpr bool isGroupManager = false;
   static constexpr bool isModeManager = true;
 
-  static void next_mode(auto& ctx) {
+  static void next_mode(auto& ctx)
+  {
     uint8_t modeIdBefore = ctx.get_active_mode(nbModes);
 
     ctx.state.customRampMemory[modeIdBefore] = ctx.get_active_custom_ramp();
@@ -151,31 +158,40 @@ struct GroupTy {
     ctx.reset_mode();
   }
 
-  static void reset_mode(auto& ctx) {
-    dispatch_mode(ctx, [](auto mode) { mode.reset(); });
+  static void reset_mode(auto& ctx)
+  {
+    dispatch_mode(ctx, [](auto mode) {
+      mode.reset();
+    });
   }
 
   //
   // all the callbacks
   //
 
-  static void loop(auto& ctx) {
-    dispatch_mode(ctx, [](auto mode) { mode.loop(); });
+  static void loop(auto& ctx)
+  {
+    dispatch_mode(ctx, [](auto mode) {
+      mode.loop();
+    });
   }
 
-  static void brightness_update(auto& ctx, uint8_t brightness) {
+  static void brightness_update(auto& ctx, uint8_t brightness)
+  {
     dispatch_mode(ctx, [&](auto mode) {
       mode.brightness_update(brightness);
     });
   }
 
-  static void custom_ramp_update(auto& ctx, uint8_t rampValue) {
+  static void custom_ramp_update(auto& ctx, uint8_t rampValue)
+  {
     dispatch_mode(ctx, [&](auto mode) {
       mode.custom_ramp_update(rampValue);
     });
   }
 
-  static bool custom_click(auto& ctx, uint8_t nbClick) {
+  static bool custom_click(auto& ctx, uint8_t nbClick)
+  {
     bool retVal = false;
     dispatch_mode(ctx, [&](auto mode) {
       retVal = mode.custom_click(nbClick);
@@ -183,37 +199,48 @@ struct GroupTy {
     return retVal;
   }
 
-  static bool custom_hold(auto& ctx,
-                          uint8_t nbClickAndHold,
-                          bool isEndOfHoldEvent,
-                          uint32_t holdDuration) {
+  static bool custom_hold(auto& ctx, uint8_t nbClickAndHold, bool isEndOfHoldEvent, uint32_t holdDuration)
+  {
     bool retVal = false;
     dispatch_mode(ctx, [&](auto mode) {
-      retVal = mode.custom_hold(nbClickAndHold,
-                                isEndOfHoldEvent,
-                                holdDuration);
+      retVal = mode.custom_hold(nbClickAndHold, isEndOfHoldEvent, holdDuration);
     });
     return retVal;
   }
 
-  static void power_on_sequence(auto& ctx) {
-    foreach_mode<true>(ctx, [](auto mode) { mode.power_on_sequence(); });
+  static void power_on_sequence(auto& ctx)
+  {
+    foreach_mode<true>(ctx, [](auto mode) {
+      mode.power_on_sequence();
+    });
   }
 
-  static void power_off_sequence(auto& ctx) {
-    foreach_mode<true>(ctx, [](auto mode) { mode.power_off_sequence(); });
+  static void power_off_sequence(auto& ctx)
+  {
+    foreach_mode<true>(ctx, [](auto mode) {
+      mode.power_off_sequence();
+    });
   }
 
-  static void write_parameters(auto& ctx) {
-    foreach_mode<true>(ctx, [](auto mode) { mode.write_parameters(); });
+  static void write_parameters(auto& ctx)
+  {
+    foreach_mode<true>(ctx, [](auto mode) {
+      mode.write_parameters();
+    });
   }
 
-  static void read_parameters(auto& ctx) {
-    foreach_mode<true>(ctx, [](auto mode) { mode.read_parameters(); });
+  static void read_parameters(auto& ctx)
+  {
+    foreach_mode<true>(ctx, [](auto mode) {
+      mode.read_parameters();
+    });
   }
 
-  static void user_thread(auto& ctx) {
-    dispatch_mode(ctx, [](auto mode) { mode.user_thread(); });
+  static void user_thread(auto& ctx)
+  {
+    dispatch_mode(ctx, [](auto mode) {
+      mode.user_thread();
+    });
   }
 };
 
@@ -222,8 +249,7 @@ struct GroupTy {
  * Binds all methods of the provided list of \p Modes and works together
  * with modes::ModeManagerTy to dispatch events and switch modes
  */
-template <typename... Modes>
-using GroupFor = GroupTy<std::tuple<Modes...>>;
+template<typename... Modes> using GroupFor = GroupTy<std::tuple<Modes...>>;
 
 } // namespace modes
 

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -1,0 +1,397 @@
+#ifndef MODES_HARDWARE_LAMP_TYPE_HPP
+#define MODES_HARDWARE_LAMP_TYPE_HPP
+
+#include <cassert>
+
+#include "src/compile.h"
+#include "src/system/behavior.h"
+#include "src/user/constants.h"
+
+#ifdef LMBD_LAMP_TYPE__INDEXABLE
+#include "src/system/utils/strip.h"
+#endif
+
+#include "src/modes/include/colors/utils.hpp"
+#include "src/modes/include/compile.hpp"
+
+/// Provide interface to the physical hardware and other facilities
+namespace modes::hardware {
+
+/** \brief Enumeration to write code working with all lamp types
+ *
+ * See LampTy::flavor and its usage
+ */
+enum class LampTypes : uint8_t
+{
+  simple,    ///< Equivalent to LMBD_LAMP_TYPE__SIMPLE
+  cct,       ///< Equivalent to LMBD_LAMP_TYPE__CCT
+  indexable, ///< Equivalent to LMBD_LAMP_TYPE__INDEXABLE
+};
+
+#ifdef LMBD_LAMP_TYPE__SIMPLE
+static constexpr LampTypes _lampType = LampTypes::simple;
+#endif
+
+#ifdef LMBD_LAMP_TYPE__CCT
+static constexpr LampTypes _lampType = LampTypes::cct;
+#endif
+
+#ifdef LMBD_LAMP_TYPE__INDEXABLE
+static constexpr LampTypes _lampType = LampTypes::indexable;
+#endif
+
+/// Currently implemented lamp type, defined at compile-time by the user
+static constexpr LampTypes lampType = _lampType;
+
+/** \brief Main interface between the user and the hardware of the lamp
+ *
+ * TODO: write recipes for best practices when doing Simple/CCT/Indexable
+ */
+struct LampTy
+{
+  //
+  // private constructors
+  //
+
+  LampTy() = delete;                         ///< \private
+  LampTy(const LampTy&) = delete;            ///< \private
+  LampTy& operator=(const LampTy&) = delete; ///< \private
+
+#ifdef LMBD_LAMP_TYPE__INDEXABLE
+private:
+  static constexpr uint16_t _width = stripXCoordinates;  ///< \private
+  static constexpr uint16_t _height = stripYCoordinates; ///< \private
+  static constexpr uint16_t _ledCount = LED_COUNT;       ///< \private
+  LedStrip& strip;                                       ///< \private
+
+public:
+  /// \private Constructor used to wrap strip if needed
+  LMBD_INLINE LampTy(LedStrip& strip) : strip {strip} {}
+#else
+private:
+  // (placeholder values to avoid bad fails on misuse)
+  static constexpr uint16_t _width = 16;     ///< \private
+  static constexpr uint16_t _height = 16;    ///< \private
+  static constexpr uint16_t _ledCount = 256; ///< \private
+
+  struct LedStrip
+  {
+  }; ///< \private
+  LedStrip fakeStrip; ///< \private
+  LedStrip& strip;    ///< \private
+
+public:
+  /// \private Constructor used to wrap strip if needed
+  LMBD_INLINE LampTy() : fakeStrip {}, strip {fakeStrip} {}
+#endif
+
+  //
+  // private API
+  //
+
+  /** \private Startup sequence of the lamp from a powered-off state
+   *
+   * In order:
+   *  - call lamp.begin()
+   *  - call lamp.clear()
+   *  - call lamp.show()
+   *  - call lamp.setBrightness(BRIGHTNESS, true, true)
+   *
+   * Supports all flavors, even if most steps are no-op if not indexable
+   */
+  void LMBD_INLINE startup()
+  {
+    begin();
+    clear();
+    show();
+    setBrightness(BRIGHTNESS, true, true);
+  }
+
+  /** \private Does necessary work to setup lamp from a powered-off state
+   *
+   * If flavor is LampTypes::indexable then:
+   *  - call the "begin" method of the LED strip to let it setup itself
+   *
+   * Or else, subject to change as other flavors are integrated:
+   *  - does nothing
+   */
+  void LMBD_INLINE begin()
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      strip.begin();
+    }
+    else
+    {
+      // (this is optimized out, and is essentially no-op for other flavors)
+      assert(true);
+    }
+  }
+
+  /** \private Does necessary work to display not-yet-shown lamp changes
+   *
+   * If LampTy::flavor is LampTypes::indexable then:
+   *  - update the output of the lamp with currently buffered changes
+   *
+   * Or else, subject to change as other flavors are integrated:
+   *  - does nothing
+   */
+  void LMBD_INLINE show()
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      strip.show();
+    }
+    else
+    {
+      // (this is optimized out, and is essentially no-op for other flavors)
+      assert(true);
+    }
+  }
+
+  //
+  // public constants
+  //
+
+  /// Which lamp flavor is currently used by the implementation?
+  static constexpr LampTypes flavor = lampType;
+
+  /** \brief (indexable) Count of indexable LEDs on the lamp
+   *
+   * Equal to \p LED_COUNT if LampTypes::indexable or else 256
+   */
+  static constexpr uint16_t ledCount = _ledCount;
+
+  /** \brief (indexable) Width of "pixel space" w/ lamp taken as a LED matrix
+   *
+   * Equal to \p stripXCoordinates if LampTypes::indexable or else 16
+   */
+  static constexpr uint16_t maxWidth = _width;
+
+  /** \brief (indexable) Height of "pixel space" w/ lamp taken as a LED matrix
+   *
+   * Equal to stripYCoordinates if LampTypes::indexable or else 16
+   */
+  static constexpr uint16_t maxHeight = _height;
+
+  //
+  // public helpers
+  //
+
+  /** \brief (indexable) Return a led count in 0-ledCount scaled by \p scale
+   *
+   * Supports:
+   *    - from float (0-1) to count (0-ledCount)
+   *    - from uint8_t (0-255) to count (0-ledCount)
+   */
+  template<typename T> static constexpr LMBD_INLINE uint16_t toLedCount(T scale)
+  {
+    if constexpr (std::is_same_v<T, float>)
+    {
+      assert(scale <= 1.0 && "scale is 0-1");
+      return ledCount * scale;
+    }
+    else if constexpr (std::is_same_v<T, uint8_t>)
+    {
+      uint32_t scaled = ledCount * scale;
+      return scaled / 256;
+    }
+    else
+    {
+      static_assert(std::is_same_v<T, std::false_type>, "Invalid type, either float or uint8_t required!");
+      return 0;
+    }
+  }
+
+  //
+  // public API
+  //
+
+  /** \brief Clear lamp to a clean state
+   *
+   * If LampTy::flavor is LampTypes::indexable then:
+   *  - clear LED strip with black pixels
+   *
+   * Or else, for interoperability:
+   *  - does nothing
+   */
+  void LMBD_INLINE clear()
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      strip.clear();
+    }
+    else
+    {
+      // (this is optimized out, and is essentially no-op for other flavors)
+      assert(true);
+    }
+  }
+
+  /** \brief Set brightness of the lamp
+   *
+   * Several behaviors:
+   *  - by default, do not call user callbacks to avoid re-entry
+   *  - by default, do call global brightness update handler (from behavior.h)
+   *  - also set the brightness in underlying strip object, if necessary
+   *
+   * Thus:
+   *  - if \p skipCallbacks is false, do call user callbacks w/ re-entry risks
+   *  - if \p skipUpdateBrightness is true, only set strip object brightness,
+   *    or do nothing if LampTy::flavor is not LampTypes::indexable
+   *
+   * Note that \p skipUpdateBrightness implies \p skipCallbacks implicitly
+   */
+  void LMBD_INLINE setBrightness(uint8_t brightness, bool skipCallbacks = true, bool skipUpdateBrightness = false)
+  {
+    assert((skipCallbacks || !skipUpdateBrightness) && "implicit callback skip!");
+
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      strip.setBrightness(brightness);
+    }
+
+    if (!skipUpdateBrightness)
+    {
+      update_brightness(brightness, false, skipCallbacks);
+    }
+  }
+
+  /// Get brightness of the lamp
+  uint8_t LMBD_INLINE getBrightness()
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      return strip.getBrightness();
+    }
+    else
+    {
+      return BRIGHTNESS;
+    }
+  }
+
+  /** \brief Fade currently displayed content by \p fadeBy units
+   *
+   * If LampTy::flavor is LampTypes::indexable then:
+   *  - do not change brightness, only scale color of individual LEDs
+   *
+   * Or else, for other flavors of lamp:
+   *  - reduce brightness by \p fadeBy floored at zero
+   */
+  void LMBD_INLINE fadeToBlackBy(uint8_t fadeBy)
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      strip.fadeToBlackBy(fadeBy);
+    }
+    else
+    {
+      uint8_t brightness = getBrightness();
+      brightness = (brightness < fadeBy) ? 0 : brightness - fadeBy;
+      setBrightness(brightness);
+    }
+  }
+
+  /** \brief Fill lamp with target light temperature, if supported
+   *
+   * If LampTy::flavor is LampTypes::simple then:
+   *  - does nothing
+   *
+   * If LampTy::flavor is LampTypes::cct then:
+   *  - scale from one supported color to the the other one
+   *
+   * If LampTy::flavor is LampTypes::indexable then:
+   *  - use modes::colors::fromTemp to fill lamp with color
+   */
+  void LMBD_INLINE setLightTemp(uint8_t temp)
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      fill(colors::fromTemp(temp));
+    }
+    else if constexpr (flavor == LampTypes::cct)
+    {
+      // TODO: implement
+      assert(false && "not yet implemented :(");
+    }
+    else
+    {
+      // -> intentionally do not trigger as error, for interoperability
+      assert(true);
+    }
+  }
+
+  //
+  // public API (indexable-only)
+  //
+
+  /// (indexable) Return raw underlying strip object
+  auto& LMBD_INLINE getLegacyStrip()
+  {
+    assert(flavor == LampTypes::indexable && "current lamp is not indexable");
+    return strip;
+  }
+
+  /** \brief (indexable) Fill lamp with target color
+   *
+   * See modes::colors::fromRGB() to set \p color
+   */
+  void LMBD_INLINE fill(uint32_t color)
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      for (uint16_t I = 0; I < ledCount; ++I)
+      {
+        strip.setPixelColor(I, color);
+      }
+    }
+    else
+    {
+      assert(false && "unsupported");
+    }
+  }
+
+  /** \brief (indexable) Fill lamp with target color, from start to end
+   *
+   * - See toLedCount() to set \p start and \p end
+   * - See modes::colors::fromRGB() to set \p color
+   */
+  void LMBD_INLINE fill(uint32_t color, uint16_t start, uint16_t end)
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      assert(start < ledCount && "invalid start parameter");
+      assert(end < ledCount && "invalid end parameter");
+
+      for (uint16_t I = start; I < end; ++I)
+      {
+        strip.setPixelColor(I, color);
+      }
+    }
+    else
+    {
+      assert(false && "unsupported");
+    }
+  }
+
+  /** \brief (indexable) Set the n-th LED color
+   *
+   * See modes::fromRGB() to set \p color
+   */
+  void LMBD_INLINE setPixelColor(uint16_t n, uint32_t color)
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      assert(n < ledCount && "invalid LED index");
+      strip.setPixelColor(n, color);
+    }
+    else
+    {
+      assert(false && "unsupported");
+    }
+  }
+};
+
+} // namespace modes::hardware
+
+#endif

--- a/src/modes/include/manager_type.hpp
+++ b/src/modes/include/manager_type.hpp
@@ -1,28 +1,32 @@
 #ifndef MANAGER_TYPE_H
 #define MANAGER_TYPE_H
 
+/** \file
+ *
+ *  \brief modes::ManagerFor and associated definitions
+ **/
+
 #include <cstdint>
 #include <cassert>
 #include <utility>
 #include <tuple>
 #include <array>
 
-/** \file manager_type.h
- *  \brief modes::ManagerFor and associated definitions
- **/
-
 #include "src/modes/include/tools.hpp"
 #include "src/modes/include/context_type.hpp"
 #include "src/modes/include/default_config.hpp"
+#include "src/modes/include/hardware/lamp_type.hpp"
 
 namespace modes {
 
 /// \private Active state is designated by a 32-bit integer
-union ActiveIndexTy {
-  struct {
-    uint8_t groupIndex; // group id (as ordered in the manager)
-    uint8_t modeIndex; // mode id (as ordered in its group)
-    uint8_t rampIndex; // ramp value (as set by the user)
+union ActiveIndexTy
+{
+  struct
+  {
+    uint8_t groupIndex;  // group id (as ordered in the manager)
+    uint8_t modeIndex;   // mode id (as ordered in its group)
+    uint8_t rampIndex;   // ramp value (as set by the user)
     uint8_t customIndex; // custom (as set by the mode)
   };
 
@@ -30,40 +34,46 @@ union ActiveIndexTy {
 
   // static constructors
   //
-  static auto from(const uint8_t* arr) {
+  static auto from(const uint8_t* arr)
+  {
     ActiveIndexTy index = {arr[0], arr[1], arr[2], arr[3]};
     return index;
   }
 };
 
 /// \private Contains the logic to handle a fixed-timestep range
-template <typename Config>
-struct RampHandlerTy {
+template<typename Config> struct RampHandlerTy
+{
   using ConfigTy = Config;
   static constexpr uint32_t startPeriod = Config::rampStartPeriodMs;
 
   // \in stepSpeed how long to wait before incrementing (ms)
   // \in rampSaturates does the ramp saturates, or else wrap around?
-  RampHandlerTy(uint32_t stepSpeed,
-                bool rampSaturates = Config::defaultRampSaturates)
-    : stepSpeed{stepSpeed}, rampSaturates{rampSaturates},
-      lastTimeMeasured{1000}, isForward{true} { }
+  RampHandlerTy(uint32_t stepSpeed, bool rampSaturates = Config::defaultRampSaturates) :
+    stepSpeed {stepSpeed},
+    rampSaturates {rampSaturates},
+    lastTimeMeasured {1000},
+    isForward {true}
+  {
+  }
 
-  void LMBD_INLINE update_ramp(uint8_t rampValue,
-                               uint32_t holdTime,
-                               auto callback) {
-
+  void LMBD_INLINE update_ramp(uint8_t rampValue, uint32_t holdTime, auto callback)
+  {
     // restart the rampage
-    if (holdTime < lastTimeMeasured) {
+    if (holdTime < lastTimeMeasured)
+    {
       lastTimeMeasured = holdTime;
 
-      if (holdTime < startPeriod) {
-
+      if (holdTime < startPeriod)
+      {
         // toggle forward / backward direction
         isForward = !isForward;
-        if (rampSaturates) {
-          if (rampValue == 0) isForward = true;
-          if (rampValue == 255) isForward = false;
+        if (rampSaturates)
+        {
+          if (rampValue == 0)
+            isForward = true;
+          if (rampValue == 255)
+            isForward = false;
         }
       }
       return;
@@ -76,8 +86,8 @@ struct RampHandlerTy {
       return;
 
     // apply steps
-    for (uint32_t I = 0; I < nextCounter - lastCounter; ++I) {
-
+    for (uint32_t I = 0; I < nextCounter - lastCounter; ++I)
+    {
       // increment iff possible
       if (isForward && (!rampSaturates || rampValue < 255))
         rampValue += 1;
@@ -100,21 +110,18 @@ struct RampHandlerTy {
 };
 
 /// \private Implementation details of modes::ManagerFor
-template <typename Config, typename AllGroups>
-struct ModeManagerTy {
-
+template<typename Config, typename AllGroups> struct ModeManagerTy
+{
   using SelfTy = ModeManagerTy<Config, AllGroups>;
   using ConfigTy = Config;
   using AllGroupsTy = AllGroups;
   using AllStatesTy = details::StateTyFrom<AllGroups>;
-  static constexpr uint8_t nbGroups{std::tuple_size_v<AllGroupsTy>};
+  static constexpr uint8_t nbGroups {std::tuple_size_v<AllGroupsTy>};
 
-  template <uint8_t Idx>
-  using GroupAt = std::tuple_element_t<Idx, AllGroupsTy>;
+  template<uint8_t Idx> using GroupAt = std::tuple_element_t<Idx, AllGroupsTy>;
 
   // required to support manager-level context
   using HasAnyGroup = details::anyOf<AllGroupsTy>;
-  static constexpr bool simpleMode = false;
   static constexpr bool hasBrightCallback = HasAnyGroup::hasBrightCallback;
   static constexpr bool hasSystemCallbacks = HasAnyGroup::hasSystemCallbacks;
   static constexpr bool requireUserThread = HasAnyGroup::requireUserThread;
@@ -122,44 +129,45 @@ struct ModeManagerTy {
   static constexpr bool hasButtonCustomUI = HasAnyGroup::hasButtonCustomUI;
 
   // constructors
-  ModeManagerTy(LedStrip& strip)
-    : activeIndex{ActiveIndexTy::from(Config::initialActiveIndex)},
-      strip{strip} { }
+  ModeManagerTy(hardware::LampTy& lamp) : activeIndex {ActiveIndexTy::from(Config::initialActiveIndex)}, lamp {lamp} {}
 
   ModeManagerTy() = delete;
   ModeManagerTy(const ModeManagerTy&) = delete;
   ModeManagerTy& operator=(const ModeManagerTy&) = delete;
 
   /// \private Get root context bound to manager
-  auto get_context() {
-    return ContextTy<SelfTy, SelfTy>(*this);
-  }
+  auto get_context() { return ContextTy<SelfTy, SelfTy>(*this); }
 
   /// \private Dispatch active group to callback
-  template<typename CallBack>
-  static void LMBD_INLINE dispatch_group(auto& ctx, CallBack&& cb) {
+  template<typename CallBack> static void LMBD_INLINE dispatch_group(auto& ctx, CallBack&& cb)
+  {
     uint8_t groupId = ctx.get_active_group(nbGroups);
 
     details::unroll<nbGroups>([&](auto Idx) LMBD_INLINE {
-      if (Idx == groupId) {
+      if (Idx == groupId)
+      {
         cb(context_as<GroupAt<Idx>>(ctx));
       }
     });
   }
 
   /// \private Forward each group to callback (if eligible)
-  template<bool systemCallbacksOnly, typename CallBack>
-  static void LMBD_INLINE foreach_group(auto& ctx, CallBack&& cb) {
-    if constexpr (systemCallbacksOnly) {
+  template<bool systemCallbacksOnly, typename CallBack> static void LMBD_INLINE foreach_group(auto& ctx, CallBack&& cb)
+  {
+    if constexpr (systemCallbacksOnly)
+    {
       details::unroll<nbGroups>([&](auto Idx) LMBD_INLINE {
         using GroupHere = GroupAt<Idx>;
         constexpr bool hasCallbacks = GroupHere::hasSystemCallbacks;
 
-        if constexpr (hasCallbacks) {
+        if constexpr (hasCallbacks)
+        {
           cb(context_as<GroupAt<Idx>>(ctx));
         }
       });
-    } else {
+    }
+    else
+    {
       details::unroll<nbGroups>([&](auto Idx) LMBD_INLINE {
         cb(context_as<GroupAt<Idx>>(ctx));
       });
@@ -170,8 +178,8 @@ struct ModeManagerTy {
   // state
   //
 
-  struct StateTy {
-
+  struct StateTy
+  {
     // All group states, containing all modes individual states
     AllStatesTy groupStates;
 
@@ -182,28 +190,30 @@ struct ModeManagerTy {
     RampHandlerTy<Config> rampHandler = {Config::defaultCustomRampStepSpeedMs};
     RampHandlerTy<Config> scrollHandler = {Config::scrollRampStepSpeedMs};
 
-
     bool clearStripOnModeChange = Config::defaultClearStripOnModeChange;
 
     ActiveIndexTy currentFavorite = ActiveIndexTy::from(Config::defaultFavorite);
 
-    static void LMBD_INLINE before_reset(auto& ctx) {
+    static void LMBD_INLINE before_reset(auto& ctx)
+    {
       auto& self = ctx.state;
       self.rampHandler.rampSaturates = Config::defaultRampSaturates;
       self.rampHandler.stepSpeed = Config::defaultCustomRampStepSpeedMs;
       self.clearStripOnModeChange = Config::defaultClearStripOnModeChange;
     }
 
-    static void LMBD_INLINE after_reset(auto& ctx) {
+    static void LMBD_INLINE after_reset(auto& ctx)
+    {
       auto& self = ctx.state;
-      if (self.clearStripOnModeChange) {
-        ctx.strip.clear();
+      if (self.clearStripOnModeChange)
+      {
+        ctx.lamp.clear();
       }
     }
   };
 
-  template <typename Group>
-  StateTyOf<Group>* LMBD_INLINE getStateGroupOf() {
+  template<typename Group> StateTyOf<Group>* LMBD_INLINE getStateGroupOf()
+  {
     using StateTy = StateTyOf<Group>;
     using OptionalTy = std::optional<StateTy>;
 
@@ -212,9 +222,11 @@ struct ModeManagerTy {
       using GroupHere = GroupAt<Idx>;
       constexpr bool IsHere = std::is_same_v<GroupHere, Group>;
 
-      if constexpr (IsHere) {
+      if constexpr (IsHere)
+      {
         OptionalTy& opt = std::get<OptionalTy>(state.groupStates);
-        if (!opt.has_value()) {
+        if (!opt.has_value())
+        {
           opt.emplace();
         }
 
@@ -228,29 +240,37 @@ struct ModeManagerTy {
     return substate;
   }
 
-  template <typename Mode>
-  StateTyOf<Mode>& LMBD_INLINE getStateOf() {
+  template<typename Mode> StateTyOf<Mode>& LMBD_INLINE getStateOf()
+  {
     using TargetStateTy = StateTyOf<Mode>;
 
     // Mode is unknown / as no state, return placeholder
-    if constexpr (std::is_same_v<TargetStateTy, NoState>) {
+    if constexpr (std::is_same_v<TargetStateTy, NoState>)
+    {
       return placeholder;
 
-    // Mode is ManagerTy, return our own state
-    } else if constexpr (std::is_same_v<TargetStateTy, StateTy>) {
+      // Mode is ManagerTy, return our own state
+    }
+    else if constexpr (std::is_same_v<TargetStateTy, StateTy>)
+    {
       return state;
 
-    // Mode is GroupTy, return the state of the group
-    } else if constexpr (details::GroupBelongsTo<Mode, AllGroups>) {
+      // Mode is GroupTy, return the state of the group
+    }
+    else if constexpr (details::GroupBelongsTo<Mode, AllGroups>)
+    {
       TargetStateTy* substate = getStateGroupOf<Mode>();
 
-      if (substate == nullptr) {
-        substate = (TargetStateTy*) &placeholder;
+      if (substate == nullptr)
+      {
+        substate = (TargetStateTy*)&placeholder;
         assert(false && "this code should be unreachable, but is it?");
       }
 
       return *substate;
-    } else {
+    }
+    else
+    {
       static_assert(details::ModeExists<Mode, AllGroups>);
 
       // Mode is somewhere in a group, search for it, return its state
@@ -259,14 +279,16 @@ struct ModeManagerTy {
       details::unroll<nbGroups>([&](auto Idx) LMBD_INLINE {
         using Group = GroupAt<Idx>;
         using AllModes = typename Group::AllModesTy;
-        if constexpr (details::ModeBelongsTo<Mode, AllModes>) {
+        if constexpr (details::ModeBelongsTo<Mode, AllModes>)
+        {
           substate = Group::template getStateOf<Mode>(*this);
         }
       });
       assert(substate != nullptr && "this should not have compiled at all!");
 
-      if (substate == nullptr) {
-        substate = (TargetStateTy*) &placeholder;
+      if (substate == nullptr)
+      {
+        substate = (TargetStateTy*)&placeholder;
         assert(false && "this code should be unreachable, but is it?");
       }
 
@@ -281,7 +303,8 @@ struct ModeManagerTy {
   static constexpr bool isGroupManager = true;
   static constexpr bool isModeManager = true;
 
-  static void next_group(auto& ctx) {
+  static void next_group(auto& ctx)
+  {
     uint8_t groupIdBefore = ctx.get_active_group(nbGroups);
 
     ctx.state.lastModeMemory[groupIdBefore] = ctx.get_active_mode();
@@ -293,30 +316,38 @@ struct ModeManagerTy {
     ctx.reset_mode();
   }
 
-  static void next_mode(auto& ctx) {
+  static void next_mode(auto& ctx)
+  {
     ctx.state.before_reset(ctx);
-    dispatch_group(ctx, [](auto group) { group.next_mode(); });
+    dispatch_group(ctx, [](auto group) {
+      group.next_mode();
+    });
     ctx.state.after_reset(ctx);
   }
 
-  static void jump_to_favorite(auto& ctx) {
+  static void jump_to_favorite(auto& ctx)
+  {
     ctx.modeManager.activeIndex = ctx.state.currentFavorite;
     ctx.reset_mode();
   }
 
-  static void set_favorite_now(auto& ctx) {
-    ctx.state.currentFavorite = ctx.modeManager.activeIndex;
-  }
+  static void set_favorite_now(auto& ctx) { ctx.state.currentFavorite = ctx.modeManager.activeIndex; }
 
-  static void reset_mode(auto& ctx) {
+  static void reset_mode(auto& ctx)
+  {
     ctx.state.before_reset(ctx);
-    dispatch_group(ctx, [](auto group) { group.reset_mode(); });
+    dispatch_group(ctx, [](auto group) {
+      group.reset_mode();
+    });
     ctx.state.after_reset(ctx);
   }
 
-  static uint8_t get_modes_count(auto& ctx) {
+  static uint8_t get_modes_count(auto& ctx)
+  {
     uint8_t value = 0;
-    dispatch_group(ctx, [&](auto group) { value = decltype(group)::LocalModeTy::nbModes; });
+    dispatch_group(ctx, [&](auto group) {
+      value = decltype(group)::LocalModeTy::nbModes;
+    });
     return value;
   }
 
@@ -324,43 +355,64 @@ struct ModeManagerTy {
   // all the callbacks
   //
 
-  static void loop(auto& ctx) {
-    dispatch_group(ctx, [](auto group) { group.loop(); });
+  static void loop(auto& ctx)
+  {
+    dispatch_group(ctx, [](auto group) {
+      group.loop();
+    });
   }
 
-  static void brightness_update(auto& ctx, uint8_t brightness) {
+  static void brightness_update(auto& ctx, uint8_t brightness)
+  {
     dispatch_group(ctx, [&](auto group) {
       group.brightness_update(brightness);
     });
   }
 
-  static void power_on_sequence(auto& ctx) {
-    foreach_group<true>(ctx, [](auto group) { group.power_on_sequence(); });
+  static void power_on_sequence(auto& ctx)
+  {
+    foreach_group<true>(ctx, [](auto group) {
+      group.power_on_sequence();
+    });
   }
 
-  static void power_off_sequence(auto& ctx) {
-    foreach_group<true>(ctx, [](auto group) { group.power_off_sequence(); });
+  static void power_off_sequence(auto& ctx)
+  {
+    foreach_group<true>(ctx, [](auto group) {
+      group.power_off_sequence();
+    });
   }
 
-  static void write_parameters(auto& ctx) {
-    foreach_group<true>(ctx, [](auto group) { group.write_parameters(); });
+  static void write_parameters(auto& ctx)
+  {
+    foreach_group<true>(ctx, [](auto group) {
+      group.write_parameters();
+    });
   }
 
-  static void read_parameters(auto& ctx) {
-    foreach_group<true>(ctx, [](auto group) { group.read_parameters(); });
+  static void read_parameters(auto& ctx)
+  {
+    foreach_group<true>(ctx, [](auto group) {
+      group.read_parameters();
+    });
   }
 
-  static void user_thread(auto& ctx) {
-    dispatch_group(ctx, [](auto group) { group.user_thread(); });
+  static void user_thread(auto& ctx)
+  {
+    dispatch_group(ctx, [](auto group) {
+      group.user_thread();
+    });
   }
 
-  static void custom_ramp_update(auto& ctx, uint8_t rampValue) {
+  static void custom_ramp_update(auto& ctx, uint8_t rampValue)
+  {
     dispatch_group(ctx, [&](auto group) {
       group.custom_ramp_update(rampValue);
     });
   }
 
-  static bool custom_click(auto& ctx, uint8_t nbClick) {
+  static bool custom_click(auto& ctx, uint8_t nbClick)
+  {
     bool retVal = false;
     dispatch_group(ctx, [&](auto group) {
       retVal = group.custom_click(nbClick);
@@ -368,15 +420,11 @@ struct ModeManagerTy {
     return retVal;
   }
 
-  static bool custom_hold(auto& ctx,
-                          uint8_t nbClickAndHold,
-                          bool isEndOfHoldEvent,
-                          uint32_t holdDuration) {
+  static bool custom_hold(auto& ctx, uint8_t nbClickAndHold, bool isEndOfHoldEvent, uint32_t holdDuration)
+  {
     bool retVal = false;
     dispatch_group(ctx, [&](auto group) {
-      retVal = group.custom_hold(nbClickAndHold,
-                                 isEndOfHoldEvent,
-                                 holdDuration);
+      retVal = group.custom_hold(nbClickAndHold, isEndOfHoldEvent, holdDuration);
     });
     return retVal;
   }
@@ -386,7 +434,7 @@ struct ModeManagerTy {
   //
 
   ActiveIndexTy activeIndex;
-  LedStrip& strip;
+  hardware::LampTy& lamp;
 
   //
   // private members
@@ -401,8 +449,8 @@ private:
  *
  * See modes::DefaultManagerConfig for guide on how to override configuration.
  */
-template <typename ManagerConfig, typename... Groups>
-using ManagerForConfig = ModeManagerTy<ManagerConfig, std::tuple<Groups...>>;
+template<typename ManagerConfig, typename... Groups> using ManagerForConfig =
+        ModeManagerTy<ManagerConfig, std::tuple<Groups...>>;
 
 /** \brief Group together several mode groups defined through modes::GroupFor
  *
@@ -412,8 +460,7 @@ using ManagerForConfig = ModeManagerTy<ManagerConfig, std::tuple<Groups...>>;
  * \remarks All enabled modes shall be enumerated in modes::GroupFor listed
  * as inside the modes::ManagerFor modes::ModeManagerTy singleton
  */
-template <typename... Groups>
-using ManagerFor = ModeManagerTy<DefaultManagerConfig, std::tuple<Groups...>>;
+template<typename... Groups> using ManagerFor = ModeManagerTy<DefaultManagerConfig, std::tuple<Groups...>>;
 
 } // namespace modes
 

--- a/src/modes/include/mode_type.hpp
+++ b/src/modes/include/mode_type.hpp
@@ -1,11 +1,12 @@
 #ifndef MODE_TYPE_H
 #define MODE_TYPE_H
 
-#include <cstdint>
-
-/** \file mode_type.hpp
+/** \file
+ *
  *  \brief Basic interface types to implement custom user modes
  **/
+
+#include <cstdint>
 
 /// Contains basic interface types to implement custom user modes
 namespace modes {
@@ -15,29 +16,13 @@ namespace modes {
  * Implement a custom user mode as follow:
  *
  * ```
- *  // simplified user mode definition
+ *  // user mode definition
  *  struct MyCustomMode : public modes::BasicMode {
- *    static void loop(LedStrip& strip) {
- *      strip.clear();
+ *    static void loop(auto& ctx) {
+ *      ctx.lamp.setBrightness(50);
  *
- *      // ... other things using strip
+ *      // ... other things using lamp
  *    }
- *  };
- * ```
- *
- * It is recommended to use the full user mode definition:
- *
- * ```
- *  // full user mode definition
- *  struct MyCustomMode : public modes::FullMode {
- *
- *   static void loop(auto& ctx) {
- *      auto& strip = ctx.strip;
- *      strip.clear();
- *
- *      // ... other things using strip & ctx
- *   }
- *
  *  };
  * ```
  *
@@ -64,33 +49,20 @@ namespace modes {
  * \remark BasicMode and all derived user modes should never be constructed,
  * use custom StateTy to implement stateful modes
  */
-struct BasicMode {
-
+struct BasicMode
+{
   /// Mode custom static state, made available through context (optional)
-  struct StateTy { };
+  struct StateTy
+  {
+  };
 
-  /** \brief Simplified user mode loop function (default)
-   *
-   * Loop function with a simplified prototype, which is called instead of full
-   * loop(auto&) if BasicMode::simpleMode is True
-   *
-   * \remark To make mode stateful, define custom StateTy and use loop(auto&)
-   * to retrieve context, then retrieve the state instance from context
-   */
-  static void loop(LedStrip& strip) { return; }
-
-  /// Picks between simplified BasicMode::loop() and full BasicMode::loop(auto&)
-  static constexpr bool simpleMode = true;
-
-  /** \brief Custom user mode loop function (optional)
+  /** \brief Custom user mode loop function (default)
    *
    * Loop function each tick called whenever the mode is set as the currently
    * active mode by the user
    *
-   * \param[in] ctx The current context, providing a interface to the
-   * controller and the LED strip, as well as an access to its state
-   * \remark By default BasicMode::simpleMode is True and simplified loop() is
-   * called instead of loop(auto&)
+   * \param[in] ctx The current context, providing a interface to the local
+   * state, the mode manager, as well as the hardware through its lamp object
    */
   static void loop(auto& ctx) { return; }
 
@@ -129,9 +101,7 @@ struct BasicMode {
    * \remark This behavior is in user::button_hold_default() and may be
    * prevented if custom "usermode UI" via custom_hold() is enabled
    */
-  static void custom_ramp_update(auto& ctx, uint8_t rampValue) {
-    return;
-  }
+  static void custom_ramp_update(auto& ctx, uint8_t rampValue) { return; }
 
   /// Toggles "usermode" button UI custom_click() and custom_hold()
   static constexpr bool hasButtonCustomUI = false;
@@ -144,9 +114,7 @@ struct BasicMode {
    * \param[in] nbClick The number of clicks made by the user
    * \return Returns True if default UI action should be prevented
    */
-  static bool custom_click(auto& ctx, uint8_t nbClick) {
-    return false;
-  }
+  static bool custom_click(auto& ctx, uint8_t nbClick) { return false; }
 
   /** \brief Custom "usermode" button UI for "click+hold" action (optional)
    *
@@ -159,10 +127,8 @@ struct BasicMode {
    * \return Returns True if default action must be prevented
    * \remark When \p isEndOfHoldEvent is True, then \p holdDuration is zero
    */
-  static bool custom_hold(auto& ctx,
-                          uint8_t nbClickAndHold,
-                          bool isEndOfHoldEvent,
-                          uint32_t holdDuration) {
+  static bool custom_hold(auto& ctx, uint8_t nbClickAndHold, bool isEndOfHoldEvent, uint32_t holdDuration)
+  {
     return false;
   }
 
@@ -216,8 +182,8 @@ struct BasicMode {
 
   /** \brief Toggles the use of custom BasicMode::user_thread() callback
    *
-   * \remark When this is enabled, default behavior is to only refresh strip in
-   * user::user_thread() after the BasicMode::user_thread() callback
+   * \remark When this is enabled, default is to call hardware::LampTy::show()
+   * in user::user_thread() after the BasicMode::user_thread() callback
    */
   static constexpr bool requireUserThread = false;
 
@@ -227,22 +193,15 @@ struct BasicMode {
    *
    * \param[in] ctx The current context
    * \remark This is executed as prologue of user::user_thread() and hence
-   * must complete quickly in order to keep the strip responsive
+   * must complete quickly in order to keep the lamp responsive
    */
-  static void user_thread(auto& ctx) {
-    return;
-  }
+  static void user_thread(auto& ctx) { return; }
 
   // modes shall not implement any constructors
-  BasicMode() = delete; ///< \private
-  BasicMode(const BasicMode&) = delete; ///< \private
+  BasicMode() = delete;                            ///< \private
+  BasicMode(const BasicMode&) = delete;            ///< \private
   BasicMode& operator=(const BasicMode&) = delete; ///< \private
 };
-
-  /// Alias for BasicMode with BasicMode::simpleMode to False
-  struct FullMode: public BasicMode {
-    static constexpr bool simpleMode = false;
-  };
 
 } // namespace modes
 

--- a/src/modes/include/tools.hpp
+++ b/src/modes/include/tools.hpp
@@ -6,53 +6,50 @@
 #include <optional>
 #include <tuple>
 
+#include "src/modes/include/compile.hpp"
 #include "src/modes/include/mode_type.hpp"
 
 #ifndef LMBD_CPP17
 #error "File requires -DLMBD_CPP17 to explicitly enables C++17 features"
 #endif
 
-// always_inline macro
-#define LMBD_INLINE __attribute__((always_inline))
-
-// maybe_unused macro
-#define LMBD_USED [[maybe_unused]]
-
 namespace modes {
 
-struct NoState { };
+struct NoState
+{
+};
 
-template <typename Mode>
-static constexpr bool isMode = std::is_base_of_v<BasicMode, Mode>;
+template<typename Mode> static constexpr bool isMode = std::is_base_of_v<BasicMode, Mode>;
 
 namespace details {
 
 /// \private Implements unroll<N>(callback)
-template <class CbTy, uint8_t... Indexes>
-static constexpr void LMBD_INLINE unroll_impl(
-        CbTy&& cb,
-        std::integer_sequence<uint8_t, Indexes...>) {
-  (cb(std::integral_constant<uint8_t, Indexes>{}), ...);
+template<class CbTy, uint8_t... Indexes>
+static constexpr void LMBD_INLINE unroll_impl(CbTy&& cb, std::integer_sequence<uint8_t, Indexes...>)
+{
+  (cb(std::integral_constant<uint8_t, Indexes> {}), ...);
 }
 
 /// \private Calls \p cb with integral constants from 0 to N
-template <uint8_t N, class CbTy>
-static constexpr void LMBD_INLINE unroll(CbTy &&cb) {
+template<uint8_t N, class CbTy> static constexpr void LMBD_INLINE unroll(CbTy&& cb)
+{
   constexpr auto Indexes = std::make_integer_sequence<uint8_t, N>();
-  unroll_impl([&](auto I) LMBD_INLINE {
-    return cb(std::integral_constant<uint8_t, decltype(I)::value>{});
-  }, Indexes);
+  unroll_impl(
+          [&](auto I) LMBD_INLINE {
+            return cb(std::integral_constant<uint8_t, decltype(I)::value> {});
+          },
+          Indexes);
 }
 
 /// \private Helper to perform queries on elements of \p TupleTy
-template <typename TupleTy, uint8_t TupleSz = std::tuple_size_v<TupleTy>>
-struct forEach {
-
+template<typename TupleTy, uint8_t TupleSz = std::tuple_size_v<TupleTy>> struct forEach
+{
   /// \private Return True if any elements returns True through \p QueryStruct
-  template <template<class> class QueryStruct, bool hasError = false>
-  static constexpr bool any() {
+  template<template<class> class QueryStruct, bool hasError = false> static constexpr bool any()
+  {
     bool acc = false;
-    if constexpr (!hasError) {
+    if constexpr (!hasError)
+    {
       unroll<TupleSz>([&](auto Idx) {
         acc |= QueryStruct<std::tuple_element_t<Idx, TupleTy>>::value;
       });
@@ -61,42 +58,52 @@ struct forEach {
   }
 
   /// \private Return True if all elements returns True through \p QueryStruct
-  template <template<class> class QueryStruct, bool hasError = false>
-  static constexpr bool all() {
+  template<template<class> class QueryStruct, bool hasError = false> static constexpr bool all()
+  {
     bool acc = true;
-    if constexpr (!hasError) {
+    if constexpr (!hasError)
+    {
       unroll<TupleSz>([&](auto Idx) {
         acc &= QueryStruct<std::tuple_element_t<Idx, TupleTy>>::value;
       });
-    } else {
-     return false;
+    }
+    else
+    {
+      return false;
     }
     return acc;
   }
-
 };
 
 /// \private Defined boolean is True if any \p TupleTy item has boolean True
-template <typename TupleTy, bool hasError = false>
-struct anyOf {
+template<typename TupleTy, bool hasError = false> struct anyOf
+{
+  template<typename Ty> struct QHasBright
+  {
+    static constexpr bool value = Ty::hasBrightCallback;
+  };
 
-  template <typename Ty>
-  struct QHasBright { static constexpr bool value = Ty::hasBrightCallback; };
+  template<typename Ty> struct QCustomRamp
+  {
+    static constexpr bool value = Ty::hasCustomRamp;
+  };
 
-  template <typename Ty>
-  struct QCustomRamp { static constexpr bool value = Ty::hasCustomRamp; };
+  template<typename Ty> struct QButtonUI
+  {
+    static constexpr bool value = Ty::hasButtonCustomUI;
+  };
 
-  template <typename Ty>
-  struct QButtonUI { static constexpr bool value = Ty::hasButtonCustomUI; };
+  template<typename Ty> struct QHasSystem
+  {
+    static constexpr bool value = Ty::hasSystemCallbacks;
+  };
 
-  template <typename Ty>
-  struct QHasSystem { static constexpr bool value = Ty::hasSystemCallbacks; };
-
-  template <typename Ty>
-  struct QUserThread { static constexpr bool value = Ty::requireUserThread; };
+  template<typename Ty> struct QUserThread
+  {
+    static constexpr bool value = Ty::requireUserThread;
+  };
 
   // booleans we need
-  static constexpr bool simpleMode = false;
   static constexpr bool hasBrightCallback = forEach<TupleTy>::template any<QHasBright, hasError>();
   static constexpr bool hasCustomRamp = forEach<TupleTy>::template any<QCustomRamp, hasError>();
   static constexpr bool hasButtonCustomUI = forEach<TupleTy>::template any<QButtonUI, hasError>();
@@ -110,60 +117,56 @@ struct anyOf {
 //  - or else return EmptyState
 //
 
-template <typename Mode,
+template<typename Mode,
          typename StateTy = typename Mode::StateTy,
          bool isDefault = std::is_same_v<StateTy, BasicMode::StateTy> || (sizeof(StateTy) == 0),
          typename RetTy = std::conditional_t<isDefault, NoState, StateTy>>
 static constexpr auto stateTyOfImpl(int) -> RetTy;
 
-template <typename>
-static constexpr auto stateTyOfImpl(...) -> NoState;
+template<typename> static constexpr auto stateTyOfImpl(...) -> NoState;
 
 /// \private Get StateTy if explicitly defined, or else EmptyState
-template <typename Mode>
-using StateTyOf = decltype(stateTyOfImpl<Mode>(0));
+template<typename Mode> using StateTyOf = decltype(stateTyOfImpl<Mode>(0));
 
 /// \private Defined boolean is True if all \p TupleTy item has boolean True
-template <typename TupleTy, bool hasError = false>
-struct allOf {
+template<typename TupleTy, bool hasError = false> struct allOf
+{
+  template<typename Ty> struct QIsMode
+  {
+    static constexpr bool value = isMode<Ty>;
+  };
 
-  template <typename Ty>
-  struct QIsMode { static constexpr bool value = isMode<Ty>; };
-
-  template <typename Ty>
-  struct QStateOk { static constexpr bool value = std::is_default_constructible_v<StateTyOf<Ty>>; };
+  template<typename Ty> struct QStateOk
+  {
+    static constexpr bool value = std::is_default_constructible_v<StateTyOf<Ty>>;
+  };
 
   static constexpr bool inheritsFromBasicMode = forEach<TupleTy>::template all<QIsMode, hasError>();
   static constexpr bool stateDefaultConstructible = forEach<TupleTy>::template all<QStateOk, hasError>();
 };
 
 /// \private Get std::tuple<Modes::StateTy...> from Modes...
-template <typename... Modes>
-using StateTyFor = std::tuple<std::optional<StateTyOf<Modes>>...>;
+template<typename... Modes> using StateTyFor = std::tuple<std::optional<StateTyOf<Modes>>...>;
 
-template <typename... Modes>
-static constexpr auto stateTyFromImpl(std::tuple<Modes...>*) -> StateTyFor<Modes...>;
+template<typename... Modes> static constexpr auto stateTyFromImpl(std::tuple<Modes...>*) -> StateTyFor<Modes...>;
 
 /// \private Get std::tuple<Mode::StateTy...> from std::tuple<Mode...>
-template <typename AsTuple>
-using StateTyFrom = decltype(stateTyFromImpl((AsTuple*) 0));
+template<typename AsTuple> using StateTyFrom = decltype(stateTyFromImpl((AsTuple*)0));
 
-template <typename Item, typename... Items>
-static constexpr bool belongsToImpl(std::tuple<Items...>*) {
+template<typename Item, typename... Items> static constexpr bool belongsToImpl(std::tuple<Items...>*)
+{
   return (std::is_same_v<Item, Items> || ...);
 };
 
 /// \private Checks if \p Mode is member of \p AllModes as tuple
-template <typename Mode, typename AllModes>
-static constexpr bool ModeBelongsTo = belongsToImpl<Mode>((AllModes*) 0);
+template<typename Mode, typename AllModes> static constexpr bool ModeBelongsTo = belongsToImpl<Mode>((AllModes*)0);
 
 /// \private Checks if \p Group is member of \p AllGroups as tuple
-template <typename Group, typename AllGroups>
-static constexpr bool GroupBelongsTo = belongsToImpl<Group>((AllGroups*) 0);
+template<typename Group, typename AllGroups> static constexpr bool GroupBelongsTo = belongsToImpl<Group>((AllGroups*)0);
 
-template <typename Mode, typename AllGroups>
-static constexpr bool testIfModeExistsImpl() {
-  constexpr uint8_t NbGroups{std::tuple_size_v<AllGroups>};
+template<typename Mode, typename AllGroups> static constexpr bool testIfModeExistsImpl()
+{
+  constexpr uint8_t NbGroups {std::tuple_size_v<AllGroups>};
 
   bool acc = false;
   unroll<NbGroups>([&](auto Idx) {
@@ -176,14 +179,12 @@ static constexpr bool testIfModeExistsImpl() {
 }
 
 /// \private Checks if \p Mode exists in the set of \p AllGroups
-template <typename Mode, typename AllGroups>
-static constexpr bool ModeExists = testIfModeExistsImpl<Mode, AllGroups>();
+template<typename Mode, typename AllGroups> static constexpr bool ModeExists = testIfModeExistsImpl<Mode, AllGroups>();
 
 } // namespace details
 
 /// \private see details::StateTyOf
-template <typename Mode>
-using StateTyOf = details::StateTyOf<Mode>;
+template<typename Mode> using StateTyOf = details::StateTyOf<Mode>;
 
 } // namespace modes
 

--- a/src/modes/legacy/legacy_modes.hpp
+++ b/src/modes/legacy/legacy_modes.hpp
@@ -15,8 +15,7 @@
 namespace modes::legacy {
 
 /// Just a way to highlight which modes still uses src/system
-using LegacyMode = FullMode;
-using LegacySimpleMode = BasicMode;
+using LegacyMode = BasicMode;
 
 //
 // legacy calm modes
@@ -28,13 +27,11 @@ namespace calm {
 struct RainbowSwirlMode : public LegacyMode {
   static void loop(auto& ctx) {
     auto& state = ctx.state;
-    animations::fill(state.rainbowSwirl, ctx.strip);
+    animations::fill(state.rainbowSwirl, ctx.lamp.getLegacyStrip());
     state.rainbowSwirl.update();
   }
 
-  static void reset(auto& ctx) {
-    ctx.state.rainbowSwirl.reset();
-  }
+  static void reset(auto& ctx) { ctx.state.rainbowSwirl.reset(); }
 
   struct StateTy {
     GenerateRainbowSwirl rainbowSwirl = GenerateRainbowSwirl(5000);
@@ -45,8 +42,7 @@ struct RainbowSwirlMode : public LegacyMode {
 struct PartyFadeMode : public LegacyMode {
   static void loop(auto& ctx) {
     auto& state = ctx.state;
-    state.isFinished = animations::fade_in(
-      state.palettePartyColor, 100, state.isFinished, ctx.strip);
+    state.isFinished = animations::fade_in(state.palettePartyColor, 100, state.isFinished, ctx.lamp.getLegacyStrip());
 
     if (state.isFinished) {
       state.palettePartyColor.update(++state.currentIndex);
@@ -71,15 +67,15 @@ struct PartyFadeMode : public LegacyMode {
  * Inherit from `NoiseMode<YourMode>`
  *  - this enable all derived `StateTy` to be unique
  */
-template <typename T>
-struct NoiseMode : public LegacyMode {
-  static void reset(auto& ctx) {
-    ctx.state.categoryChange = true;
-  }
+template<typename T> struct NoiseMode : public LegacyMode
+{
+  static void reset(auto& ctx) { ctx.state.categoryChange = true; }
 
-  struct StateTy {
-    void random_noise(auto& strip, const palette_t& palette) {
-      animations::random_noise(palette, strip, categoryChange, true, 3);
+  struct StateTy
+  {
+    void random_noise(auto& lamp, const palette_t& palette)
+    {
+      animations::random_noise(palette, lamp.getLegacyStrip(), categoryChange, true, 3);
       categoryChange = false;
     }
 
@@ -88,32 +84,28 @@ struct NoiseMode : public LegacyMode {
 };
 
 /// Noise from PaletteLavaColors
-struct LavaNoiseMode : public NoiseMode<LavaNoiseMode> {
-  static void loop(auto& ctx) {
-    ctx.state.random_noise(ctx.strip, PaletteLavaColors);
-  }
+struct LavaNoiseMode : public NoiseMode<LavaNoiseMode>
+{
+  static void loop(auto& ctx) { ctx.state.random_noise(ctx.lamp, PaletteLavaColors); }
 };
 
 /// Noise from PaletteForestColors
-struct ForestNoiseMode : public NoiseMode<ForestNoiseMode> {
-  static void loop(auto& ctx) {
-    ctx.state.random_noise(ctx.strip, PaletteForestColors);
-  }
+struct ForestNoiseMode : public NoiseMode<ForestNoiseMode>
+{
+  static void loop(auto& ctx) { ctx.state.random_noise(ctx.lamp, PaletteForestColors); }
 };
 
 /// Noise from PaletteOceanColors
-struct OceanNoiseMode : public NoiseMode<OceanNoiseMode> {
-  static void loop(auto& ctx) {
-    ctx.state.random_noise(ctx.strip, PaletteOceanColors);
-  }
+struct OceanNoiseMode : public NoiseMode<OceanNoiseMode>
+{
+  static void loop(auto& ctx) { ctx.state.random_noise(ctx.lamp, PaletteOceanColors); }
 };
 
 /// Polar lights
 struct PolarMode : public LegacyMode {
   static void loop(auto& ctx) {
     auto& categoryChange = ctx.state.categoryChange;
-    animations::mode_2DPolarLights(
-      255, 128, PaletteAuroraColors, categoryChange, ctx.strip);
+    animations::mode_2DPolarLights(255, 128, PaletteAuroraColors, categoryChange, ctx.lamp.getLegacyStrip());
     categoryChange = false;
   }
 
@@ -127,31 +119,27 @@ struct PolarMode : public LegacyMode {
 };
 
 /// Fireplace
-struct FireMode : public LegacySimpleMode {
-  static void loop(auto& strip) {
-    animations::fire(60, 60, 255, PaletteHeatColors, strip);
-  }
+struct FireMode : public LegacyMode
+{
+  static void loop(auto& ctx) { animations::fire(60, 60, 255, PaletteHeatColors, ctx.lamp.getLegacyStrip()); }
 };
 
 /// Rainbow sin waves
-struct SineMode : public LegacySimpleMode {
-  static void loop(auto& strip) {
-    animations::mode_sinewave(128, 128, PaletteRainbowColors, strip);
-  }
+struct SineMode : public LegacyMode
+{
+  static void loop(auto& ctx) { animations::mode_sinewave(128, 128, PaletteRainbowColors, ctx.lamp.getLegacyStrip()); }
 };
 
 /// Bubbles
-struct DriftMode : public LegacySimpleMode {
-  static void loop(auto& strip) {
-    animations::mode_2DDrift(64, 64, PaletteRainbowColors, strip);
-  }
+struct DriftMode : public LegacyMode
+{
+  static void loop(auto& ctx) { animations::mode_2DDrift(64, 64, PaletteRainbowColors, ctx.lamp.getLegacyStrip()); }
 };
 
 /// Distortion
-struct DistMode : public LegacySimpleMode {
-  static void loop(auto& strip) {
-    animations::mode_2Ddistortionwaves(128, 128, strip);
-  }
+struct DistMode : public LegacyMode
+{
+  static void loop(auto& ctx) { animations::mode_2Ddistortionwaves(128, 128, ctx.lamp.getLegacyStrip()); }
 };
 
 } // modes::legacy::calm
@@ -166,11 +154,12 @@ namespace party {
 struct ColorWipeMode : public LegacyMode {
   static void loop(auto& ctx) {
     auto& state = ctx.state;
-    state.isFinished = state.switchMode ? (
-        animations::color_wipe_up(state.complementaryColor, 500, state.isFinished, ctx.strip)
-      ) : (
-        animations::color_wipe_down(state.complementaryColor, 500, state.isFinished, ctx.strip)
-      );
+    auto& legacyStrip = ctx.lamp.getLegacyStrip();
+
+    state.isFinished =
+            state.switchMode ?
+                    (animations::color_wipe_up(state.complementaryColor, 500, state.isFinished, legacyStrip)) :
+                    (animations::color_wipe_down(state.complementaryColor, 500, state.isFinished, legacyStrip));
 
     if (state.isFinished) {
       state.switchMode = !state.switchMode;
@@ -193,8 +182,8 @@ struct ColorWipeMode : public LegacyMode {
 struct RandomFillMode : public LegacyMode {
   static void loop(auto& ctx) {
     auto& state = ctx.state;
-    state.isFinished = animations::double_side_fill(
-      state.randomColor, 500, state.isFinished, ctx.strip);
+    state.isFinished =
+            animations::double_side_fill(state.randomColor, 500, state.isFinished, ctx.lamp.getLegacyStrip());
 
     if (state.isFinished) {
       state.randomColor.update();
@@ -216,7 +205,7 @@ struct PingPongMode : public LegacyMode {
   static void loop(auto& ctx) {
     auto& state = ctx.state;
     state.isFinished = animations::dot_ping_pong(
-      state.complementaryPingPongColor, 1000, 128, state.isFinished, ctx.strip);
+            state.complementaryPingPongColor, 1000, 128, state.isFinished, ctx.lamp.getLegacyStrip());
 
     if (state.isFinished) {
       state.complementaryPingPongColor.update();
@@ -239,7 +228,7 @@ namespace sound {
 struct VuMeterMode : public LegacyMode {
   static void loop(auto& ctx) {
     auto& state = ctx.state;
-    animations::vu_meter(state.redToGreenGradient, 128, ctx.strip);
+    animations::vu_meter(state.redToGreenGradient, 128, ctx.lamp.getLegacyStrip());
   }
 
   static void reset(auto& ctx) {
@@ -254,10 +243,9 @@ struct VuMeterMode : public LegacyMode {
   };
 };
 
-struct FftMode : public LegacyMode {
-  static void loop(auto& ctx) {
-    animations::fft_display(64, 64, PalettePartyColors, ctx.strip);
-  }
+struct FftMode : public LegacyMode
+{
+  static void loop(auto& ctx) { animations::fft_display(64, 64, PalettePartyColors, ctx.lamp.getLegacyStrip()); }
 
   static void reset(auto& ctx) {}
 

--- a/src/modes/legacy/legacy_modes.hpp
+++ b/src/modes/legacy/legacy_modes.hpp
@@ -24,8 +24,10 @@ using LegacyMode = BasicMode;
 namespace calm {
 
 /// Do a rainbow swirl!
-struct RainbowSwirlMode : public LegacyMode {
-  static void loop(auto& ctx) {
+struct RainbowSwirlMode : public LegacyMode
+{
+  static void loop(auto& ctx)
+  {
     auto& state = ctx.state;
     animations::fill(state.rainbowSwirl, ctx.lamp.getLegacyStrip());
     state.rainbowSwirl.update();
@@ -33,29 +35,35 @@ struct RainbowSwirlMode : public LegacyMode {
 
   static void reset(auto& ctx) { ctx.state.rainbowSwirl.reset(); }
 
-  struct StateTy {
+  struct StateTy
+  {
     GenerateRainbowSwirl rainbowSwirl = GenerateRainbowSwirl(5000);
   };
 };
 
 /// Fade slowly between PalettePartyColors
-struct PartyFadeMode : public LegacyMode {
-  static void loop(auto& ctx) {
+struct PartyFadeMode : public LegacyMode
+{
+  static void loop(auto& ctx)
+  {
     auto& state = ctx.state;
     state.isFinished = animations::fade_in(state.palettePartyColor, 100, state.isFinished, ctx.lamp.getLegacyStrip());
 
-    if (state.isFinished) {
+    if (state.isFinished)
+    {
       state.palettePartyColor.update(++state.currentIndex);
     }
   }
 
-  static void reset(auto& ctx) {
+  static void reset(auto& ctx)
+  {
     auto& state = ctx.state;
     state.currentIndex = 0;
     state.palettePartyColor.reset();
   }
 
-  struct StateTy {
+  struct StateTy
+  {
     GeneratePaletteIndexed palettePartyColor = GeneratePaletteIndexed(PalettePartyColors);
     uint8_t currentIndex = 0;
     bool isFinished = false;
@@ -102,18 +110,19 @@ struct OceanNoiseMode : public NoiseMode<OceanNoiseMode>
 };
 
 /// Polar lights
-struct PolarMode : public LegacyMode {
-  static void loop(auto& ctx) {
+struct PolarMode : public LegacyMode
+{
+  static void loop(auto& ctx)
+  {
     auto& categoryChange = ctx.state.categoryChange;
     animations::mode_2DPolarLights(255, 128, PaletteAuroraColors, categoryChange, ctx.lamp.getLegacyStrip());
     categoryChange = false;
   }
 
-  static void reset(auto& ctx) {
-    ctx.state.categoryChange = true;
-  }
+  static void reset(auto& ctx) { ctx.state.categoryChange = true; }
 
-  struct StateTy {
+  struct StateTy
+  {
     bool categoryChange = false;
   };
 };
@@ -142,7 +151,7 @@ struct DistMode : public LegacyMode
   static void loop(auto& ctx) { animations::mode_2Ddistortionwaves(128, 128, ctx.lamp.getLegacyStrip()); }
 };
 
-} // modes::legacy::calm
+} // namespace calm
 
 //
 // legacy party modes
@@ -151,8 +160,10 @@ struct DistMode : public LegacyMode
 namespace party {
 
 /// Wipe up and down complementary colors
-struct ColorWipeMode : public LegacyMode {
-  static void loop(auto& ctx) {
+struct ColorWipeMode : public LegacyMode
+{
+  static void loop(auto& ctx)
+  {
     auto& state = ctx.state;
     auto& legacyStrip = ctx.lamp.getLegacyStrip();
 
@@ -161,17 +172,17 @@ struct ColorWipeMode : public LegacyMode {
                     (animations::color_wipe_up(state.complementaryColor, 500, state.isFinished, legacyStrip)) :
                     (animations::color_wipe_down(state.complementaryColor, 500, state.isFinished, legacyStrip));
 
-    if (state.isFinished) {
+    if (state.isFinished)
+    {
       state.switchMode = !state.switchMode;
       state.complementaryColor.update();
     }
   }
 
-  static void reset(auto& ctx) {
-    ctx.state.complementaryColor.reset();
-  }
+  static void reset(auto& ctx) { ctx.state.complementaryColor.reset(); }
 
-  struct StateTy {
+  struct StateTy
+  {
     GenerateComplementaryColor complementaryColor = GenerateComplementaryColor(0.3);
     bool switchMode = false;
     bool isFinished = false;
@@ -179,67 +190,75 @@ struct ColorWipeMode : public LegacyMode {
 };
 
 /// Animated random color fill from each side
-struct RandomFillMode : public LegacyMode {
-  static void loop(auto& ctx) {
+struct RandomFillMode : public LegacyMode
+{
+  static void loop(auto& ctx)
+  {
     auto& state = ctx.state;
     state.isFinished =
             animations::double_side_fill(state.randomColor, 500, state.isFinished, ctx.lamp.getLegacyStrip());
 
-    if (state.isFinished) {
+    if (state.isFinished)
+    {
       state.randomColor.update();
     }
   }
 
-  static void reset(auto& ctx) {
-    ctx.state.randomColor.reset();
-  }
+  static void reset(auto& ctx) { ctx.state.randomColor.reset(); }
 
-  struct StateTy {
+  struct StateTy
+  {
     GenerateRandomColor randomColor = GenerateRandomColor();
     bool isFinished = false;
   };
 };
 
 /// Animated back-and-forth with random complementary color
-struct PingPongMode : public LegacyMode {
-  static void loop(auto& ctx) {
+struct PingPongMode : public LegacyMode
+{
+  static void loop(auto& ctx)
+  {
     auto& state = ctx.state;
     state.isFinished = animations::dot_ping_pong(
             state.complementaryPingPongColor, 1000, 128, state.isFinished, ctx.lamp.getLegacyStrip());
 
-    if (state.isFinished) {
+    if (state.isFinished)
+    {
       state.complementaryPingPongColor.update();
     }
   }
 
   static void reset(auto& ctx) { ctx.state.complementaryPingPongColor.reset(); }
 
-  struct StateTy {
-    GenerateComplementaryColor complementaryPingPongColor =
-        GenerateComplementaryColor(0.4);
+  struct StateTy
+  {
+    GenerateComplementaryColor complementaryPingPongColor = GenerateComplementaryColor(0.4);
     bool isFinished = false;
   };
 };
 
-}  // namespace party
+} // namespace party
 
 namespace sound {
 
-struct VuMeterMode : public LegacyMode {
-  static void loop(auto& ctx) {
+struct VuMeterMode : public LegacyMode
+{
+  static void loop(auto& ctx)
+  {
     auto& state = ctx.state;
     animations::vu_meter(state.redToGreenGradient, 128, ctx.lamp.getLegacyStrip());
   }
 
-  static void reset(auto& ctx) {
+  static void reset(auto& ctx)
+  {
     auto& state = ctx.state;
     state.redToGreenGradient.reset();
   }
 
-  struct StateTy {
+  struct StateTy
+  {
     GenerateGradientColor redToGreenGradient = GenerateGradientColor(
-        LedStrip::Color(0, 255, 0),
-        LedStrip::Color(255, 0, 0));  // gradient from red to green};
+            LedStrip::Color(0, 255, 0), LedStrip::Color(255, 0, 0)); // gradient from red to green};
   };
 };
 
@@ -249,39 +268,32 @@ struct FftMode : public LegacyMode
 
   static void reset(auto& ctx) {}
 
-  struct StateTy {};
+  struct StateTy
+  {
+  };
 };
 
-}  // namespace sound
+} // namespace sound
 
 //
 // Legacy modes groups
 //
 
-using CalmModes = modes::GroupFor<
-  calm::RainbowSwirlMode,
-  calm::PartyFadeMode,
-  calm::LavaNoiseMode,
-  calm::ForestNoiseMode,
-  calm::OceanNoiseMode,
-  calm::PolarMode,
-  calm::FireMode,
-  calm::SineMode,
-  calm::DriftMode,
-  calm::DistMode
->;
+using CalmModes = modes::GroupFor<calm::RainbowSwirlMode,
+                                  calm::PartyFadeMode,
+                                  calm::LavaNoiseMode,
+                                  calm::ForestNoiseMode,
+                                  calm::OceanNoiseMode,
+                                  calm::PolarMode,
+                                  calm::FireMode,
+                                  calm::SineMode,
+                                  calm::DriftMode,
+                                  calm::DistMode>;
 
-using PartyModes = modes::GroupFor<
-  party::ColorWipeMode,
-  party::RandomFillMode,
-  party::PingPongMode
->;
+using PartyModes = modes::GroupFor<party::ColorWipeMode, party::RandomFillMode, party::PingPongMode>;
 
-using SoundModes = modes::GroupFor<
-  sound::VuMeterMode,
-  sound::FftMode
->;
+using SoundModes = modes::GroupFor<sound::VuMeterMode, sound::FftMode>;
 
-} // modes::legacy
+} // namespace modes::legacy
 
 #endif

--- a/src/modes/user/indexable_behavior.hpp
+++ b/src/modes/user/indexable_behavior.hpp
@@ -14,11 +14,8 @@ void power_on_sequence() {
   pinMode(LED_POWER_PIN, OUTPUT);
   digitalWrite(LED_POWER_PIN, HIGH);
 
-  // initialize the strip object
-  manager.strip.begin();
-  manager.strip.clear();
-  manager.strip.show();  // Turn OFF all pixels ASAP
-  manager.strip.setBrightness(BRIGHTNESS);
+  // initialize the lamp object
+  manager.lamp.startup();
 
   // callbacks
   manager.power_on_sequence();
@@ -30,9 +27,9 @@ void power_off_sequence() {
   auto manager = get_context();
   manager.power_off_sequence();
 
-  // clean strip object
-  manager.strip.clear();
-  manager.strip.show();  // Clear all pixels
+  // clear lamp on power-off
+  manager.lamp.clear();
+  manager.lamp.show();
 
   // power off
   digitalWrite(LED_POWER_PIN, LOW);
@@ -48,8 +45,8 @@ void power_off_sequence() {
 void brightness_update(const uint8_t brightness) {
   auto manager = get_context();
 
-  // set brightness in strip object
-  manager.strip.setBrightness(brightness);
+  // set brightness for underlying object (w/o re-entry in update_brightness)
+  manager.lamp.setBrightness(brightness, true, true);
 
   // callbacks
   manager.brightness_update(brightness);
@@ -208,7 +205,7 @@ bool should_spawn_thread() {
 
 void user_thread() {
   auto manager = get_context();
-  manager.strip.show();
+  manager.lamp.show();
 
   if (manager.should_spawn_thread()) {
     manager.user_thread();

--- a/src/modes/user/indexable_behavior.hpp
+++ b/src/modes/user/indexable_behavior.hpp
@@ -7,7 +7,8 @@
 //  - simulator/src/mode-simulator.cpp
 //
 
-void power_on_sequence() {
+void power_on_sequence()
+{
   auto manager = get_context();
 
   // power on
@@ -21,8 +22,8 @@ void power_on_sequence() {
   manager.power_on_sequence();
 }
 
-void power_off_sequence() {
-
+void power_off_sequence()
+{
   // callbacks
   auto manager = get_context();
   manager.power_off_sequence();
@@ -42,7 +43,8 @@ void power_off_sequence() {
   ensure_build_canary();
 }
 
-void brightness_update(const uint8_t brightness) {
+void brightness_update(const uint8_t brightness)
+{
   auto manager = get_context();
 
   // set brightness for underlying object (w/o re-entry in update_brightness)
@@ -52,21 +54,25 @@ void brightness_update(const uint8_t brightness) {
   manager.brightness_update(brightness);
 }
 
-void write_parameters() {
+void write_parameters()
+{
   auto manager = get_context();
   manager.write_parameters();
 }
 
-void read_parameters() {
+void read_parameters()
+{
   auto manager = get_context();
   manager.read_parameters();
   manager.reset_mode();
 }
 
-void button_clicked_default(const uint8_t clicks) {
+void button_clicked_default(const uint8_t clicks)
+{
   auto manager = get_context();
 
-  switch (clicks) {
+  switch (clicks)
+  {
     case 2: // 2 clicks: next mode
       manager.next_mode();
       break;
@@ -81,97 +87,103 @@ void button_clicked_default(const uint8_t clicks) {
   }
 
 #ifdef LMBD_SIMU_ENABLED
-  fprintf(stderr, "group %d *mode %d\n",
-    manager.get_active_group(),
-    manager.get_active_mode());
+  fprintf(stderr, "group %d *mode %d\n", manager.get_active_group(), manager.get_active_mode());
 #endif
 }
 
-void button_hold_default(const uint8_t clicks,
-                         const bool isEndOfHoldEvent,
-                         const uint32_t holdDuration) {
+void button_hold_default(const uint8_t clicks, const bool isEndOfHoldEvent, const uint32_t holdDuration)
+{
   auto manager = get_context();
   auto& rampHandler = manager.state.rampHandler;
   auto& scrollHandler = manager.state.scrollHandler;
 
-  switch (clicks) {
+  switch (clicks)
+  {
     case 3: // 3 click+hold: configure custom ramp
-      rampHandler.update_ramp(
-        manager.get_active_custom_ramp(), holdDuration,
-        [&](uint8_t rampValue) {
-          manager.custom_ramp_update(rampValue);
-          manager.set_active_custom_ramp(rampValue);
-        });
+      rampHandler.update_ramp(manager.get_active_custom_ramp(), holdDuration, [&](uint8_t rampValue) {
+        manager.custom_ramp_update(rampValue);
+        manager.set_active_custom_ramp(rampValue);
+      });
       break;
 
     case 4: // 4 click+hold: scroll across modes and group
-      scrollHandler.update_ramp(128, holdDuration,
-        [&](uint8_t rampValue) {
-          uint8_t modeIndex = manager.get_active_mode();
-          uint8_t groupIndex = manager.get_active_group();
-          uint8_t modeCount = manager.get_modes_count();
-          uint8_t groupCount = manager.get_groups_count();
+      scrollHandler.update_ramp(128, holdDuration, [&](uint8_t rampValue) {
+        uint8_t modeIndex = manager.get_active_mode();
+        uint8_t groupIndex = manager.get_active_group();
+        uint8_t modeCount = manager.get_modes_count();
+        uint8_t groupCount = manager.get_groups_count();
 
-          // we are going backward
-          //
-          if (rampValue < 128) {
-
-            // if modeIndex is not the first, just decrement it
-            if (modeIndex > 0) {
-              manager.set_active_mode(modeIndex - 1, modeCount);
-              manager.reset_mode();
+        // we are going backward
+        //
+        if (rampValue < 128)
+        {
+          // if modeIndex is not the first, just decrement it
+          if (modeIndex > 0)
+          {
+            manager.set_active_mode(modeIndex - 1, modeCount);
+            manager.reset_mode();
 
             // or else decrement group, then set mode to last one
-            } else {
-
-              // if groupIndex is not the first, just decrement it
-              if (groupIndex > 0) {
-                manager.set_active_group(groupIndex - 1, groupCount);
+          }
+          else
+          {
+            // if groupIndex is not the first, just decrement it
+            if (groupIndex > 0)
+            {
+              manager.set_active_group(groupIndex - 1, groupCount);
 
               // else wrap to last group
-              } else {
-                manager.set_active_group(groupCount - 1, groupCount);
-              }
-
-              // backward scroll: set mode to last one on group change
-              modeCount = manager.get_modes_count();
-              manager.set_active_mode(modeCount - 1, modeCount);
-              manager.reset_mode();
             }
+            else
+            {
+              manager.set_active_group(groupCount - 1, groupCount);
+            }
+
+            // backward scroll: set mode to last one on group change
+            modeCount = manager.get_modes_count();
+            manager.set_active_mode(modeCount - 1, modeCount);
+            manager.reset_mode();
+          }
 
           // we are going forward
           //
-          } else {
-
-            // if modeIndex is not the last, just increment it
-            if (modeIndex + 1 < modeCount) {
-              manager.next_mode();
+        }
+        else
+        {
+          // if modeIndex is not the last, just increment it
+          if (modeIndex + 1 < modeCount)
+          {
+            manager.next_mode();
 
             // or else increment group
-            } else {
-
-              // if groupIndex is not the last, just increment it
-              if (groupIndex + 1 < groupCount) {
-                manager.next_group();
+          }
+          else
+          {
+            // if groupIndex is not the last, just increment it
+            if (groupIndex + 1 < groupCount)
+            {
+              manager.next_group();
 
               // else wrap to first group
-              } else {
-                manager.set_active_group(0, groupCount);
-              }
-
-              // forward scroll: set mode to first one on group change
-              manager.set_active_mode(0, modeCount);
-              manager.reset_mode();
             }
-          }
+            else
+            {
+              manager.set_active_group(0, groupCount);
+            }
 
-        });
+            // forward scroll: set mode to first one on group change
+            manager.set_active_mode(0, modeCount);
+            manager.reset_mode();
+          }
+        }
+      });
       break;
 
     case 5: // 5 click+hold: configure favorite
 
       // TODO: add button animation to help know when favorite is set
-      if (holdDuration > 2000) {
+      if (holdDuration > 2000)
+      {
         manager.set_favorite_now();
       }
 
@@ -182,32 +194,33 @@ void button_hold_default(const uint8_t clicks,
   }
 }
 
-bool button_clicked_usermode(const uint8_t clicks) {
+bool button_clicked_usermode(const uint8_t clicks)
+{
   auto manager = get_context();
   return manager.custom_click(clicks);
 }
 
-bool button_hold_usermode(const uint8_t clicks,
-                          const bool isEndOfHoldEvent,
-                          const uint32_t holdDuration) {
+bool button_hold_usermode(const uint8_t clicks, const bool isEndOfHoldEvent, const uint32_t holdDuration)
+{
   auto manager = get_context();
   return manager.custom_hold(clicks, isEndOfHoldEvent, holdDuration);
 }
 
-void loop() {
+void loop()
+{
   auto manager = get_context();
   manager.loop();
 }
 
-bool should_spawn_thread() {
-  return true;
-}
+bool should_spawn_thread() { return true; }
 
-void user_thread() {
+void user_thread()
+{
   auto manager = get_context();
   manager.lamp.show();
 
-  if (manager.should_spawn_thread()) {
+  if (manager.should_spawn_thread())
+  {
     manager.user_thread();
   }
 }

--- a/src/system/behavior.h
+++ b/src/system/behavior.h
@@ -1,7 +1,8 @@
 #ifndef BEHAVIOR_HPP
 #define BEHAVIOR_HPP
 
-/** \file behavior.h
+/** \file
+ *
  *  \brief Basic controller behavior, including alerts and user interactions
  **/
 

--- a/src/user/functions.h
+++ b/src/user/functions.h
@@ -1,7 +1,8 @@
 #ifndef USER_FUNCTIONS_H
 #define USER_FUNCTIONS_H
 
-/** \file functions.h
+/** \file
+ *
  *  \brief Custom user mode functions for indexable strips
  **/
 

--- a/src/user/indexable_functions.cpp
+++ b/src/user/indexable_functions.cpp
@@ -36,7 +36,8 @@ using ManagerTy = modes::ManagerFor<modes::FixedModes,
 namespace _private {
 
 LedStrip strip(AD0);
-ManagerTy modeManager(strip);
+modes::hardware::LampTy lamp {strip};
+ManagerTy modeManager(lamp);
 
 } // namespace _private
 


### PR DESCRIPTION
The aim of this PR is to:

1. start having a clear separation on the hardware (how the lamp works) and the software (what modes do)
2. have a "lamp" object that can be used by any lamp type (with infrastructure to support both simple/cct/indexable)
3. be able at some point to use the same `src/modes/` codebase for the all the lamp types transparently

Other things done and mixed within this PR:

1. removing `simpleMode` boolean as distinction is made less useful by `LampTy`
2. formatting the rest of the codebase & adding an optional `pre-commit` hook
4. adjusting some documentation bugs

The main novelty is `LampTy` and is documented as follows:
![2024-11-22_16-52](https://github.com/user-attachments/assets/adb1da37-5cd8-411d-bbb8-84f6f3863e15)
![2024-11-22_16-54](https://github.com/user-attachments/assets/b5095247-e374-49c0-b371-d3961869e4e4)
![2024-11-22_17-00](https://github.com/user-attachments/assets/0fd33bc6-54b6-4896-a59d-ffcd06c5532e)

Where the `(indexable)` methods do nothing on release build for simple/cct — but assert fail on debug simulator

The idea is to be able, at some point, write modes without using anything from `src/system` and without relying on how the hardware is build, letting the (experienced) developer specify how his hardware works inside `src/modes/hardware`

Also, I would like at some point, be able to have all the simple/cct modes, work as-is in indexable