### PR TITLE
Key store manager+FileSystem.h simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 _build
 .gitignore
+.lampda.par

--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,7 @@ build: has-lamp-type process $(BUILD_DIR)/properties-${LMBD_LAMP_TYPE}.txt
 	# verifying if cached sketch objects were used...
 	@(grep -q -E ' -o [^ ]*/_build/objs/sketch/src/[^ ]*.cpp.o' $(BUILD_DIR)/verbose.txt \
 		&& echo && echo \
-		&& echo "ERROR: arduino-cli rebuilt sketch without our custom setup!" \
+		&& echo "ERROR: arduino-cli rebuilt sketch without our custom setup :(" \
 		&& echo && echo \
 	) || echo '-> everything went fine!'
 	# exporting artifacts...

--- a/simulator/include/Adafruit_LittleFS.h
+++ b/simulator/include/Adafruit_LittleFS.h
@@ -1,0 +1,8 @@
+#ifndef FAKE_LITTLEFS_H
+#define FAKE_LITTLEFS_H
+
+namespace Adafruit_LittleFS_Namespace {
+static constexpr uint8_t _placeholder_littlefs = 0;
+}
+
+#endif

--- a/simulator/include/InternalFileSystem.h
+++ b/simulator/include/InternalFileSystem.h
@@ -1,0 +1,1 @@
+// nothing to see here

--- a/simulator/include/behavior_simulator.h
+++ b/simulator/include/behavior_simulator.h
@@ -1,6 +1,8 @@
 #ifndef BEHAVIOR_SIMULATOR_H
 #define BEHAVIOR_SIMULATOR_H
 
+#include <filesystem_simulator.h>
+
 // prevent inclusion of colliding src/system/behavior.h
 #define BEHAVIOR_HPP
 
@@ -71,6 +73,7 @@ void power_on_behavior(auto& simu)
   isButtonUsermodeEnabled = false;
   fprintf(stderr, "startup\n");
 
+  fileSystem::load_initial_values();
   simu.power_on_sequence();
   simu.read_parameters();
 }
@@ -82,6 +85,7 @@ void power_off_behavior(auto& simu)
 
   simu.write_parameters();
   simu.power_off_sequence();
+  fileSystem::write_state();
 }
 
 void click_behavior(auto& simu, uint8_t consecutiveButtonCheck)

--- a/simulator/include/filesystem_simulator.h
+++ b/simulator/include/filesystem_simulator.h
@@ -1,0 +1,163 @@
+#ifndef FILESYSTEM_SIMULATOR_H
+#define FILESYSTEM_SIMULATOR_H
+
+#include <serial_simulator.h>
+
+#include <cstdio>
+#include <unistd.h>
+
+struct InternalFSTy
+{
+  bool begin()
+  {
+    // fprintf(stderr, "info: InternalFS.begin called\n");
+    return true;
+  }
+
+  void format() { fprintf(stderr, "warning: InternalFS.format called\n"); }
+};
+
+InternalFSTy InternalFS {};
+
+#define FILE_O_READ  "r+"
+#define FILE_O_WRITE "w+"
+
+struct File
+{
+  File(InternalFSTy& InternalFS) : file {nullptr}, filemode {nullptr}, InternalFS {InternalFS} {}
+
+  bool open(const char* fname, const char* mode)
+  {
+    // fprintf(stderr, "fopen: %s %s\n", fname, mode);
+
+    if (file != nullptr)
+    {
+      fprintf(stderr, "fopen: opening two files?\n");
+      filemode = nullptr;
+      fclose(file);
+    }
+
+    snprintf(filename, sizeof(filename), ".%s", fname);
+    filemode = mode;
+    file = fopen(filename, mode);
+    if (file == nullptr)
+    {
+      fprintf(stderr, "fopen: failed with %s %s\n", filename, mode);
+    }
+    return file != nullptr;
+  }
+
+  bool isOpen() { return file != nullptr; }
+
+  bool available() { return file != nullptr; }
+
+  void close()
+  {
+    if (file != nullptr)
+    {
+      fclose(file);
+      file = nullptr;
+      filemode = nullptr;
+    }
+    else
+    {
+      fprintf(stderr, "error: closing a closed file!\n");
+    }
+  }
+
+  size_t size()
+  {
+    if (file != nullptr)
+    {
+      size_t pos = ftell(file);
+      fseek(file, 0L, SEEK_END);
+      size_t size = ftell(file);
+      fseek(file, pos, SEEK_SET);
+      return size;
+    }
+
+    fprintf(stderr, "error: measuring size on a closed file!\n");
+    return 0;
+  }
+
+  size_t write(uint8_t* in, size_t sz)
+  {
+    if (file != nullptr)
+    {
+      // uncomment this to log all filesystem write
+#if 0
+      fprintf(stderr, "write: (%d) ", sz);
+      for (size_t I = 0; I < sz; ++I)
+      {
+        fprintf(stderr, "%02x", in[I]);
+      }
+      fprintf(stderr, "\n");
+#endif
+
+      return fwrite(in, sizeof(uint8_t), sz, file);
+    }
+
+    fprintf(stderr, "error: writing on a closed file!\n");
+    return 0;
+  }
+
+  size_t read(char* out, size_t sz)
+  {
+    if (file != nullptr)
+    {
+      return fread(out, sizeof(char), sz, file);
+    }
+
+    fprintf(stderr, "error: reading a closed file!\n");
+    return 0;
+  }
+
+  void truncate(uint8_t sz)
+  {
+    if (file != nullptr)
+    {
+      fclose(file);
+      file = nullptr;
+
+      if (filemode != nullptr)
+      {
+        ::truncate(filename, sz);
+      }
+      else
+      {
+        fprintf(stderr, "error: invalid truncate filename\n");
+      }
+
+      if (filemode != nullptr)
+      {
+        file = fopen(filename, filemode);
+      }
+      else
+      {
+        fprintf(stderr, "error: invalid truncate fopen\n");
+      }
+    }
+    else
+    {
+      fprintf(stderr, "error: truncate closed file\n");
+    }
+  }
+
+  operator bool() const { return file != nullptr; }
+
+  FILE* file;
+  char filename[256];
+  const char* filemode;
+  InternalFSTy& InternalFS;
+};
+
+// comment this to enable verbose filesystem debug log in simulator
+#undef LMBD_SIMU_ENABLED
+
+#include "src/system/physical/fileSystem.cpp"
+
+#ifndef LMBD_SIMU_ENABLED
+#define LMBD_SIMU_ENABLED
+#endif
+
+#endif

--- a/simulator/include/serial_simulator.h
+++ b/simulator/include/serial_simulator.h
@@ -1,0 +1,13 @@
+#ifndef SERIAL_SIMULATOR_H
+#define SERIAL_SIMULATOR_H
+
+#include <iostream>
+
+struct SerialTy
+{
+  void println(auto input) { std::cerr << "serial: " << input << std::endl; }
+};
+
+SerialTy Serial {};
+
+#endif

--- a/simulator/include/simulator.h
+++ b/simulator/include/simulator.h
@@ -29,6 +29,10 @@ using utils::map;
 
 #include "src/system/utils/coordinates.cpp"
 
+void delay(uint32_t milli) { sf::sleep(sf::milliseconds(milli)); }
+
+#include <serial_simulator.h>
+#include <filesystem_simulator.h>
 #include <behavior_simulator.h>
 
 //
@@ -276,6 +280,7 @@ template<typename T> struct simulator
 
     // start the simulation
     behavior::isShutdown = true;
+    fileSystem::setup();
     behavior::power_on_behavior(simu);
     bool shouldSpawnThread = simu.should_spawn_thread();
 
@@ -301,6 +306,7 @@ template<typename T> struct simulator
       {
         if (event.type == sf::Event::Closed)
         {
+          power_off_behavior(simu);
           window.close();
           recorder.stop();
         }

--- a/simulator/include/simulator.h
+++ b/simulator/include/simulator.h
@@ -306,7 +306,7 @@ template<typename T> struct simulator
       {
         if (event.type == sf::Event::Closed)
         {
-          power_off_behavior(simu);
+          behavior::power_off_behavior(simu);
           window.close();
           recorder.stop();
         }

--- a/src/modes/custom/my_custom_mode.hpp
+++ b/src/modes/custom/my_custom_mode.hpp
@@ -40,6 +40,6 @@ struct MyCustomMode : public modes::BasicMode
   static constexpr bool hasButtonCustomUI = false;
   static constexpr bool hasSystemCallbacks = false;
   static constexpr bool requireUserThread = false;
-}
+};
 
 #endif

--- a/src/modes/default/fixed_modes.hpp
+++ b/src/modes/default/fixed_modes.hpp
@@ -16,8 +16,11 @@ struct KelvinMode : public modes::BasicMode
 {
   static void loop(auto& ctx) { ctx.lamp.setLightTemp(ctx.get_active_custom_ramp()); }
 
-  // (force ramp to saturates, instead of wrapping ramp around)
+  // set ramp to saturates instead of wrapping around
   static void reset(auto& ctx) { ctx.template set_config_bool<ConfigKeys::rampSaturates>(true); }
+
+  // hint manager to save our custom ramp
+  static constexpr bool hasCustomRamp = true;
 };
 
 /// Rainbow fixed colors ramp mode
@@ -31,6 +34,9 @@ struct RainbowMode : public modes::BasicMode
 
     ctx.lamp.fill(color);
   }
+
+  // hint manager to save our custom ramp
+  static constexpr bool hasCustomRamp = true;
 };
 
 //
@@ -45,6 +51,9 @@ struct PaletteMode : public modes::BasicMode
     uint32_t color = modes::colors::from_palette(ctx.get_active_custom_ramp(), ctx.state.palette);
     ctx.lamp.fill(color);
   }
+
+  // hint manager to save our custom ramp
+  static constexpr bool hasCustomRamp = true;
 };
 
 /// Party fixed colors ramp mode

--- a/src/modes/include/context_type.hpp
+++ b/src/modes/include/context_type.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "src/modes/include/hardware/keystore.hpp"
 #include "src/modes/include/hardware/lamp_type.hpp"
 #include "src/modes/include/tools.hpp"
 #include "src/modes/include/default_config.hpp"
@@ -30,6 +31,19 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
   using ModeManagerTy = ModeManager;
   using LocalModeTy = LocalBasicMode;
   using StateTy = StateTyOf<LocalModeTy>;
+
+  /// \private True if LocalModeTy is a BasicMode
+  static constexpr bool isMode = isMode<LocalModeTy>;
+
+  /// \private True if context is root "manager" context
+  static constexpr bool isManager = std::is_same_v<LocalModeTy, ModeManagerTy>;
+
+  // useful proxies
+  static constexpr bool hasBrightCallback = LocalModeTy::hasBrightCallback;   ///< \private
+  static constexpr bool hasSystemCallbacks = LocalModeTy::hasSystemCallbacks; ///< \private
+  static constexpr bool requireUserThread = LocalModeTy::requireUserThread;   ///< \private
+  static constexpr bool hasCustomRamp = LocalModeTy::hasCustomRamp;           ///< \private
+  static constexpr bool hasButtonCustomUI = LocalModeTy::hasButtonCustomUI;   ///< \private
 
   //
   // constructors
@@ -196,6 +210,165 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
     return value;
   }
 
+  /// (getter) Get active custom index (recalled when jumping favorites)
+  uint8_t LMBD_INLINE get_active_custom_index() const { return modeManager.activeIndex.customIndex; }
+
+  /// (setter) Set active custom index (recalled when jumping favorites)
+  uint8_t LMBD_INLINE set_active_custom_index(uint8_t value)
+  {
+    modeManager.activeIndex.customIndex = value;
+    return value;
+  }
+
+  //
+  // getters / setters for other properties
+  //
+
+  /// (getter) Return current brightness value
+  uint8_t LMBD_INLINE get_brightness() { return behavior::BRIGHTNESS; }
+
+  //
+  // store
+  //
+
+  /// \private Group number where \p LocalBasicMode belongs to (or -1 if absent)
+  static constexpr int groupId = details::GroupIdFrom<LocalModeTy, typename ModeManagerTy::AllGroupsTy>;
+
+  /// \private Mode position of \p LocalBasicMode in its group (or -1 if absent)
+  static constexpr int modeId = details::ModeIdFrom<LocalModeTy, typename ModeManagerTy::AllGroupsTy, groupId>;
+
+  /// \private Local store will be in general, manager, or private key space ?
+  static constexpr auto prefix =
+          (isManager ? store::PrefixValues::managerKeys :
+                       (isMode ? store::PrefixValues::generalKeys : store::PrefixValues::privateKeys));
+
+  /// \private Store enumeration used by \p LocalModeTy to index its storage
+  using StoreEnum = StoreEnumOf<LocalModeTy>;
+
+  /// \private Internal key store implementation used by KeyProxy
+  using LocalStore = store::KeyStore<StoreEnum, groupId, modeId, prefix>;
+
+  /// (store) True if \p LocalBasicMode has access to a local key store
+  static constexpr bool hasStore = not std::is_same_v<StoreEnum, NoStoreHere>;
+
+  /** \brief (store) Binds a local variable of type \p T to \p key in storage
+   * (with automatic read & save)
+   *
+   * Before using this, you must define in your mode the following:
+   *
+   * ```
+   *    struct MyMode : public modes::BasicMode {
+   *
+   *      enum class Store : uint16_t {
+   *        keyA,
+   *        keyB
+   *      };
+   *
+   *      static constexpr uint32_t storeId = modes::store::hash("MyMode");
+   *
+   *      // ... (other stuff from your mode) ...
+   *    };
+   * ```
+   *
+   * You will then be able to bind persistent storage to a local variable:
+   *
+   * ```
+   *    static void loop(auto& ctx) {
+   *      float a = 1.5; // default value
+   *
+   *      // load value for "a" at "keyA" from storage if available
+   *      auto storeA = ctx.template storageFor<keyA>(a);
+   *
+   *      // ... (do some other stuff) ...
+   *      a += 1.0;
+   *
+   *      // no need to explicitly* save "a" (done automatically)
+   *    }
+   *
+   * // *when storeA is destroyed, storage for "a" is updated
+   * ```
+   *
+   * Other advanced use-cases are left undocumented, for experienced users :)
+   */
+  template<StoreEnum _key, typename T> struct KeyProxy
+  {
+    static_assert(std::is_same_v<T, std::conditional_t<hasStore, T, NoStoreId>>,
+                  "KeyProxy can not be used when no storeId has been defined!");
+
+    /// Enumeration value uniquely identifying where \p local will be stored
+    static constexpr StoreEnum key = _key;
+
+    /// Local variable reference bound to KeyProxy
+    T& local;
+
+    /// (optional) Set \p local to \p value then write \p key to store
+    inline void LMBD_INLINE setValue(T value)
+    {
+      local = value;
+      LocalStore::template setValue<key, T>(value);
+    };
+
+    /// (optional) Read \p key from store, return True if \p local was written
+    inline bool LMBD_INLINE getValue() { return LocalStore::template getValue<key, T>(local); }
+
+    /// (optional) Read \p key value, if not found, set \p local to \p defVal
+    inline void LMBD_INLINE getValue(T defVal) { LocalStore::template getValue<key, T>(local, defVal); }
+
+    /// (optional) Return True if \p key is set in store, False if unknown
+    inline bool LMBD_INLINE hasValue() { return LocalStore::template hasValue<key, T>(); }
+
+    //
+    // private API
+    //
+
+    /// \private Force local to storage, even if done elsewhere automatically
+    inline void LMBD_INLINE forceSave() { LocalStore::template setValue<key, T>(local); }
+
+    //
+    // constructors
+    //
+
+    /// Use ContextTy::storageFor to construct a KeyProxy bound to \p local
+    KeyProxy(T& local) : local {local} { getValue(); }
+
+    KeyProxy() = delete;                           ///< \private
+    KeyProxy(const KeyProxy&) = delete;            ///< \private
+    KeyProxy& operator=(const KeyProxy&) = delete; ///< \private
+
+    /// \private Automagically save value when context is lost
+    ~KeyProxy() { forceSave(); }
+  };
+
+  /// (store) Get storage KeyProxy for \p key bound to \p local variable
+  template<StoreEnum key, typename T = uint32_t>
+  static auto LMBD_INLINE storageFor(LMBD_USED T& local) // requires storeId :)
+  {
+    if constexpr (hasStore)
+    {
+      return KeyProxy<key, T> {local};
+    }
+    else
+    {
+      return NoStoreId {};
+    }
+  }
+
+  /// (store) Load \p key into \p local if available (single-shot)
+  template<StoreEnum key, typename T = uint32_t> static bool LMBD_INLINE storageLoadOnly(LMBD_USED T& local)
+  {
+    return LocalStore::template getValue<key, T>(local);
+  }
+
+  /// (store) Save \p local into \p key storage (single-shot)
+  template<StoreEnum key, typename T = uint32_t> static void LMBD_INLINE storageSaveOnly(LMBD_USED T& local)
+  {
+    return LocalStore::template setValue<key, T>(local);
+  }
+
+  //
+  // manager config
+  //
+
   /** \brief (setter) Set a configurable boolean to target \p value
    *
    * See modes::ConfigKeys for documentation of configurable booleans.
@@ -235,23 +408,6 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
     }
   }
 
-  /// (getter) Get active custom index (recalled when jumping favorites)
-  uint8_t LMBD_INLINE get_active_custom_index() const { return modeManager.activeIndex.customIndex; }
-
-  /// (setter) Set active custom index (recalled when jumping favorites)
-  uint8_t LMBD_INLINE set_active_custom_index(uint8_t value)
-  {
-    modeManager.activeIndex.customIndex = value;
-    return value;
-  }
-
-  //
-  // getters / setters for other properties
-  //
-
-  /// (getter) Return current brightness value
-  uint8_t LMBD_INLINE get_brightness() { return behavior::BRIGHTNESS; }
-
   //
   // quick bindings to \p LocalModeTy
   //
@@ -260,7 +416,14 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
   void LMBD_INLINE loop() { LocalModeTy::loop(*this); }
 
   /// Binds to local BasicMode::reset()
-  void LMBD_INLINE reset() { LocalModeTy::reset(*this); }
+  void LMBD_INLINE reset()
+  {
+    if (hasStore)
+    {
+      LocalStore::template migrateStoreIfNeeded<LocalModeTy::storeId>();
+    }
+    LocalModeTy::reset(*this);
+  }
 
   /// Binds to local BasicMode::brightness_update()
   void LMBD_INLINE brightness_update(LMBD_USED uint8_t brightness)
@@ -356,8 +519,8 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
   // context members for direct access
   //
 
-  hardware::LampTy& lamp;
-  StateTy& state;
+  hardware::LampTy& lamp; ///< Interact with the lamp hardware
+  StateTy& state;         ///< Interact with the current active mode state
 
 private:
   ModeManagerTy& modeManager;

--- a/src/modes/include/hardware/keystore.hpp
+++ b/src/modes/include/hardware/keystore.hpp
@@ -1,0 +1,343 @@
+#ifndef MODES_HARDWARD_KEYSTORE_HPP
+#define MODES_HARDWARD_KEYSTORE_HPP
+
+#include "src/modes/include/compile.hpp"
+#include "src/modes/include/tools.hpp"
+
+#include "src/system/physical/fileSystem.h"
+#include "src/system/utils/utils.h"
+
+#include <cstring>
+#include <array>
+
+/// Mode key store interface, see ContextTy::KeyProxy
+namespace modes::store {
+
+/** \private Store identifier (change to force cleanup of all values)
+ *
+ * Implementation should call migrateIfNeeded() which implements:
+ *
+ *    If not hasValue(storeUid):
+ *        setValue(storeUid, storeUid);
+ *    If not getValue(storeUid) == storeUid:
+ *        forceEraseAllData();
+ *        setValue(storeUid, storeUid);
+ *
+ * This enable to force cleanup of an old database after a migration, by
+ * changing the value picked as store unique identifier.
+ */
+static constexpr uint32_t storeUid = utils::hash("StoreRev:v01");
+
+/// \private Map a 32-bit hash value to a 31-bit value
+static constexpr uint32_t map32to31hash(uint32_t a)
+{
+  uint32_t lsb = a & 0b1; // mix the lost LSB info into the 13th bit
+  uint32_t val = (a ^ storeUid ^ (lsb << 14));
+  return val >> 1;
+}
+
+/// \private Same as hash, but called when hash("string") to verify length
+template<int16_t N> static constexpr uint32_t LMBD_INLINE hash(const char (&s)[N])
+{
+  static_assert(N - 1 <= 14, "Please use keys shorter than 14 bytes!");
+  return map32to31hash(utils::hash(s, N));
+}
+
+/** \brief Set value for named \p key and read in in \p out
+ *
+ * \param[in] key Key string to be hashed as 31 bit integer
+ * \param[in] value Value to be saved for \p key corresponding hash
+ */
+template<int16_t N> static inline void LMBD_INLINE setValue(const char (&key)[N], uint32_t value)
+{
+  static_assert(N - 1 <= 14, "Please use keys shorter than 14 bytes!");
+  fileSystem::set_value(hash(key), value);
+}
+
+/** \brief Get value for named \p key and write it in \p out
+ *
+ * \param[in] key Key string to be hashed as 31 bit integer
+ * \param[out] out Value where result will be written if found
+ * \return Returns True if key is found and \p out has been written
+ */
+template<int16_t N> static inline bool LMBD_INLINE getValue(const char (&key)[N], uint32_t& out)
+{
+  static_assert(N - 1 <= 14, "Please use keys shorter than 14 bytes!");
+  return fileSystem::get_value(hash(key), out);
+}
+
+/** \brief Check if value for \p key exists
+ *
+ * \param[in] key Key string to be hashed as 31 bit integer
+ * \return Returns True if key exists
+ */
+template<int16_t N> static inline bool LMBD_INLINE hasValue(const char (&key)[N], uint32_t& out)
+{
+  static_assert(N - 1 <= 14, "Please use keys shorter than 14 bytes!");
+  return fileSystem::doKeyExists(hash(key), out);
+}
+
+/// \private Check for migration and erase all values if needed
+static inline void LMBD_INLINE migrateIfNeeded()
+{
+  if (not fileSystem::doKeyExists(storeUid))
+  {
+    fileSystem::set_value(storeUid, storeUid);
+  }
+
+  uint32_t out = storeUid ^ 0xff;
+  if (not fileSystem::get_value(storeUid, out))
+  {
+    fileSystem::set_value(storeUid, storeUid);
+    fileSystem::get_value(storeUid, out);
+  }
+
+  if (out != storeUid)
+  {
+    fileSystem::clear_internal_fs();
+    fileSystem::clear();
+    fileSystem::set_value(storeUid, storeUid);
+    fileSystem::write_state();
+    fileSystem::load_initial_values();
+  }
+}
+
+/** \private Flag indexed / enumeration-based key space
+ *
+ * There are two ways of storing and retrieving persistent key store values:
+ *  - by named key, a C-string hashed on the 31 least-significant bytes
+ *  - by indexed keys, using fixed values, all starting by a 1 on their MSB
+ *
+ * This flag (0x8000000) reflects this and is or-ed to each PrefixValues
+ */
+static constexpr uint32_t indexKeyFlag = (1 << 31);
+
+/** \private Possible prefixes to differentiate indexed keys use cases
+ *
+ * The bit format for all indexed keys is the following:
+ *
+ * ```
+ *    indexed key format, first 16 most-significant bits:
+ *
+ * 0b1                        31  1       (always present)
+ *    ..                      29  0-3     prefix to differentiate use-cases
+ *      ....                  25  0-14    group identifier
+ *          .....             20  0-30    mode identifier
+ *               ....         16  0-15    data offset for large values
+ * ```
+ *
+ * Where the 16 least-significant bits are used by user to enumerate keys.
+ */
+enum class PrefixValues : uint32_t
+{
+  generalKeys = indexKeyFlag | (0x0 << 29), ///< General keys (user)
+  managerKeys = indexKeyFlag | (0x1 << 29), ///< Manager keys (per-mode)
+  privateKeys = indexKeyFlag | (0x2 << 29), ///< Private keys (system-only)
+  invalidKeys = indexKeyFlag | (0x3 << 29), ///< (reserved) for later use
+};
+
+/// \private Used for no group index (global to all groups and all modes)
+static constexpr uint32_t noGroupIndex = 15;
+
+/// \private Used for no mode index (local to group, global to its modes)
+static constexpr uint32_t noModeIndex = 31;
+
+/// \private Return indexed key given its parameters
+static constexpr uint32_t LMBD_INLINE
+indexKeyFor(PrefixValues prefix, uint32_t groupId, uint32_t modeId, uint32_t offset, uint32_t index)
+{
+  uint32_t rawPrefix = (uint32_t)prefix;
+
+  assert((rawPrefix >> 31) == 0b1); // prefix on 2 of the MSBs +indexKeyFlag
+  assert((groupId >> 4) == 0);      // groupId on 4 bits (0-14)
+  assert((modeId >> 5) == 0);       // modeId on 5 bits (0-30)
+  assert((offset >> 4) == 0);       // offset on 4 bits (0-15)
+  assert((index >> 16) == 0);       // index on 16 bits (0-65535)
+
+  return rawPrefix | (groupId << 25) | (modeId << 20) | (offset << 16) | index;
+}
+
+/// \private Orchestrate interactions with the indexed key store
+template<typename _EnumTy, int _groupId, int _modeId, PrefixValues _prefix = PrefixValues::generalKeys> struct KeyStore
+{
+  using EnumTy = _EnumTy;
+  static constexpr uint32_t groupId = _groupId < 0 ? noGroupIndex : _groupId;
+  static constexpr uint32_t modeId = _modeId < 0 ? noModeIndex : _modeId;
+  static constexpr PrefixValues prefix = _prefix;
+
+  // it's magic!
+  static constexpr uint16_t storeIdKey = 0xafff;
+
+  static_assert(sizeof(EnumTy) == sizeof(uint16_t), "uint16_t enum only");
+  static_assert((groupId >> 4) == 0, "Group index must fit on 4 bits!");
+  static_assert((modeId >> 5) == 0, "Mode index must fit on 5 bits!");
+
+  // \private maps to ContextTy::KeyProxy::setValue()
+  template<EnumTy key, typename T> static inline void LMBD_INLINE setValue(T value)
+  {
+    using valueTy = std::remove_cv_t<std::remove_reference_t<T>>;
+    constexpr uint16_t rawKey = (uint16_t)key;
+
+    static_assert(storeIdKey != rawKey, "error: key can not match storeIdKey (0xafff)");
+
+    // simple case: value is uint32_t, store it as-is
+    if constexpr (std::is_same_v<valueTy, uint32_t>)
+    {
+      constexpr auto idx = indexKeyFor(prefix, groupId, modeId, 0, rawKey);
+      fileSystem::set_value(idx, value);
+
+      // small case: value is smaller than uint32_t, store it on a uint32_t
+    }
+    else if constexpr (sizeof(valueTy) <= sizeof(uint32_t))
+    {
+      uint32_t storage = 0;
+      details::bit_cast<sizeof(value)>(storage, value);
+      setValue<key>(storage);
+
+      // large case: value is stored on up to 16 uint32_t
+    }
+    else if constexpr (sizeof(valueTy) <= 16 * sizeof(uint32_t))
+    {
+      constexpr uint8_t N = ((sizeof(valueTy) - 1) / sizeof(uint32_t)) + 1;
+      std::array<uint32_t, N> storage {};
+      details::bit_cast<sizeof(value)>(storage, value);
+      for (uint8_t I = 0; I < N; ++I)
+      {
+        uint32_t off = indexKeyFor(prefix, groupId, modeId, I, rawKey);
+        fileSystem::set_value(off, storage[I]);
+      }
+    }
+    else
+    {
+      static_assert(sizeof(valueTy) <= 64, "KeyStore values limited to 64 bytes!");
+    }
+  }
+
+  // \private maps to ContextTy::KeyProxy::getValue()
+  template<EnumTy key, typename T> static inline bool LMBD_INLINE getValue(T& output)
+  {
+    constexpr uint16_t rawKey = (uint16_t)key;
+
+    static_assert(storeIdKey != rawKey, "error: key can not match storeIdKey (0xafff)");
+
+    // simple case: value is uint32_t, get it as-is
+    if constexpr (std::is_same_v<T, uint32_t>)
+    {
+      constexpr auto idx = indexKeyFor(prefix, groupId, modeId, 0, rawKey);
+      return fileSystem::get_value(idx, output);
+
+      // small case: value is smaller than uint32_t, get it on a uint32_t
+    }
+    else if constexpr (sizeof(T) <= sizeof(uint32_t))
+    {
+      uint32_t storage = 0;
+      if (not getValue<key, uint32_t>(storage))
+      {
+        return false;
+      }
+
+      details::bit_cast<sizeof(output)>(output, storage);
+      return true;
+
+      // large case: value is stored on up to 16 uint32_t
+    }
+    else if constexpr (sizeof(T) <= 16 * sizeof(uint32_t))
+    {
+      constexpr uint8_t N = ((sizeof(T) - 1) / sizeof(uint32_t)) + 1;
+      std::array<uint32_t, N> storage {};
+      for (uint8_t I = 0; I < N; ++I)
+      {
+        uint32_t off = indexKeyFor(prefix, groupId, modeId, I, rawKey);
+        if (not fileSystem::get_value(off, storage[I]))
+        {
+          return false;
+        }
+      }
+
+      details::bit_cast<sizeof(output)>(output, storage);
+      return true;
+    }
+    else
+    {
+      static_assert(sizeof(T) <= 64, "KeyStore values limited to 64 bytes!");
+    }
+    return false;
+  }
+
+  // \private maps to ContextTy::KeyProxy::getValue(defaultValue)
+  template<EnumTy key, typename T> static inline void LMBD_INLINE getValue(T& output, T defValue)
+  {
+    if (not getValue<key, T>(output))
+    {
+      output = defValue;
+    }
+  }
+
+  // \private maps to ContextTy::KeyProxy::hasValue
+  template<EnumTy key, typename T = uint32_t> static inline bool LMBD_INLINE hasValue()
+  {
+    T output;
+    return getValue<key, T>(output);
+  }
+
+  // \private empty store if \p storeId mismatch with value at \p storeIdKey
+  template<uint32_t storeId> static void migrateStoreIfNeeded()
+  {
+    constexpr auto idx = indexKeyFor(prefix, groupId, modeId, 0, storeIdKey);
+
+    // retrieve storeId from storage
+    uint32_t otherId = 0;
+    if (not fileSystem::get_value(idx, otherId))
+    {
+      otherId = storeId;
+      fileSystem::set_value(idx, storeId);
+    }
+
+    // if it don't match our storeId, clean storage from our old keys
+    if (otherId != storeId || otherId == 0)
+    {
+      constexpr uint32_t select = 0xfff00000; // all but offset
+      constexpr uint32_t masked = idx & select;
+      fileSystem::dropMatchingKeys(masked, select);
+      fileSystem::set_value(idx, storeId);
+    }
+  }
+};
+
+/// \private
+template<uint32_t baseId, typename AllModes> static constexpr uint32_t derivateStoreIdImpl()
+{
+  constexpr uint32_t MixCstA = 0x8af8901d, MixCstB = 0x2f9c7c90;
+  constexpr uint8_t NbModes = std::tuple_size_v<AllModes>;
+
+  uint32_t storeId = baseId;
+  details::unroll<NbModes>([&](auto Idx) {
+    constexpr uint8_t I = decltype(Idx)::value;
+    using ModeHere = std::tuple_element_t<I, AllModes>;
+    using StoreHere = StoreEnumOf<ModeHere>;
+    constexpr bool hasStore = not std::is_same_v<StoreHere, NoStoreHere>;
+
+    uint32_t storeIdHere = 0;
+    if constexpr (hasStore)
+    {
+      storeIdHere = ModeHere::storeId;
+    }
+
+    // straightforward mix function
+    storeId += MixCstA;
+    storeId = (storeId << 7) ^ (storeId >> (32 - 7));
+    storeId ^= MixCstB;
+
+    storeId += storeIdHere;
+  });
+
+  return storeId;
+}
+
+/// \private Returns a new storeId, sensitive to all storeId of AllModes
+template<uint32_t baseId, typename AllModes> static constexpr uint32_t derivateStoreId =
+        derivateStoreIdImpl<baseId, AllModes>();
+
+} // namespace modes::store
+
+#endif

--- a/src/modes/include/mode_type.hpp
+++ b/src/modes/include/mode_type.hpp
@@ -88,7 +88,10 @@ struct BasicMode
    */
   static void brightness_update(auto& ctx, uint8_t brightness) { return; }
 
-  /// Toggles the use BasicMode::custom_ramp_update() callback
+  /** \brief Toggles the use of custom ramps & BasicMode::custom_ramp_update()
+   *
+   * \remark Without this set to True, manager will NOT save custom ramp value!
+   */
   static constexpr bool hasCustomRamp = false;
 
   /** \brief Custom callback when system sets user ramp (optional)
@@ -182,7 +185,7 @@ struct BasicMode
 
   /** \brief Toggles the use of custom BasicMode::user_thread() callback
    *
-   * \remark When this is enabled, default is to call hardware::LampTy::show()
+   * \remark When this is enabled, default is to call hardware::LampTy's `show()`
    * in user::user_thread() after the BasicMode::user_thread() callback
    */
   static constexpr bool requireUserThread = false;
@@ -196,6 +199,50 @@ struct BasicMode
    * must complete quickly in order to keep the lamp responsive
    */
   static void user_thread(auto& ctx) { return; }
+
+  /** \brief Store identifier for persistent storage (optional)
+   *
+   * By default, all modes are reset upon a shutdown, providing no persistence
+   * of their state across several on/off cycles. To expose to the user a way
+   * to configure your mode in a persistent fashion, you can use:
+   *
+   * ```
+   *    static void loop(auto& ctx) {
+   *      uint8_t rampValue = ctx.get_active_custom_ramp();
+   *      // ... (use rampValue to pick a color or something) ...
+   *    }
+   *
+   *    static constexpr bool hasCustomRamp = true; // required
+   * ```
+   *
+   * This value is configurable through user interaction with the button. If
+   * you need a persistent value, private to your mode, you can use:
+   *
+   * ```
+   *    static void loop(auto& ctx) {
+   *      uint8_t indexValue = ctx.get_active_custom_index();
+   *      // ... (use indexValue to change how something works) ...
+   *
+   *      // at some point, indexValue is modified:
+   *      indexValue += 1;
+   *      ctx.set_active_custom_index(indexValue);
+   *
+   *      // next time mode is enabled, or saved as favorite, both custom
+   *      // values (rampValue, indexValue) are remembered by default
+   *    }
+   *
+   *    static constexpr bool hasCustomRamp = true; // also required
+   * ```
+   *
+   * These are the two always-available persistent state that a mode can
+   * configure by default. However, for more advanced modes (like games, with a
+   * list of high-scores, for example) more flexibility can be required.
+   *
+   * If you need such extended storage, see ContextTy::KeyProxy for usage.
+   *
+   * If you don't need these capabilities, just ignore this identifier :)
+   */
+  static constexpr uint32_t storeId = 0;
 
   // modes shall not implement any constructors
   BasicMode() = delete;                            ///< \private

--- a/src/system/physical/fileSystem.cpp
+++ b/src/system/physical/fileSystem.cpp
@@ -4,21 +4,21 @@
 #include <InternalFileSystem.h>
 
 #include <cassert>
-#include <map>
+#include <unordered_map>
 #include <vector>
 
 #include "src/system/utils/constants.h"
 
 namespace fileSystem {
 
-constexpr auto FILENAME = "/.lampda.par";
+static constexpr auto FILENAME = "/.lampda.par";
 
 using namespace Adafruit_LittleFS_Namespace;
 
 File file(InternalFS);
 
 // the stored configurations
-std::map<uint32_t, uint32_t> _valueMap;
+std::unordered_map<uint32_t, uint32_t> _valueMap;
 
 struct keyValue
 {
@@ -171,15 +171,36 @@ bool doKeyExists(const uint32_t key) { return _valueMap.find(key) != _valueMap.e
 
 bool get_value(const uint32_t key, uint32_t& value)
 {
+#ifdef LMBD_SIMU_ENABLED
+  fprintf(stderr, "fs: get_value %08x -> ", key);
+#endif
+
   const auto& res = _valueMap.find(key);
   if (res != _valueMap.end())
   {
     value = res->second;
+
+#ifdef LMBD_SIMU_ENABLED
+    fprintf(stderr, "%08x\n", value);
+#endif
+
     return true;
   }
+
+#ifdef LMBD_SIMU_ENABLED
+  fprintf(stderr, "not found\n");
+#endif
+
   return false;
 }
 
-void set_value(const uint32_t key, const uint32_t value) { _valueMap[key] = value; }
+void set_value(const uint32_t key, const uint32_t value)
+{
+  _valueMap[key] = value;
+
+#ifdef LMBD_SIMU_ENABLED
+  fprintf(stderr, "fs: set_value %08x -> %08x\n", key, value);
+#endif
+}
 
 } // namespace fileSystem

--- a/src/system/physical/fileSystem.cpp
+++ b/src/system/physical/fileSystem.cpp
@@ -203,4 +203,30 @@ void set_value(const uint32_t key, const uint32_t value)
 #endif
 }
 
+uint32_t dropMatchingKeys(const uint32_t bitMatch, const uint32_t bitSelect)
+{
+  auto& c = _valueMap;
+
+  // std::erase_if implementation
+  //
+  auto old_size = c.size();
+  for (auto first = c.begin(), last = c.end(); first != last;)
+  {
+    uint32_t key = std::get<0>(*first);
+    if ((key & bitSelect) == bitMatch)
+    {
+      first = c.erase(first);
+
+#ifdef LMBD_SIMU_ENABLED
+      fprintf(stderr, "fs: key dropped %08x (matches %08x)\n", key, bitMatch & bitSelect);
+#endif
+    }
+    else
+    {
+      ++first;
+    }
+  }
+  return old_size - c.size();
+}
+
 } // namespace fileSystem

--- a/src/system/physical/fileSystem.h
+++ b/src/system/physical/fileSystem.h
@@ -27,6 +27,16 @@ bool doKeyExists(const uint32_t key);
 bool get_value(const uint32_t key, uint32_t& value);
 void set_value(const uint32_t key, const uint32_t value);
 
+/** \brief Drop all keys using the given bit prefix
+ *
+ * All keys such as `bitMatch == (bitSelect & key)` will be removed
+ *
+ * \param[in] bitMatch keys matching this pattern will be dropped
+ * \param[in] bitSelect select which key bits to match with
+ * \returns count of elements removed from storage
+ */
+uint32_t dropMatchingKeys(const uint32_t bitMatch, const uint32_t bitSelect = 0xffffffff);
+
 } // namespace fileSystem
 
 #endif

--- a/src/system/utils/utils.h
+++ b/src/system/utils/utils.h
@@ -78,11 +78,11 @@ constexpr float map(float x, float in_min, float in_max, float out_min, float ou
  * from the beginning of the string for simplicity.
  *
  * \param[in] s Zero-terminated input string
- * \param[in] maxSize (optional) Maximal byte count to process, defaults to 12
+ * \param[in] maxSize (optional) Maximal byte count to process, defaults to 14
  * \param[in] off (optional) Skip the first \p off bytes, defaults to 0
- * \remark By default, only the first 12 bytes of the string are used!
+ * \remark By default, only the first 14 bytes of the string are used!
  */
-template<typename T> static constexpr uint32_t hash(const T s, const uint16_t maxSize = 12, const uint16_t off = 0)
+template<typename T> static constexpr uint32_t hash(const T s, const uint16_t maxSize = 14, const uint16_t off = 0)
 {
 #ifdef LMBD_CPP17
   uint32_t hashAcc = 5381;
@@ -104,8 +104,8 @@ template<typename T> static constexpr uint32_t hash(const T s, const uint16_t ma
 /// \private Same as hash, but takes priority when called with hash("string")
 template<int16_t N> static constexpr uint32_t hash(const char (&s)[N])
 {
-  static_assert((N - 1 <= 12) && "Use hash(s, maxSize) to hash strings longer than 12 bytes!");
-  return hash(s, 12);
+  static_assert((N - 1 <= 14) && "Use hash(s, maxSize) to hash strings longer than 14 bytes!");
+  return hash(s, 14);
 }
 
 void calcGammaTable(float gamma);


### PR DESCRIPTION
This PR does two things:

1. add support of `src/system/physical/fileSystem.h` in simulator
2. add abstraction to give everyone access to the common key-value store

-------------

Users may discover new static methods in their mode context:

![2024-12-02_17-31](https://github.com/user-attachments/assets/5b57b92e-dc69-480e-8d7a-fa0b9dbeb28d)

-------------

There are pointers to the `KeyProxy` class which describes a typical use case:

![2024-12-02_17-32](https://github.com/user-attachments/assets/dcff863b-4f88-4e24-b95c-8e68b067e60d)

-------------

Others may discover these functionnalities through the basic mode documentation:

![2024-12-02_17-33](https://github.com/user-attachments/assets/21f2b287-918b-4dc4-8e9d-470447442029)

**Note: intentionally, we try to orient users into using the custom ramp & index, more basic & less error-prone!**

-------------

Other ways to discover direct access to the key-value store system is through its namespace:

![2024-12-02_17-34](https://github.com/user-attachments/assets/c0b39814-9721-46d7-a6d9-83c0482ef977)
![2024-12-02_17-35](https://github.com/user-attachments/assets/2d07370a-9d6d-466d-a51b-44366daf1e41)

-------------

Several remarks:

1. accessing key / values by "name" hashes the key name on the 31 lower-significant bits, prone to collisions
2. all other keys starts with a one, with the next 15 bits partitioning the key space in way to avoid collisions
3. the manager, each group and each mode have all their own `uint16_t` key space, indexed with enumerations
4. each space has a `storeId` serial, used to detect when groups / modes changes, dropping "obsolete" keys
5. values up to 64 bytes in size are transparently stored on several keys, only when using indexed key spaces

And as a bonus, at last, the lamp now remembers what was its last mode, its ramp value, other favorites, etc

**Draft: I still need to validate that everything works on real hardware!**