### PR TITLE
(minor) Fix README.md & .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 venv
 _build
-.gitignore
 .lampda.par
-arduino-cli
 */**/*.o
 */**/*.d
 */**/*.txt
+arduino-cli

--- a/Makefile
+++ b/Makefile
@@ -253,8 +253,8 @@ local-arduino-cli:
 	# enabling local arduino-cli command
 	@cp $(TOOLS_DIR)/arduino-cli $(SRC_DIR)
 	# adding local arduino-cli to .gitignore
-	@echo 'arduino-cli' >> $(SRC_DIR).gitignore
-	@echo '.gitignore' >> $(SRC_DIR).gitignore
+	# @echo 'arduino-cli' >> $(SRC_DIR).gitignore
+	# @echo '.gitignore' >> $(SRC_DIR).gitignore
 
 arduino-cli-download:
 	mkdir -p $(ARDUINO_LOC)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ First clone the repository:
 git clone https://github.com/BaptisteHudyma/Lamp-Da.git LampColorControler
 cd LampColorControler
 git submodule update --init
-make verify-all
 ```
 
 As highlighted above, this project uses Arduino SDK, you will need to


### PR DESCRIPTION
Two minor changes:
 - don't tell new users to immediately build the WHOLE project¹
 - previous editor removed `.gitignore` ending newline which badly interacted with the `Makefile`

> ¹the first step in the `README.md` is cloning the repo, then we talk about deps & stuff like the arduino-cli, jumping straight to `make verify-all` is just likely to confuse users & produce a large error message