### PR TITLE
Add buffer APIs to lamp +Work on grid-based automata

### DIFF
--- a/src/modes/example/automaton.hpp
+++ b/src/modes/example/automaton.hpp
@@ -1,0 +1,178 @@
+#ifndef AUTOMATON_MODE_HPP
+#define AUTOMATON_MODE_HPP
+
+#include "src/modes/include/draw/grid_rule.hpp"
+
+#include "src/system/ext/random8.h"
+
+/// Modes implementing cellular automaton using "grid" tools
+namespace modes::automaton {
+
+struct BubbleMode : public BasicMode
+{
+  using GridTy = draw::grid::LineRule<>;
+
+  struct StateTy
+  {
+    GridTy grid;
+    uint32_t algeaStart, algeaLifetime, algeaPos;
+  };
+
+  static constexpr int nbBubbles = 4;      // 0-10 max number of bubble per turn
+  static constexpr int bubbleFreq = 70;    // 0-255 the more the less bubbles
+  static constexpr int minBubbleDist = 4;  // 0-5 min distance of bubbles?
+  static constexpr int eventFreq = 70;     // 0-255 how likely are events?
+  static constexpr int algeaFreq = 60;     // 0-255 how likely event is algea?
+  static constexpr int algeaLength = 3000; // (ms) +/- 1s average algea size
+  static constexpr int algeaSwims = 400;   // (ms) how fast algea ondulates
+  static constexpr int starFreq = 3;       // 0-255 how likely event is star?
+
+  // colors
+  static constexpr auto waterColor = colors::DarkBlue;
+  static constexpr auto algeaColor = colors::ForestGreen;
+  static constexpr auto starColor = colors::Gold;
+
+  static void reset(auto& ctx)
+  {
+    // fill the initial automata with zeros +few colored pixels
+    GridTy::LineTy first {};
+    first.fill(waterColor);
+
+    // reset grid object & config
+    ctx.state.grid.reset(ctx.lamp, first);
+
+    // reset stateful events
+    ctx.state.algeaStart = 0;
+  }
+
+  static void loop(auto& ctx)
+  {
+    // rng helper
+    uint8_t mini = ctx.get_active_custom_ramp() / 4;
+    uint8_t maxi = 255;
+    auto rng = [&](auto p) LMBD_INLINE {
+      return random8(mini, maxi) < p;
+    };
+
+    // st & lamp for brievty
+    auto& st = ctx.state;
+    auto& lamp = ctx.lamp;
+
+    // callback to update the automaton
+    auto cb = [&](const auto& before, auto& after) {
+      after.fill(waterColor);
+
+      // add randomly bubbles
+      for (size_t I = 0; I < nbBubbles; ++I)
+      {
+        if (rng(bubbleFreq))
+          after[random8(0, after.size())] = colors::fromGrey(0xff);
+      }
+
+      // one pass to remove too crowded stuff
+      int lastBubble = 255;
+      for (int I = 0; I < after.size(); ++I)
+      {
+        // if something above, cancel bubble
+        if (before[I] != waterColor)
+          lastBubble = I;
+
+        if (after[I] == waterColor)
+          continue;
+
+        // if other bubble too close, cancel bubble
+        if (abs(int(lastBubble - I)) < minBubbleDist)
+        {
+          after[I] = waterColor;
+        }
+
+        lastBubble = I;
+      }
+
+      // trigger events
+      if (rng(eventFreq) && rng(eventFreq))
+      {
+        if (rng(starFreq))
+        {
+          after[random8(0, after.size())] = starColor;
+        }
+
+        if (st.algeaStart == 0 && rng(algeaFreq))
+        {
+          st.algeaPos = random8(2, after.size() - 2);
+          st.algeaStart = lamp.now;
+          st.algeaLifetime = random16(algeaLength - 1000, algeaLength + 1000);
+        }
+      }
+
+      // draw oscillating algea if active
+      if (st.algeaStart && st.algeaStart + st.algeaLifetime > lamp.now)
+      {
+        int shift = abs(int(((lamp.now / algeaSwims) % 8) - 3)) - 2; // oscillate -2..+2
+        after[st.algeaPos + shift] = algeaColor;
+      }
+      else
+      {
+        st.algeaStart = 0;
+      }
+    };
+
+    // default grid loop
+    ctx.state.grid.template loop<false>(ctx, cb);
+  }
+
+  static constexpr bool hasCustomRamp = true;
+};
+
+struct SierpinskiMode : public BasicMode
+{
+  struct ConfigTy : public draw::grid::LineRuleConfig
+  {
+    // scroll the grid skewed (no "bubble" effect
+    static constexpr bool scrollSkewed = true;
+    // add more blur
+    static constexpr uint8_t renderBlurAmount = 128;
+  };
+  using GridTy = draw::grid::LineRule<ConfigTy>;
+
+  struct StateTy
+  {
+    GridTy grid;
+  };
+
+  static void reset(auto& ctx)
+  {
+    // fill the initial automata with zeros +few colored pixels
+    GridTy::LineTy first {};
+    first[4] = colors::fromRGB(0x00, 0x00, 0x12);
+    first[5] = colors::fromRGB(0x00, 0x00, 0x23);
+    first[6] = colors::fromRGB(0x00, 0x20, 0x40);
+    first[7] = colors::fromRGB(0x80, 0x80, 0x80);
+    first[8] = colors::fromRGB(0x40, 0x40, 0x00);
+    first[9] = colors::fromRGB(0x23, 0x0c, 0x00);
+    first[10] = colors::fromRGB(0x12, 0x03, 0x00);
+
+    // reset grid object & config
+    ctx.state.grid.reset(ctx.lamp, first);
+    ctx.template set_config_bool<ConfigKeys::rampSaturates>(true);
+  }
+
+  static void loop(auto& ctx)
+  {
+    // setup a callback, use wolframRule's 1-d cellular automata
+    auto cb = [&](const auto& before, auto& after) {
+      draw::grid::wolframRule<90>(before, after);
+    };
+
+    // default grid loop
+    ctx.state.grid.template loop<hasCustomRamp>(ctx, cb);
+  }
+
+  static constexpr bool hasCustomRamp = true;
+};
+
+using AutomatonModes = modes::GroupFor<BubbleMode, SierpinskiMode>;
+
+} // namespace modes::automaton
+
+#endif

--- a/src/modes/include/anims/ramp_update.hpp
+++ b/src/modes/include/anims/ramp_update.hpp
@@ -69,12 +69,12 @@ void rampColorRing(auto& ctx, uint8_t rampValue, auto palette)
 {
   ctx.skipFirstLedsForFrames(0);
 
-  for (uint8_t i = 0; i < ctx.lamp.maxWidth * nbBlackLines - 1; ++i)
+  for (uint8_t i = 0; i < ctx.lamp.maxWidth * nbBlackLines; ++i)
   {
     ctx.lamp.setPixelColor(i, 0);
   }
 
-  for (uint16_t i = 0; i < ctx.lamp.maxWidth - 1; ++i)
+  for (uint16_t i = 0; i < ctx.lamp.maxWidth; ++i)
   {
     uint8_t rampScale = (i * 255) / ctx.lamp.maxWidth;
     if (rampScale < rampValue)

--- a/src/modes/include/colors/utils.hpp
+++ b/src/modes/include/colors/utils.hpp
@@ -37,6 +37,9 @@ struct ToRGB
   uint8_t r, g, b;
 };
 
+/// Return color (w, w, w) as a single uint32_t integer
+static constexpr LMBD_INLINE uint32_t fromGrey(uint32_t w) { return fromRGB(w, w, w); }
+
 static constexpr uint8_t colorRotation[360] = {
         0,   0,   0,   0,   0,   1,   1,   2,   2,   3,   4,   5,   6,   7,   8,   9,   11,  12,  13,  15,  17,  18,
         20,  22,  24,  26,  28,  30,  32,  35,  37,  39,  42,  44,  47,  49,  52,  55,  58,  60,  63,  66,  69,  72,

--- a/src/modes/include/context_type.hpp
+++ b/src/modes/include/context_type.hpp
@@ -30,7 +30,6 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
   using SelfTy = ContextTy<LocalBasicMode, ModeManager>;
   using ModeManagerTy = ModeManager;
   using LocalModeTy = LocalBasicMode;
-  using ThisLampTy = typename ModeManagerTy::ThisLampTy;
   using StateTy = StateTyOf<LocalModeTy>;
 
   /// \private True if LocalModeTy is a BasicMode
@@ -438,8 +437,8 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
   void LMBD_INLINE skipFirstLedsForFrames(uint8_t amount, uint8_t count = 1)
   {
     auto ctx = modeManager.get_context();
-    ctx.state.skipFirstLedsForAmount = amount;
-    ctx.state.skipFirstLedsForEffect = count;
+    ctx.lamp.config.skipFirstLedsForAmount = amount;
+    ctx.lamp.config.skipFirstLedsForEffect = count;
   }
 
   //
@@ -559,8 +558,8 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
   // context members for direct access
   //
 
-  ThisLampTy& lamp; ///< Interact with the lamp hardware
-  StateTy& state;   ///< Interact with the current active mode state
+  hardware::LampTy& lamp; ///< Interact with the lamp hardware
+  StateTy& state;         ///< Interact with the current active mode state
 
 private:
   ModeManagerTy& modeManager;

--- a/src/modes/include/draw/grid_rule.hpp
+++ b/src/modes/include/draw/grid_rule.hpp
@@ -97,8 +97,9 @@ template<typename ConfigTy = LineRuleConfig> struct LineRule
     currentLine = newLine;
 
     // save result to buffer & move to next line
-    assert(nextStart + width <= buffer.size());
-    std::copy(newLine.begin(), newLine.end(), buffer.begin() + nextStart);
+    if (assertBool(nextStart + width <= buffer.size()))
+      std::copy(newLine.begin(), newLine.end(), buffer.begin() + nextStart);
+
     lastLine = (1 + lastLine) % (nbLines + 1);
   }
 
@@ -146,8 +147,8 @@ template<typename ConfigTy = LineRuleConfig> struct LineRule
     if (lineIndex < nbLines)
     {
       uint16_t lineStart = lineIndex * fwidth;
-      assert(lineStart + width <= buffer.size());
-      std::copy(buffer.cbegin() + lineStart, buffer.cbegin() + lineStart + width, newLine.begin());
+      if (assertBool(lineStart + width <= buffer.size()))
+        std::copy(buffer.cbegin() + lineStart, buffer.cbegin() + lineStart + width, newLine.begin());
     }
 
     return newLine;
@@ -178,8 +179,8 @@ template<typename ConfigTy = LineRuleConfig> struct LineRule
       if (skewed && I == 2)
         shiftStart -= 1;
 
-      assert(shiftStart + line.size() <= buffer.size());
-      std::copy(line.begin() + ((I || !skewed) ? 0 : 1), line.end(), buffer.begin() + shiftStart);
+      if (assertBool(shiftStart + line.size() <= buffer.size()))
+        std::copy(line.begin() + ((I || !skewed) ? 0 : 1), line.end(), buffer.begin() + shiftStart);
     }
   }
 

--- a/src/modes/include/draw/grid_rule.hpp
+++ b/src/modes/include/draw/grid_rule.hpp
@@ -1,0 +1,295 @@
+#ifndef MODES_DRAW_GRID_RULE_HPP
+#define MODES_DRAW_GRID_RULE_HPP
+
+#include <array>
+
+namespace modes::draw::grid {
+
+using LampTy = hardware::LampTy;
+
+struct LineRuleConfig
+{
+  static constexpr uint8_t dstBufIdx = 0;         /// Main buf. used for the grid
+  static constexpr uint8_t srcBufIdx = 1;         /// Sec. buf. used for smooth grid
+  static constexpr uint8_t scrollAmount = 1;      /// Scroll each update
+  static constexpr uint8_t renderBlurAmount = 32; /// Blur before display
+  static constexpr bool scrollSkewed = false;     /// Scroll skewed to the left
+};
+
+/* \brief Implement a line-based grid pattern, update line per line.
+ *
+ * Typical usage is:
+ *
+ * @code{.cpp}
+ *
+ *   static void loop(auto& ctx)
+ *   {
+ *     auto cb = [&](const auto& before, auto& after) {
+ *      // read array "before" for previous line, write updated line to "after" array
+ *     };
+ *
+ *     ctx.state.grid.update(ctx.lamp, cb);
+ *     ctx.state.grid.display(ctx.lamp);
+ *   }
+ *
+ * @endcode
+ *
+ * See examples to learn more about the behavior of this.
+ */
+template<typename ConfigTy = LineRuleConfig> struct LineRule
+{
+  static constexpr uint8_t dstBufIdx = ConfigTy::dstBufIdx; /// \private
+  static constexpr uint8_t srcBufIdx = ConfigTy::srcBufIdx; /// \private
+
+  static constexpr float fwidth = LampTy::maxWidthFloat; /// \private
+  static constexpr uint16_t width = LampTy::maxWidth;    /// \private
+  using LineTy = std::array<uint32_t, width>;            // Type of a line array
+
+  /// Number of lines in grid
+  static constexpr uint16_t nbLines = LampTy::maxHeight;
+
+  /// To be called in the parent .reset() to set \p firstLine as first line
+  void reset(LampTy& lamp, LineTy& firstLine)
+  {
+    lastLine = 0;
+    currentLine = firstLine;
+
+    auto& buffer = lamp.template getTempBuffer<dstBufIdx>();
+    std::copy(currentLine.begin(), currentLine.end(), buffer.begin());
+  }
+
+  /// Reset grip with an empty (black) first line
+  void LMBD_INLINE reset(LampTy& lamp)
+  {
+    LineTy first {};
+    reset(lamp, first);
+  }
+
+  /// When called, pass \p before and \p after line to callback for processing
+  void update(LampTy& lamp, auto& callback)
+  {
+    auto& buffer = lamp.template getTempBuffer<dstBufIdx>();
+
+    uint16_t nextLine = (lastLine + 1) % (nbLines + 1);
+    uint16_t nextStart = nextLine * fwidth;
+    bool endReached = (nextStart + width) > buffer.size();
+
+    // if scrollAmount is 0, then we prefer wrapping the grid
+    if (endReached && ConfigTy::scrollAmount == 0)
+    {
+      nextStart = 0;
+      lastLine = (1 + lastLine) % (nbLines + 1);
+    }
+
+    // if not, scroll grid by scrollAmount (skewed or not)
+    else if (endReached)
+    {
+      scrollBy(lamp, ConfigTy::scrollAmount, ConfigTy::scrollSkewed);
+
+      lastLine -= ConfigTy::scrollAmount;
+      nextLine -= ConfigTy::scrollAmount;
+      nextStart = nextLine * fwidth;
+    }
+
+    // call callback
+    LineTy newLine {};
+    callback(currentLine, newLine);
+    currentLine = newLine;
+
+    // save result to buffer & move to next line
+    assert(nextStart + width <= buffer.size());
+    std::copy(newLine.begin(), newLine.end(), buffer.begin() + nextStart);
+    lastLine = (1 + lastLine) % (nbLines + 1);
+  }
+
+  /// Display the line-rule grid onto screen (if \p reversed reverse it)
+  void display(LampTy& lamp, bool reversed = false)
+  {
+    if (reversed)
+    {
+      lamp.template setColorsFromBufferReversed<dstBufIdx>(true);
+    }
+    else
+    {
+      lamp.template setColorsFromBuffer<dstBufIdx>();
+    }
+  }
+
+  /// Same as \p .update() but uses two buffers, required for \p smoothDisplay()
+  void LMBD_INLINE smoothUpdate(LampTy& lamp, auto& callback)
+  {
+    hardware::LampTy::BufferTy bufCopy = lamp.template getTempBuffer<dstBufIdx>();
+    update(lamp, callback);
+    lamp.template getTempBuffer<srcBufIdx>() = bufCopy;
+  }
+
+  /// Display grid buffers as an in-between frame, at \p phasis (from 0 to 1)
+  void LMBD_INLINE smoothDisplay(LampTy& lamp, float phasis)
+  {
+    lamp.setColorsFromMixedBuffers<dstBufIdx, srcBufIdx>(phasis);
+  }
+
+  /// For a \p counter between 0 and \p maxCounter display a smooth frame
+  void LMBD_INLINE smoothDisplay(LampTy& lamp, uint16_t counter, uint16_t maxCounter, uint16_t maxValue = 256)
+  {
+    uint16_t increment = maxValue / maxCounter;
+    float phase = counter * increment + increment / 2.0;
+    smoothDisplay(lamp, phase / maxValue);
+  }
+
+  /// Return a copy of line at \p lineAtIndex (may be empty if out of screen)
+  LineTy LMBD_INLINE lineAtIndex(LampTy& lamp, uint16_t lineIndex)
+  {
+    const auto& buffer = lamp.template getTempBuffer<dstBufIdx>();
+    LineTy newLine {};
+
+    if (lineIndex < nbLines)
+    {
+      uint16_t lineStart = lineIndex * fwidth;
+      assert(lineStart + width <= buffer.size());
+      std::copy(buffer.cbegin() + lineStart, buffer.cbegin() + lineStart + width, newLine.begin());
+    }
+
+    return newLine;
+  }
+
+  /// Scroll grid by \p amount upward (optionnaly skewed to the left)
+  void scrollBy(LampTy& lamp, uint8_t amount, bool skewed)
+  {
+    auto& buffer = lamp.template getTempBuffer<dstBufIdx>();
+
+    for (uint16_t I = 0; I < nbLines; ++I)
+    {
+      auto line = lineAtIndex(lamp, I + amount);
+      uint16_t shiftStart = I * fwidth;
+      uint16_t shiftTweak = I * fwidth + 0.5;
+
+      // unholy coordinate system w/ LEDs 0.041151pt too long
+      constexpr uint16_t residue = 1 / (2 * fwidth - 2 * floor(fwidth) - 1);
+
+      if (skewed && shiftStart == shiftTweak && (I > 2 && I != residue))
+      {
+        auto last = line[0];
+        std::copy(line.begin() + 1, line.end(), line.begin());
+        line[line.size() - 1] = last;
+      }
+
+      // (at that point I gave up finding why)
+      if (skewed && I == 2)
+        shiftStart -= 1;
+
+      assert(shiftStart + line.size() <= buffer.size());
+      std::copy(line.begin() + ((I || !skewed) ? 0 : 1), line.end(), buffer.begin() + shiftStart);
+    }
+  }
+
+  /* \brief Default loop function, update and display, smooth display if fast
+   *
+   * If \p hasCustomRamp is True, uses internally custom ramp to configure
+   * update speed of the grid. If fast and high luminosity, try smoothing the
+   * display, if slow or low luminosity, disable smoothing to avoid user seeing
+   * a blurry "marching effect" between updates.
+   *
+   * If \p hasCustomRamp is False, use \p rampSubstitute as value, higher being
+   * slower (from 0 to 256). Use \p baseSmooth to configure how fast the smooth
+   * mode can go, value 0 being the fastest, and 10 disabling smoothing.
+   *
+   */
+  template<bool hasCustomRamp, uint8_t rampSubstitute = 70, uint8_t baseSmooth = 4>
+  void LMBD_INLINE loop(auto& ctx, auto& callback)
+  {
+    auto& lamp = ctx.lamp;
+    uint8_t rampValue = (hasCustomRamp ? ctx.get_active_custom_ramp() : rampSubstitute);
+
+    // by default, quickly run smoothly the grid scrolling
+    uint16_t smoothFrame = baseSmooth + rampValue / 16;
+    if (smoothFrame <= 10 && lamp.getBrightness() > 32)
+    {
+      uint32_t counter = lamp.raw_frame_count % smoothFrame;
+      if (!counter)
+        smoothUpdate(lamp, callback);
+
+      smoothDisplay(lamp, counter, smoothFrame);
+      if constexpr (ConfigTy::renderBlurAmount)
+        lamp.getLegacyStrip().blur(ConfigTy::renderBlurAmount);
+
+      // coarser display for slow scrolling (smoothing too visible)
+    }
+    else
+    {
+      int now = lamp.get_time_ms();
+      int frameDuration = rampValue + lamp.frameDurationMs;
+
+      if (abs(int(now - lastUpdate)) > frameDuration)
+      {
+        lastUpdate = now;
+        update(lamp, callback);
+
+        display(lamp);
+        if constexpr (ConfigTy::renderBlurAmount)
+          lamp.getLegacyStrip().blur(ConfigTy::renderBlurAmount);
+      }
+    }
+  }
+
+  LineTy currentLine;
+  uint16_t lastLine = 0;
+  uint32_t lastUpdate = 0;
+};
+
+/** \brief Process 1-d cellular automata from \p before to \p after array
+ *
+ * In order:
+ *
+ *  - \p ruleNo is the wolframe rule number
+ *  - \p straight if True, skew the automata, to get triangles to be "straight"
+ *  - \p leftBound if True, do not wrap arrays on the left boundary
+ *  - \p rightBound if TRue, do not wrap arrays on the right boundary
+ *  - \p nbBits process only some (24 default) lower bits of the input arrays
+ */
+template<uint8_t ruleNo, bool straight = false, bool leftBound = false, bool rightBound = false, uint8_t nbBits = 24>
+void wolframRule(const auto& before, auto& after)
+{
+  constexpr uint8_t pattern[8] = {0b1 & (ruleNo >> 7),
+                                  0b1 & (ruleNo >> 6),
+                                  0b1 & (ruleNo >> 5),
+                                  0b1 & (ruleNo >> 4),
+                                  0b1 & (ruleNo >> 3),
+                                  0b1 & (ruleNo >> 2),
+                                  0b1 & (ruleNo >> 1),
+                                  0b1 & (ruleNo >> 0)};
+
+  uint16_t start = leftBound ? 1 : 0;
+  uint16_t end = rightBound ? after.size() - 1 : after.size();
+
+  for (uint16_t I = start; I < end; ++I)
+  {
+    uint16_t J = (I + (straight ? 1 : 0)) % end;
+    after[J] = 0;
+
+    for (uint32_t P = 0; P < nbBits; ++P)
+    {
+      uint32_t mask = 1 << P;
+      uint32_t l = before[(I + before.size() - 1) % before.size()] & mask;
+      uint32_t m = before[I] & mask;
+      uint32_t r = before[(I + 1) % before.size()] & mask;
+
+      uint8_t lmr = 0;
+      if (l)
+        lmr |= 0b100;
+      if (m)
+        lmr |= 0b010;
+      if (r)
+        lmr |= 0b001;
+
+      if (pattern[lmr])
+      {
+        after[J] |= mask;
+      }
+    }
+  }
+}
+
+} // namespace modes::draw::grid
+
+#endif

--- a/src/modes/include/group_type.hpp
+++ b/src/modes/include/group_type.hpp
@@ -7,11 +7,12 @@
  **/
 
 #include <cstdint>
-#include <cassert>
 #include <utility>
 #include <optional>
 #include <tuple>
 #include <array>
+
+#include <src/system/assert.h>
 
 #include "src/modes/include/context_type.hpp"
 #include "src/modes/include/manager_type.hpp"

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -1,10 +1,9 @@
 #ifndef MODES_HARDWARE_LAMP_TYPE_HPP
 #define MODES_HARDWARE_LAMP_TYPE_HPP
 
-#include <cassert>
-
 #include "src/compile.h"
 #include "src/user/constants.h"
+#include <src/system/assert.h>
 #include "src/system/utils/curves.h"
 #include "src/system/utils/constants.h"
 #include "src/system/utils/brightness_handle.h"

--- a/src/modes/include/manager_type.hpp
+++ b/src/modes/include/manager_type.hpp
@@ -7,10 +7,11 @@
  **/
 
 #include <cstdint>
-#include <cassert>
 #include <utility>
 #include <tuple>
 #include <array>
+
+#include <src/system/assert.h>
 
 #include "src/modes/include/tools.hpp"
 #include "src/modes/include/context_type.hpp"

--- a/src/modes/include/manager_type.hpp
+++ b/src/modes/include/manager_type.hpp
@@ -482,11 +482,11 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
       return;
     }
 
+    ctx.lamp.refresh_tick_value();
+
     dispatch_group(ctx, [](auto group) {
       group.loop();
     });
-
-    ctx.lamp.refresh_tick_value();
   }
 
   static void brightness_update(auto& ctx, brightness_t brightness)

--- a/src/modes/include/manager_type.hpp
+++ b/src/modes/include/manager_type.hpp
@@ -121,7 +121,6 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
 {
   using SelfTy = ModeManagerTy<Config, AllGroups>;
   using ConfigTy = Config;
-  using ThisLampTy = hardware::LampTy<SelfTy>;
   using AllGroupsTy = AllGroups;
   using AllStatesTy = details::StateTyFrom<AllGroups>;
   static constexpr uint8_t nbGroups {std::tuple_size_v<AllGroupsTy>};
@@ -140,10 +139,7 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
   static constexpr bool hasButtonCustomUI = HasAnyGroup::hasButtonCustomUI;
 
   // constructors
-  ModeManagerTy(ThisLampTy& lamp) : activeIndex {ActiveIndexTy::from(Config::initialActiveIndex)}, lamp {lamp}
-  {
-    lamp._stateManagerPtr = &(get_context().state);
-  }
+  ModeManagerTy(hardware::LampTy& lamp) : activeIndex {ActiveIndexTy::from(Config::initialActiveIndex)}, lamp {lamp} {}
 
   ModeManagerTy() = delete;
   ModeManagerTy(const ModeManagerTy&) = delete;
@@ -236,9 +232,11 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
     bool clearStripOnModeChange = Config::defaultClearStripOnModeChange;
 
     // special effects
-    uint8_t skipNextFrameEffect = 0;    // should the next .loop() mode be skipped?
-    uint8_t skipFirstLedsForEffect = 0; // should the loop skip some lower LEDs?
-    uint8_t skipFirstLedsForAmount = 0; // how many pixels to shave from the top?
+    uint8_t skipNextFrameEffect = 0; // should the next .loop() mode be skipped?
+
+    // inside lamp.config
+    //  - skipFirstLedsForEffect = 0; // should the loop skip some lower LEDs?
+    //  - skipFirstLedsForAmount = 0; // how many pixels to shave from the top?
 
     // configuration-related actions done before mode reset
     static void LMBD_INLINE before_reset(auto& ctx)
@@ -473,9 +471,9 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
       }
     }
 
-    if (ctx.state.skipFirstLedsForEffect > 0)
+    if (ctx.lamp.config.skipFirstLedsForEffect > 0)
     {
-      ctx.state.skipFirstLedsForEffect -= 1;
+      ctx.lamp.config.skipFirstLedsForEffect -= 1;
     }
 
     if (ctx.state.skipNextFrameEffect > 0)
@@ -610,7 +608,7 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
   //
 
   ActiveIndexTy activeIndex;
-  ThisLampTy& lamp;
+  hardware::LampTy& lamp;
 
   //
   // private members

--- a/src/system/assert.h
+++ b/src/system/assert.h
@@ -1,0 +1,14 @@
+#ifndef SRC_SYSTEM_ASSERT_H
+#define SRC_SYSTEM_ASSERT_H
+
+#include <cassert>
+
+#ifdef NDEBUG
+static bool assertBool(int expression) { return expression; }
+#else
+#define assertBool(condition) \
+  assert(condition);          \
+  true
+#endif
+
+#endif

--- a/src/system/utils/utils.h
+++ b/src/system/utils/utils.h
@@ -29,7 +29,7 @@ template<typename T, typename U> static constexpr U lmpd_map(T x, T in_min, T in
 template<typename N, typename M> static constexpr N min(const N a, const M b) { return a < b ? a : b; }
 template<typename N, typename M> static constexpr N max(const N a, const M b) { return a > b ? a : b; }
 
-template<typename N> static constexpr N abs(const N a) { return std::abs(a); }
+template<typename N> static constexpr N abs(const N a) { return std::abs(N(a)); }
 
 #endif
 

--- a/src/user/indexable_functions.cpp
+++ b/src/user/indexable_functions.cpp
@@ -41,7 +41,7 @@ constexpr DigitalPin::GPIO ledStripPinId = DigitalPin::GPIO::gpio6;
 static DigitalPin LedStripPin(ledStripPinId);
 
 LedStrip strip(LedStripPin.pin());
-modes::hardware::LampTy<ManagerTy> lamp {strip};
+modes::hardware::LampTy lamp {strip};
 ManagerTy modeManager(lamp);
 
 } // namespace _private


### PR DESCRIPTION
Closes #192 

Partial work on #127 with a "line per line" (1D) grid system, to be improved later (get 2D & better doc)

Adds `BubbleMode` and `SierpinskiMode` modes in `modes/examples`:

![BubbleMode](https://github.com/user-attachments/assets/7ed7859f-3afd-44f3-8208-9f6216f9da31)
![SerpinskiMode](https://github.com/user-attachments/assets/043cfa4c-a00e-452c-b874-c8b8b6885ff0)


(if merged, I'll list them in #150 as they use yet-to-be-migrated `blur`+`get_gradient`)