### PR TITLE
Improve SFML integration +groundwork for Vagrant VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ venv
 _build
 .lampda.par
 arduino-cli
+.vagrant
+_vagrant_build

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Alternatively, at the cost of some additional disk space, you may use the provid
 ```sh
 git clone https://github.com/BaptisteHudyma/Lamp-Da.git LampColorControler
 cd LampColorControler
+git submodule update --init
 make mr_proper arduino-cli-download safe-install
 ```
 
@@ -232,6 +233,45 @@ Once you're finished with your work on the project:
 # this removes build artifacts AND all local dependencies
 cd LampColorControler
 make mr_proper
+```
+
+## Vagrant setup (WIP)
+
+There is a `VagrantFile` provided, for people that has a working
+[Vagrant](https://developer.hashicorp.com/vagrant/docs/installation)
+installation:
+
+```sh
+cd LampColorControler
+vagrant up # turn on the VM +provision +default builds
+vagrant ssh # get a shell inside the VM
+```
+
+The repository is copied to the VM in `/LampColorControler`, you can do
+`vagrant rsync` to synchronize it again, `vagrant reload` to restart the VM,
+or `vagrant halt` to stop it.
+
+To build & upload to a lamp plugged as an USB device:
+
+```sh
+vagrant ssh -c "cd /LampColorControler && make clean-artifacts upload-indexable"
+```
+
+To copy files from the VM guest to the host:
+
+```sh
+vagrant plugin install vagrant-scp
+mkdir _vagrant_build # must exist before copying
+vagrant scp lampbuild:/LampColorControler/<source> ./_vagrant_build/
+```
+
+To try X11 forwarding:
+
+```sh
+vagrant ssh -c "sudo vim /etc/ssh/sshd_config" # verify sshd config: AddressFamily inet
+vagrant ssh -c "sudo systemctl restart sshd"
+vagrant ssh -c "cd /LampColorControler && make simulator"
+vagrant ssh -c "cd /LampColorControler/_build/simulator && ./indexable-simulator" -- -Y
 ```
 
 ## Contributing code

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,110 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "generic/debian12"
+  config.vm.box_version = "4.3.12"
+  config.vm.define "lampbuild"
+  config.vm.hostname = "lampbuild"
+  config.vm.disk :disk, size: "10GB", primary: true
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network", :dev => "wlan0"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "./src", "/LampColorControler/src"
+  config.vm.synced_folder "./depends", "/LampColorControler/depends"
+  config.vm.synced_folder "./flashInfo", "/LampColorControler/flashInfo"
+  config.vm.synced_folder "./scripts", "/LampColorControler/scripts"
+  config.vm.synced_folder "./simulator", "/LampColorControler/simulator"
+  config.vm.synced_folder "./tools", "/LampColorControler/tools"
+
+  config.vm.synced_folder ".", "/LampColorControler", type: "rsync",
+    rsync__auto: false,
+    rsync__exclude: [".vagrant", "_build", "_vagrant_build", "venv",
+                     "doc", "src", "depends", "flashInfo", "scripts", "simulator", "tools",
+                     "objects", "electrical", "Medias"]
+
+  # Disable the default share of the current code directory. Doing this
+  # provides improved isolation between the vagrant box and your host
+  # by making sure your Vagrantfile isn't accessible to the vagrant box.
+  # If you use this you may want to enable additional shared subfolders as
+  # shown above.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    #
+    # compilers & tools
+    apt-get update -y
+    apt-get install -y build-essential gcc g++ clang clang-format make cmake git
+    #
+    # for python dependencies (!! python is python3 !!)
+    apt-get install -y python3 python3-venv python-is-python3
+    #
+    # all dependencies required for SFML 3.0.1
+    apt-get install -y libx11-dev libxrandr-dev libxcursor-dev libxi-dev libudev-dev libfreetype-dev libvorbis-dev libflac-dev
+    apt-get install -y libsfml-dev # (this sets up SFML 2.6.2)
+    #
+    # by default, download+install arduino-cli in _build/arduino-cli directory
+    chown -R vagrant:vagrant /LampColorControler/*
+    su vagrant -c "cd /LampColorControler && git submodule update --init"
+    su vagrant -c "cd /LampColorControler && make mr_proper arduino-cli-download safe-install"
+    #
+    # for example, build indexable & simulator:
+    # su vagrant -c "cd /LampColorControler && make indexable simulator"
+
+  SHELL
+end

--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.25)
 project(LampSimulator CXX C)
 
 set(LMBD_ROOT_DIR $ENV{LMBD_ROOT_DIR} CACHE PATH "Root directory for the project")
@@ -6,6 +6,7 @@ if(LMBD_ROOT_DIR STREQUAL "")
     set(LMBD_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../")
 endif()
 
+# get SFML version, if not found, use FetchContent
 set(SFML_VERSION 3.0.1)
 set(SFML_FETCH 0 CACHE PATH "If not set, try to use local install of SFML")
 if (NOT SFML_FETCH)
@@ -18,16 +19,20 @@ if (NOT SFML_FOUND)
 endif()
 
 if (SFML_FETCH)
+    set(BUILD_SHARED_LIBS OFF)
     include(FetchContent)
-    FetchContent_Declare(SFML
+    FetchContent_Declare(sfml
         GIT_REPOSITORY https://github.com/SFML/SFML.git
         GIT_TAG ${SFML_VERSION}
         GIT_SHALLOW ON
+        SYSTEM
         EXCLUDE_FROM_ALL
-        SYSTEM)
+        OVERRIDE_FIND_PACKAGE
+    )
     FetchContent_MakeAvailable(SFML)
-endif()
 
+    find_package(SFML ${SFML_VERSION} COMPONENTS System Window Graphics Audio Main)
+endif()
 
 # Compiler and Flags
 set(CMAKE_CXX_STANDARD 17)
@@ -151,25 +156,17 @@ function(create_simulator_target SIM_NAME)
     )
     target_compile_definitions(simulator_${SIM_NAME} PUBLIC LMBD_LAMP_TYPE__${UPPER_SIM_NAME})
 
-    if (SFML_FETCH)
-        target_link_libraries(${TARGET_NAME}
-            simulator_${SIM_NAME}
-            SFML::System
-            SFML::Window
-            SFML::Graphics
-            SFML::Audio
-            pthread
-        )
-    else()
-        target_link_libraries(${TARGET_NAME}
-            simulator_${SIM_NAME}
-            sfml-graphics
-            sfml-window
-            sfml-audio
-            sfml-system
-            pthread
-        )
-    endif()
+    target_link_libraries(simulator_${SIM_NAME}
+        sfml-graphics
+        sfml-window
+        sfml-audio
+        sfml-system
+    )
+
+    target_link_libraries(${TARGET_NAME}
+        simulator_${SIM_NAME}
+        pthread
+    )
 
 endfunction()
 

--- a/simulator/include/default_simulation.h
+++ b/simulator/include/default_simulation.h
@@ -12,7 +12,7 @@ struct defaultSimulation
   float fakeXorigin = 0; // start lamp N led to the left
   float fakeXend = 0;    // remove N led from right
 
-  float buttonSize = 40.f; // draw a lamp button of 40 pixels
+  float buttonSize = 40.f;   // draw a lamp button of 40 pixels
   float buttonMargin = 15.f; // draw a button color indicator 10 pixels larger
 
   defaultSimulation() {}

--- a/simulator/include/simulator.h
+++ b/simulator/include/simulator.h
@@ -53,9 +53,12 @@ template<typename T> struct simulator
     // init font
     sf::Font font;
     bool enableFont = false, enableText = false;
-    if (font.openFromFile("DejaVuSansMono.ttf")) {
+    if (font.openFromFile("DejaVuSansMono.ttf"))
+    {
       enableFont = true;
-    } else {
+    }
+    else
+    {
       fprintf(stderr, "DejaVuSansMono.ttf not found, disabling text...");
     }
 
@@ -164,34 +167,48 @@ template<typename T> struct simulator
           auto& state = sim::globals::state;
 
           // pause event
-          if (state.lastKeyPressed == 'p') {
+          if (state.lastKeyPressed == 'p')
+          {
             state.paused = !state.paused;
           }
 
           // verbose event
-          if (state.lastKeyPressed == 'v') {
+          if (state.lastKeyPressed == 'v')
+          {
             state.verbose = !state.verbose;
           }
 
           // slower simulation
-          if (state.lastKeyPressed == 's') {
-            if (state.slowTimeFactor > 1.50) {
+          if (state.lastKeyPressed == 's')
+          {
+            if (state.slowTimeFactor > 1.50)
+            {
               state.slowTimeFactor *= 0.95;
-            } else if (state.slowTimeFactor > 1.0) {
+            }
+            else if (state.slowTimeFactor > 1.0)
+            {
               state.slowTimeFactor = ceil(state.slowTimeFactor * 20 - 1) / 20;
-            } else {
+            }
+            else
+            {
               state.slowTimeFactor = max(0.1, state.slowTimeFactor - 0.05);
             }
             fprintf(stderr, "slower %f\n", state.slowTimeFactor);
           }
 
           // faster simulation
-          if (state.lastKeyPressed == 'f') {
-            if (state.slowTimeFactor > 1.20) {
+          if (state.lastKeyPressed == 'f')
+          {
+            if (state.slowTimeFactor > 1.20)
+            {
               state.slowTimeFactor *= 1.05;
-            } else if (state.slowTimeFactor > 1.0) {
+            }
+            else if (state.slowTimeFactor > 1.0)
+            {
               state.slowTimeFactor = ceil(state.slowTimeFactor * 20 + 1) / 20;
-            } else {
+            }
+            else
+            {
               state.slowTimeFactor += 0.05;
             }
             fprintf(stderr, "faster %f\n", state.slowTimeFactor);
@@ -208,7 +225,8 @@ template<typename T> struct simulator
           float dy = indCoordY - mousePos.y + simu.buttonSize;
           float norm = simu.buttonSize;
 
-          if (dx * dx + dy * dy < norm * norm) {
+          if (dx * dx + dy * dy < norm * norm)
+          {
             mouseClick += 3;
           }
           break;
@@ -226,8 +244,8 @@ template<typename T> struct simulator
       // TODO: #156 move mock-specific parts to another process
       // ======================================================
 
-      if (!sim::globals::state.paused) {
-
+      if (!sim::globals::state.paused)
+      {
         // deep sleep, exit
         if (mock_registers::isDeepSleep)
         {
@@ -298,27 +316,29 @@ template<typename T> struct simulator
           window.draw(shape);
 
           // display text information if mouse is pressed
-          if (enableText) {
-
+          if (enableText)
+          {
             // (used to compute which pixel is pointed by mouse)
             int MouseYpos = 1 + (mousePos.y / ledPadSz);
             float MouseXpos = ((mousePos.x - ledSz - (MouseYpos % 2 - Yoff) * ledOffset) / ledPadSz);
 
-            if (MouseYpos > ledH + 1 && !sim::globals::state.verbose) {
+            if (MouseYpos > ledH + 1 && !sim::globals::state.verbose)
+            {
               enableText = false;
               continue;
             }
 
             float offsetY = 0;
-            if (MouseXpos < simu.fakeXorigin - 0.5) {
+            if (MouseXpos < simu.fakeXorigin - 0.5)
+            {
               offsetY = ledSz;
               MouseYpos += 1;
             }
 
             // display Ypos on the right
             float dy = abs(shape.getPosition().y - mousePos.y + ledSz / 2 + offsetY);
-            if (fXpos + 1 >= ledW - simu.fakeXend && dy < ledPadSz / 2) {
-
+            if (fXpos + 1 >= ledW - simu.fakeXend && dy < ledPadSz / 2)
+            {
               sf::Text text(font, std::to_string(Ypos));
               text.setCharacterSize(12);
 
@@ -329,7 +349,8 @@ template<typename T> struct simulator
 
             // display Xpos on the bottom
             float dx = abs(shape.getPosition().x - mousePos.x - (MouseYpos % 2) * ledOffset + ledSz / 2);
-            if (Ypos + 1 >= ledH && dx < ledPadSz / 2) {
+            if (Ypos + 1 >= ledH && dx < ledPadSz / 2)
+            {
               sf::Text text(font, std::to_string(Xpos));
               text.setCharacterSize(12);
 
@@ -339,7 +360,8 @@ template<typename T> struct simulator
             }
 
             // display color at pixel
-            if (dx < ledPadSz / 2 && dy < ledPadSz / 2) {
+            if (dx < ledPadSz / 2 && dy < ledPadSz / 2)
+            {
               auto str = "(" + std::to_string(int(r)) + ", ";
               str += std::to_string(int(g)) + ", ";
               str += std::to_string(int(b)) + ")";

--- a/simulator/mocks/time_mock.cpp
+++ b/simulator/mocks/time_mock.cpp
@@ -2,7 +2,7 @@
 
 #define PLATFORM_TIME_CPP
 
-#include <SFML/Graphics.hpp>
+#include <SFML/System/Time.hpp>
 
 #include "simulator_state.h"
 


### PR DESCRIPTION
- https://github.com/BaptisteHudyma/Lamp-Da/commit/55e552cc770ed79024a57ac2d38d20947843321a Closes #159 
   - :green_circle: I was able to fix the confusion inside the build system around SFML 3.0.1
   - …but we still need to pull all the dependencies to build the SFML (see the `Vagrantfile`)
   - …maybe reverting back to 2.5.6 would be less of a pain? :eyes: 

- https://github.com/BaptisteHudyma/Lamp-Da/commit/7b8c0601c8ff9cbb91348fcf335039b744c0420b Start work on #160
   - :green_circle: Everything builds against debian bookworm with libvirt as provider for Vagrant 
   - :red_circle: No USB passthrough yet so no `make upload-indexable` in the VM (work in progress)
   - :yellow_circle: Simulator builds and can be used through `X11Forwarding` (needs more work, for some reason, it is very laggy)
   - :orange_circle: Also a `clang-format`  fix required to pass `make verify-all` inside the VM
   - :red_circle: Also need a `README.md` split as per #126 

That's not finished yet, but I'm leaving for vacations :wave: 