### PR TITLE
Lower vbus detection threshold only when battery is charging

### DIFF
--- a/src/system/power/PDlib/power_delivery.cpp
+++ b/src/system/power/PDlib/power_delivery.cpp
@@ -97,8 +97,13 @@ void ic_interrupt()
 bool is_vbus_powered()
 {
   // isVbusPresent = pd_is_vbus_present(devicePort);
+
   // more reliable when vbus is under load
-  return get_vbus_voltage() >= 3000;
+  if (charger::drivers::get_measurments().batChargeCurrent_mA >= 50)
+    return get_vbus_voltage() >= 3000;
+  else
+    // no load, threshold is higher
+    return get_vbus_voltage() >= 4300;
 }
 
 struct UsbPDData

--- a/src/system/utils/constants.h
+++ b/src/system/utils/constants.h
@@ -20,6 +20,9 @@
 #if HARDWARE_VERSION_MAJOR == 1 && HARDWARE_VERSION_MINOR == 0
 #define IS_HARDWARE_1_0
 #endif
+#if HARDWARE_VERSION_MAJOR == 1 && HARDWARE_VERSION_MINOR == 1
+#define IS_HARDWARE_1_1
+#endif
 
 // expected firmware version, will not compile if missmatch
 // Update your dependencies : adafruit lampda_nrf52840


### PR DESCRIPTION
Linked to #218 
Do not resolve the problem of leakage current, but remove the 'power detected' alert when the leakage occurs