### PR TITLE
Minor charger improvements

### DIFF
--- a/src/system/alerts.h
+++ b/src/system/alerts.h
@@ -20,6 +20,8 @@ enum Alerts
   TEMP_CRITICAL = 1 << 6,               // Processor temperature is critical
 
   BLUETOOTH_ADVERT = 1 << 7, // bluetooth is advertising
+
+  HARDWARE_ALERT = 1 << 8, // any hardware alert
 };
 
 class Alert

--- a/src/system/behavior.cpp
+++ b/src/system/behavior.cpp
@@ -44,6 +44,9 @@ bool isBluetoothAdvertising = false;
 uint8_t BRIGHTNESS = 50; // default start value
 uint8_t currentBrightness = 50;
 
+// timestamp of the system wake up
+static uint32_t turnOnTime = millis();
+
 void update_brightness(const uint8_t newBrightness, const bool shouldUpdateCurrentBrightness, const bool isInitialRead)
 {
   // safety
@@ -418,7 +421,8 @@ void button_hold_callback(const uint8_t consecutiveButtonCheck, const uint32_t b
 
 void handle_alerts()
 {
-  const uint32_t current = AlertManager.current();
+  // do not display alerts for the first 500 ms
+  const uint32_t current = ((millis() - turnOnTime) < 500) ? Alerts::NONE : AlertManager.current();
 
   static uint32_t criticalbatteryRaisedTime = 0;
   if (current == Alerts::NONE)

--- a/src/system/behavior.cpp
+++ b/src/system/behavior.cpp
@@ -435,7 +435,9 @@ void handle_alerts()
     const auto& chargerStatus = charger::get_state();
     if (chargerStatus.is_charging())
     {
-      if (chargerStatus.status == charger::Charger_t::ChargerStatus_t::SLOW_CHARGING)
+      // power detected with no charge or slow charging raises a special animation
+      if (chargerStatus.status == charger::Charger_t::ChargerStatus_t::POWER_DETECTED or
+          chargerStatus.status == charger::Charger_t::ChargerStatus_t::SLOW_CHARGING)
       {
         // fast blinking
         // TODO: find a better way to tell user that the chargeur is bad
@@ -459,6 +461,10 @@ void handle_alerts()
     {
       // shutdown when battery is critical
       shutdown();
+    }
+    else if ((current & Alerts::HARDWARE_ALERT) != 0x00)
+    {
+      button::blink(100, 50, utils::ColorSpace::TOMATO);
     }
     else if ((current & Alerts::TEMP_TOO_HIGH) != 0x00)
     {

--- a/src/system/charger/BQ25703A/charging_ic.cpp
+++ b/src/system/charger/BQ25703A/charging_ic.cpp
@@ -139,14 +139,7 @@ void update_battery()
   const bool isInputSourcePresent = is_input_source_present();
 
   // charger is present (consider only charging current)
-  if (isInputSourcePresent)
-  {
-    battery_s.current_mA = chargingCurrent;
-  }
-  else
-  {
-    battery_s.current_mA = -measurments_s.batDischargeCurrent_mA;
-  }
+  battery_s.current_mA = (int16_t)chargingCurrent - (int16_t)measurments_s.batDischargeCurrent_mA;
 
   // output voltage saturated, battery is not here
   battery_s.isPresent = battery_s.voltage_mV < BQ25703Areg.maxChargeVoltage.get();
@@ -157,7 +150,7 @@ void update_battery()
     chargeStatus_s = ChargeStatus_t::OFF;
   }
   //
-  else if (chargingCurrent < powerLimits_s.maxChargingCurrent_mA * 0.1)
+  else if (chargingCurrent <= powerLimits_s.maxChargingCurrent_mA * 0.1)
   {
     chargeStatus_s = ChargeStatus_t::SLOW_CHARGE;
   }

--- a/src/system/charger/charger.h
+++ b/src/system/charger/charger.h
@@ -14,6 +14,9 @@ void loop();
 // call when the system will shutdown
 void shutdown();
 
+// debug feature: disable the charging process
+void set_enable_charge(const bool shouldCharge);
+
 struct Charger_t
 {
   // everything below makes no sense if this is false

--- a/src/system/charger/power_source.cpp
+++ b/src/system/charger/power_source.cpp
@@ -83,7 +83,8 @@ uint16_t get_max_input_current()
       if (can_use_PD_full_power())
       {
         // resolution of 10 mA
-        return PD_UFP.get_current() * 10;
+        // do not use the whole current capabilities, or the source will cut us off
+        return (PD_UFP.get_current() * 10) * 0.90;
       }
     }
     else

--- a/src/system/utils/serial.cpp
+++ b/src/system/utils/serial.cpp
@@ -29,32 +29,17 @@ void handleCommand(const String& command)
       Serial.println("v: hardware & software version");
       Serial.println("bl: battery level");
       Serial.println("vbus: USB voltage bus infos");
+      Serial.println("cinfo: charge infos");
+      Serial.println("ADC: all values from the ADC");
+      Serial.println("cen: enable charger. Debug only");
+      Serial.println("cdis: disable charger. Debug only !");
       Serial.println("format-fs: format the whole file system (dangerous)");
+      Serial.println("format-fs: format the whole file system (dangerous)");
+      Serial.println("-----------------");
       Serial.println("-----------------");
       break;
 
-    case utils::hash("v"):
-    case utils::hash("V"):
-    case utils::hash("version"):
-      Serial.print("hardware:");
-      Serial.println(HARDWARE_VERSION);
-      Serial.print("base software:");
-      Serial.println(BASE_SOFTWARE_VERSION);
-      Serial.print("user software:");
-      Serial.println(SOFTWARE_VERSION);
-      break;
-
-    case utils::hash("bl"):
-    case utils::hash("battery"):
-      Serial.print("raw battery level:");
-      Serial.print(battery::get_raw_battery_level() / 100.0);
-      Serial.println("%");
-      Serial.print("battery level:");
-      Serial.print(battery::get_battery_level() / 100.0);
-      Serial.println("%");
-      break;
-
-    case utils::hash("vbus"):
+    case utils::hash("cinfo"):
       {
         const auto& chargerState = charger::get_state();
         Serial.print("voltage on vbus:");
@@ -77,6 +62,37 @@ void handleCommand(const String& command)
         Serial.print(battery::get_battery_level() / 100.0);
         Serial.println("%");
         Serial.println(chargerState.get_status_str());
+        break;
+      }
+
+    case utils::hash("cen"):
+      Serial.println("Enabling the charging process");
+      charger::set_enable_charge(true);
+      break;
+
+    case utils::hash("cdis"):
+      Serial.println("Disabling the charging process");
+      charger::set_enable_charge(false);
+      break;
+
+    case utils::hash("ADC"):
+      {
+        const auto& chargerState = charger::get_state();
+        Serial.print("VBUS voltage: ");
+        Serial.print(chargerState.vbus_mV);
+        Serial.println("mV");
+
+        Serial.print("VBUS current: ");
+        Serial.print(chargerState.inputCurrent_mA);
+        Serial.println("mA");
+
+        Serial.print("Bat voltage: ");
+        Serial.print(chargerState.batteryVoltage_mV);
+        Serial.println("mV");
+
+        Serial.print("Bat current: ");
+        Serial.print(chargerState.batteryCurrent_mA);
+        Serial.println("mA");
         break;
       }
 

--- a/src/system/utils/serial.cpp
+++ b/src/system/utils/serial.cpp
@@ -34,8 +34,6 @@ void handleCommand(const String& command)
       Serial.println("cen: enable charger. Debug only");
       Serial.println("cdis: disable charger. Debug only !");
       Serial.println("format-fs: format the whole file system (dangerous)");
-      Serial.println("format-fs: format the whole file system (dangerous)");
-      Serial.println("-----------------");
       Serial.println("-----------------");
       break;
 


### PR DESCRIPTION
Minor life improvement changes on the charge & related alerts.

- Do not handle alerts for the first few milliseconds at startup
- Latch the battery state when full, to avoid display flickering
- display a slow charge status when the charger is plugged in but we use 0mA
- Add faulty hardware alert (set up when the charging component fails)