### PR TITLE
Add output gate timing blip

### DIFF
--- a/simulator/mocks/gpio_mock.cpp
+++ b/simulator/mocks/gpio_mock.cpp
@@ -7,6 +7,8 @@
 #include "src/system/utils/input_output.h"
 #include "src/system/utils/utils.h"
 
+#include "src/system/physical/indicator.h"
+
 #include "simulator/include/hardware_influencer.h"
 
 #define PLATFORM_GPIO_CPP
@@ -68,18 +70,18 @@ public:
     {
       case RedIndicator:
         {
-          mock_indicator::idColor.red = (value & 255);
+          mock_indicator::idColor.red = (value & 255) / indicator::redColorCorrection;
           break;
         }
       case GreenIndicator:
         {
           // correction value for the real luminosity
-          mock_indicator::idColor.green = (value & 255) * 7.5;
+          mock_indicator::idColor.green = (value & 255) / indicator::greenColorCorrection;
           break;
         }
       case BlueIndicator:
         {
-          mock_indicator::idColor.blue = (value & 255);
+          mock_indicator::idColor.blue = (value & 255) / indicator::blueColorCorrection;
           break;
         }
     }

--- a/src/system/behavior.cpp
+++ b/src/system/behavior.cpp
@@ -468,7 +468,7 @@ std::string get_error_state_message()
 void handle_error_state()
 {
   set_error_state_message("Unspecified raised error state reason");
-  powergates::disable_gates();
+  outputPower::disable_power_gates();
 
   // not allowed to start, can only be stopped
   // turn off system is needed

--- a/src/system/physical/button.cpp
+++ b/src/system/physical/button.cpp
@@ -11,9 +11,6 @@
 
 #include "src/system/platform/time.h"
 
-#define RELEASE_TIMING_MS      250 // time to release the button after no inputs
-#define RELEASE_BETWEEN_CLICKS 50  // minimum release timing (debounce)
-
 namespace button {
 
 static ButtonStateTy buttonState = ButtonStateTy();
@@ -57,6 +54,11 @@ void button_state_interrupt()
 
 void init(const bool isSystemStartedFromButton)
 {
+  static_assert(RELEASE_BETWEEN_CLICKS < RELEASE_TIMING_MS,
+                "release debounce should always be less than release timing");
+  static_assert((RELEASE_BETWEEN_CLICKS + RELEASE_TIMING_MS) < HOLD_BUTTON_MIN_MS,
+                "button release timing should always be less then the button hold timing");
+
   // attach the button interrupt
   ButtonPin.set_pin_mode(DigitalPin::Mode::kInputPullUpSense);
   ButtonPin.attach_callback(button_state_interrupt, DigitalPin::Interrupt::kChange);

--- a/src/system/physical/button.h
+++ b/src/system/physical/button.h
@@ -6,7 +6,9 @@
 
 namespace button {
 
-#define HOLD_BUTTON_MIN_MS 500 // press and hold delay (ms)
+#define RELEASE_BETWEEN_CLICKS 50  // minimum release timing (debounce)
+#define RELEASE_TIMING_MS      250 // time to release the button after no inputs
+#define HOLD_BUTTON_MIN_MS     500 // press and hold delay (ms)
 
 void init(const bool isSystemStartedFromButton);
 

--- a/src/system/physical/indicator.cpp
+++ b/src/system/physical/indicator.cpp
@@ -29,11 +29,6 @@ void init()
 
 void set_color(const utils::ColorSpace::RGB& c)
 {
-  // Red green and blue leds of this indicators do not have the same power
-  static constexpr float redColorCorrection = 1.0;
-  static constexpr float greenColorCorrection = 1.0 / 3.0;
-  static constexpr float blueColorCorrection = 1.0 / 4.0;
-
   const COLOR& col = c.get_rgb();
   ButtonRedPin.write(col.red * redColorCorrection);
   ButtonGreenPin.write(col.green * greenColorCorrection);

--- a/src/system/physical/indicator.h
+++ b/src/system/physical/indicator.h
@@ -6,6 +6,11 @@
 
 namespace indicator {
 
+// Red green and blue leds of this indicators do not have the same power
+static constexpr float redColorCorrection = 1.0;
+static constexpr float greenColorCorrection = 1.0 / 3.0;
+static constexpr float blueColorCorrection = 1.0 / 4.0;
+
 extern void init();
 
 extern void set_color(const utils::ColorSpace::RGB& c);

--- a/src/system/physical/output_power.cpp
+++ b/src/system/physical/output_power.cpp
@@ -27,7 +27,7 @@ void write_voltage(const uint16_t voltage_mv)
   power::set_output_max_current_mA(3000);
 }
 
-void blip() { powergates::power::blip(); }
+void blip(const uint32_t timing) { powergates::power::blip(timing); }
 
 void disable_power_gates() { powergates::disable_gates(); }
 

--- a/src/system/physical/output_power.h
+++ b/src/system/physical/output_power.h
@@ -12,7 +12,7 @@ extern void write_voltage(const uint16_t voltage_mv);
 /**
  * \brief Very short interruption of output voltage
  */
-extern void blip();
+extern void blip(const uint32_t timing);
 
 /**
  * \brief close all external voltage path

--- a/src/system/power/power_gates.h
+++ b/src/system/power/power_gates.h
@@ -1,6 +1,7 @@
 #ifndef POWER_GATES_H
 #define POWER_GATES_H
 
+#include <cstdint>
 namespace powergates {
 
 void init();
@@ -11,8 +12,9 @@ namespace power {
 
 /**
  * \brief blip power gate (very short power interruption)
+ * \param[in] timing a timing in milliseconds, limited to 1 second
  */
-void blip();
+void blip(const uint32_t timing);
 
 } // namespace power
 

--- a/src/system/power/power_handler.cpp
+++ b/src/system/power/power_handler.cpp
@@ -207,11 +207,11 @@ void handle_output_voltage_mode()
 
   set_otg_parameters(_outputVoltage_mV, _outputCurrent_mA);
 
-  // open power gate when voltage matches expected voltage
-  uint32_t vbusVoltage = get_power_rail_voltage();
+  // enable power gate when voltage matches expected voltage
+  const uint32_t vbusVoltage = get_power_rail_voltage();
   if (vbusVoltage >= _outputVoltage_mV * 0.9 and vbusVoltage <= _outputVoltage_mV * 1.1)
   {
-    // close power gate
+    // enable power gate
     powergates::enable_power_gate();
     s_isOutputModeReady = true;
   }

--- a/src/user/cct_functions.cpp
+++ b/src/user/cct_functions.cpp
@@ -66,7 +66,7 @@ void brightness_update(const brightness_t brightness)
   if (constraintBrightness == maxBrightness)
   {
     // blip
-    outputPower::blip();
+    outputPower::blip(50);
   }
 
   // map to a new curve, favorising low levels

--- a/src/user/simple_functions.cpp
+++ b/src/user/simple_functions.cpp
@@ -34,7 +34,7 @@ void brightness_update(const brightness_t brightness)
   if (constraintBrightness >= maxBrightness)
   {
     // blip
-    outputPower::blip();
+    outputPower::blip(50);
   }
 
   // map to a new curve, favorising low levels


### PR DESCRIPTION
Close #242

Allow fast shutdown and turn on of output power.
Should not be used with the indexable type