### PR TITLE
Add brightness graph on simulator

### DIFF
--- a/simulator/include/default_simulation.h
+++ b/simulator/include/default_simulation.h
@@ -12,8 +12,12 @@ struct defaultSimulation
   float fakeXorigin = 0; // start lamp N led to the left
   float fakeXend = 0;    // remove N led from right
 
-  float buttonSize = 40.f;   // draw a lamp button of 40 pixels
-  float buttonMargin = 15.f; // draw a button color indicator 10 pixels larger
+  float buttonSize = 40.f;    // draw a lamp button of 40 pixels
+  float buttonMargin = 15.f;  // draw a button color indicator 10 pixels larger
+  float buttonLeftPos = 80.f; // draw a lamp button 80 pixels from the left
+
+  float brightnessRate = 4.f;    // record brightness every n-th frame
+  float brightnessScale = 120.f; // how tall is the brightness graph
 
   defaultSimulation() {}
 };


### PR DESCRIPTION
Just a quick one to have fun:

<img width="732" height="857" alt="2025-08-27_17-50" src="https://github.com/user-attachments/assets/2e6e6d43-ebdd-40b6-82f6-f0fc6fb0982c" />

As we're going to write temporal animations on the brightness level, let's graph that