### PR TITLE
Make simulator display closer to real indexable

### DIFF
--- a/simulator/include/default_simulation.h
+++ b/simulator/include/default_simulation.h
@@ -3,7 +3,7 @@
 
 struct defaultSimulation
 {
-  float fps = 60.f; // how fast animation is
+  float fps = 80.f; // how fast animation is
 
   float ledSizePx = 24.f;   // square size to represent one LED (in pixels)
   float ledPaddingPx = 4.f; // padding between two LEDs (in pixels)

--- a/simulator/include/simulator_state.h
+++ b/simulator/include/simulator_state.h
@@ -16,6 +16,7 @@ struct GlobalSimStateTy
   bool isButtonPressed = false;
   char lastKeyPressed = 0;
   uint8_t brightness = 255;
+  uint8_t tickAndPause = 0;
   uint32_t colorBuffer[LED_COUNT] = {};
   uint32_t indicatorColor = 0;
   float slowTimeFactor = 1.0;


### PR DESCRIPTION
Closes #205 

The proposed implementation is inexact and will create a misalignment of a half-LED every 79.80156 rows, but this should be fine as we only have 23-ish rows.

Also added `t` as hotkey for simulator, to run a mode step by step, useful for debugging.