### PR TITLE
Reset ramp handler cleanly

### DIFF
--- a/src/modes/custom/my_custom_mode.hpp
+++ b/src/modes/custom/my_custom_mode.hpp
@@ -4,7 +4,7 @@
 struct MyCustomMode : public modes::BasicMode
 {
   static void loop(auto& ctx) {}
-  static void reset(auto& ctx) {}
+  static void on_enter_mode(auto& ctx) {}
 
   // only if hasBrightCallback
   static void brightness_update(auto& ctx, brightness_t brightness) {}

--- a/src/modes/default/fireplace.hpp
+++ b/src/modes/default/fireplace.hpp
@@ -30,7 +30,7 @@ struct FireMode : public BasicMode
     audio::SoundEventTy<> soundEvent;
   };
 
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     ctx.state.soundEvent.reset(ctx);
 

--- a/src/modes/default/fixed_modes.hpp
+++ b/src/modes/default/fixed_modes.hpp
@@ -17,7 +17,7 @@ struct KelvinMode : public modes::BasicMode
   static void loop(auto& ctx) { ctx.lamp.setLightTemp(ctx.get_active_custom_ramp()); }
 
   // configure custom ramp
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     ctx.template set_config_bool<ConfigKeys::rampSaturates>(true);
     ctx.template set_config_bool<ConfigKeys::customRampAnimEffect>(false);
@@ -31,7 +31,7 @@ struct KelvinMode : public modes::BasicMode
 struct RainbowMode : public modes::BasicMode
 {
   // configure custom ramp
-  static void reset(auto& ctx) { ctx.template set_config_bool<ConfigKeys::customRampAnimEffect>(false); }
+  static void on_enter_mode(auto& ctx) { ctx.template set_config_bool<ConfigKeys::customRampAnimEffect>(false); }
 
   static void loop(auto& ctx)
   {
@@ -53,7 +53,7 @@ struct RainbowMode : public modes::BasicMode
 /// Single-color mode for indexable strips with palette ramp
 struct PaletteMode : public modes::BasicMode
 {
-  static void reset(auto& ctx) { ctx.template set_config_bool<ConfigKeys::customRampAnimEffect>(false); }
+  static void on_enter_mode(auto& ctx) { ctx.template set_config_bool<ConfigKeys::customRampAnimEffect>(false); }
 
   static void loop(auto& ctx)
   {

--- a/src/modes/default/sine_mode.hpp
+++ b/src/modes/default/sine_mode.hpp
@@ -20,7 +20,7 @@ struct SineMode : public modes::BasicMode
     uint16_t step;
   };
 
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     ctx.state.step = 0;
 

--- a/src/modes/example/automaton.hpp
+++ b/src/modes/example/automaton.hpp
@@ -32,7 +32,7 @@ struct BubbleMode : public BasicMode
   static constexpr auto algeaColor = colors::ForestGreen;
   static constexpr auto starColor = colors::Gold;
 
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     // fill the initial automata with zeros +few colored pixels
     GridTy::LineTy first {};
@@ -140,7 +140,7 @@ struct SierpinskiMode : public BasicMode
     GridTy grid;
   };
 
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     // fill the initial automata with zeros +few colored pixels
     GridTy::LineTy first {};

--- a/src/modes/include/audio/utils.hpp
+++ b/src/modes/include/audio/utils.hpp
@@ -20,7 +20,7 @@ namespace modes::audio {
  *      modes::audio::SoundEventTy<> soundEvent;
  *    };
  *
- *    static void reset(auto& ctx) {
+ *    static void on_enter_mode(auto& ctx) {
  *      ctx.state.soundEvent.reset(ctx);
  *    }
  *
@@ -83,7 +83,7 @@ struct SoundEventTy
   /// Window size used for ``avgDelta``
   static constexpr float _windowShort = windowShort / 4.0;
 
-  /// Call this once inside the mode reset callback
+  /// Call this once inside the mode on_enter_mode callback
   void reset(auto& ctx)
   {
     level = ctx.lamp.get_sound_level();

--- a/src/modes/include/context_type.hpp
+++ b/src/modes/include/context_type.hpp
@@ -151,20 +151,6 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
     }
   }
 
-  /// \private Reset active mode
-  auto LMBD_INLINE reset_mode()
-  {
-    if constexpr (LocalModeTy::isModeManager)
-    {
-      LocalModeTy::reset_mode(*this);
-    }
-    else
-    {
-      auto& manager = modeManager.get_context();
-      return manager.reset_mode();
-    }
-  }
-
   //
   // getters / setters for activeIndex
   //
@@ -533,14 +519,14 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
     this->lamp.getLegacyStrip().signal_display();
   }
 
-  /// Binds to local BasicMode::reset()
-  void LMBD_INLINE reset()
+  /// Binds to local BasicMode::on_enter_mode()
+  void LMBD_INLINE on_enter_mode()
   {
     if (hasStore)
     {
       LocalStore::template migrateStoreIfNeeded<LocalModeTy::storeId>();
     }
-    LocalModeTy::reset(*this);
+    LocalModeTy::on_enter_mode(*this);
   }
 
   /// Binds to local BasicMode::brightness_update()

--- a/src/modes/include/default_config.hpp
+++ b/src/modes/include/default_config.hpp
@@ -78,7 +78,7 @@ struct DefaultManagerConfig
 
 /** \brief Keys to enable modes to change configuration at runtime.
  *
- * During modes::BasicMode::reset() callback, modes can change configuration
+ * During modes::BasicMode::on_enter_mode() callback, modes can change configuration
  * temporarily, for example to change how the ramp behaves, or how fast it
  * goes.
  *
@@ -86,7 +86,7 @@ struct DefaultManagerConfig
  *
  * ```
  *   // set value for "rampSaturates" to "True" for active mode
- *   static void reset(auto& ctx) {
+ *   static void on_enter_mode(auto& ctx) {
  *     ctx.template set_config_bool<ConfigKeys::rampSaturates>(true);
  *   }
  * ```
@@ -95,7 +95,7 @@ struct DefaultManagerConfig
  *
  * ```
  *   // set value for "customRampStepSpeedMs" to "32" for active mode
- *   static void reset(auto& ctx) {
+ *   static void on_enter_mode(auto& ctx) {
  *     ctx.template set_config_u32<ConfigKeys::customRampStepSpeedMs>(32);
  *   }
  * ```

--- a/src/modes/include/group_type.hpp
+++ b/src/modes/include/group_type.hpp
@@ -190,13 +190,6 @@ template<typename AllModes, bool earlyFail = verifyGroup<AllModes>()> struct Gro
     ctx.set_active_mode(modeIdBefore + 1, nbModes);
   }
 
-  static void reset_mode(auto& ctx)
-  {
-    dispatch_mode(ctx, [](auto mode) {
-      mode.reset();
-    });
-  }
-
   static void enter_mode(auto& ctx)
   {
     // set ramps if they exist
@@ -206,8 +199,10 @@ template<typename AllModes, bool earlyFail = verifyGroup<AllModes>()> struct Gro
       ctx.state.load_ramps(ctx, modeIdAfter);
     }
 
-    // reset new mode we switched to
-    ctx.reset_mode();
+    // start new mode we switched to
+    dispatch_mode(ctx, [](auto mode) {
+      mode.on_enter_mode();
+    });
   }
 
   static void quit_mode(auto& ctx)

--- a/src/modes/include/manager_type.hpp
+++ b/src/modes/include/manager_type.hpp
@@ -259,16 +259,16 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
     //  - skipFirstLedsForEffect = 0; // should the loop skip some lower LEDs?
     //  - skipFirstLedsForAmount = 0; // how many pixels to shave from the top?
 
-    // configuration-related actions done before mode reset
-    static void LMBD_INLINE before_reset(auto& ctx)
+    // configuration-related actions done before entering mode
+    static void LMBD_INLINE before_enter_mode(auto& ctx)
     {
       auto& self = ctx.state;
       self.rampHandler.reset();
       self.clearStripOnModeChange = Config::defaultClearStripOnModeChange;
     }
 
-    // configuration-related actions done after mode reset
-    static void LMBD_INLINE after_reset(auto& ctx)
+    // configuration-related actions done after mode entering
+    static void LMBD_INLINE after_enter_mode(auto& ctx)
     {
       auto& self = ctx.state;
       if (self.clearStripOnModeChange)
@@ -394,7 +394,7 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
     ctx.modeManager.activeIndex.customIndex = newActiveIndex.customIndex;
     ctx.modeManager.activeIndex.rampIndex = newActiveIndex.rampIndex;
 
-    // if ramps loaded in reset_mode != ones saved as favorite, emulate update
+    // if ramps loaded in enter_mode != ones saved as favorite, emulate update
     if (ctx.modeManager.activeIndex.rawIndex != newActiveIndex.rawIndex)
     {
       ctx.modeManager.activeIndex = newActiveIndex;
@@ -444,15 +444,6 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
     }
   }
 
-  static void reset_mode(auto& ctx)
-  {
-    ctx.state.before_reset(ctx);
-    dispatch_group(ctx, [](auto group) {
-      group.reset_mode();
-    });
-    ctx.state.after_reset(ctx);
-  }
-
   static uint8_t get_modes_count(auto& ctx)
   {
     uint8_t value = 0;
@@ -486,18 +477,14 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
 
   static void enter_mode(auto& ctx)
   {
-    // this is a bit hackish
-    // before reset is mandatory here to reset the ramps correctly
-    ctx.state.before_reset(ctx);
+    ctx.state.before_enter_mode(ctx);
 
     // enter mode
     dispatch_group(ctx, [](auto group) {
       group.enter_mode();
     });
 
-    // this is a bit hackish
-    // after reset is mandatory here to reset the ramps correctly
-    ctx.state.after_reset(ctx);
+    ctx.state.after_enter_mode(ctx);
   }
 
   static void quit_mode(auto& ctx)

--- a/src/modes/include/manager_type.hpp
+++ b/src/modes/include/manager_type.hpp
@@ -66,6 +66,15 @@ template<typename Config> struct RampHandlerTy
   {
   }
 
+  void LMBD_INLINE reset()
+  {
+    isForward = true;
+    stepSpeed = Config::defaultCustomRampStepSpeedMs;
+    rampSaturates = Config::defaultRampSaturates;
+    animEffect = Config::defaultCustomRampAnimEffect;
+    animChoice = Config::defaultCustomRampAnimChoice;
+  }
+
   void LMBD_INLINE update_ramp(uint8_t rampValue, uint32_t holdTime, auto callback)
   {
     // restart the rampage
@@ -254,8 +263,7 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
     static void LMBD_INLINE before_reset(auto& ctx)
     {
       auto& self = ctx.state;
-      self.rampHandler.rampSaturates = Config::defaultRampSaturates;
-      self.rampHandler.stepSpeed = Config::defaultCustomRampStepSpeedMs;
+      self.rampHandler.reset();
       self.clearStripOnModeChange = Config::defaultClearStripOnModeChange;
     }
 

--- a/src/modes/include/manager_type.hpp
+++ b/src/modes/include/manager_type.hpp
@@ -378,11 +378,9 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
 
   static void next_mode(auto& ctx)
   {
-    ctx.state.before_reset(ctx);
     dispatch_group(ctx, [](auto group) {
       group.next_mode();
     });
-    ctx.state.after_reset(ctx);
   }
 
   /// jump to an active index cleanly
@@ -488,9 +486,18 @@ template<typename Config, typename AllGroups> struct ModeManagerTy
 
   static void enter_mode(auto& ctx)
   {
+    // this is a bit hackish
+    // before reset is mandatory here to reset the ramps correctly
+    ctx.state.before_reset(ctx);
+
+    // enter mode
     dispatch_group(ctx, [](auto group) {
       group.enter_mode();
     });
+
+    // this is a bit hackish
+    // after reset is mandatory here to reset the ramps correctly
+    ctx.state.after_reset(ctx);
   }
 
   static void quit_mode(auto& ctx)

--- a/src/modes/include/mode_type.hpp
+++ b/src/modes/include/mode_type.hpp
@@ -72,7 +72,7 @@ struct BasicMode
    *
    * \param[in] ctx The current context
    */
-  static void reset(auto& ctx) { return; }
+  static void on_enter_mode(auto& ctx) { return; }
 
   /// Toggles the use of custom BasicMode::brightness_update() callback
   static constexpr bool hasBrightCallback = false;

--- a/src/modes/legacy/legacy_modes.hpp
+++ b/src/modes/legacy/legacy_modes.hpp
@@ -38,7 +38,7 @@ struct RainbowSwirlMode : public LegacyMode
     state.rainbowSwirl.update();
   }
 
-  static void reset(auto& ctx) { ctx.state.rainbowSwirl.reset(); }
+  static void on_enter_mode(auto& ctx) { ctx.state.rainbowSwirl.reset(); }
 
   struct StateTy
   {
@@ -60,7 +60,7 @@ struct PartyFadeMode : public LegacyMode
     }
   }
 
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     auto& state = ctx.state;
     state.currentIndex = 0;
@@ -96,7 +96,7 @@ struct NoiseMode : public LegacyMode
     state.selectedPalette = state._palettes[rampIndex];
   }
 
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     ctx.state.categoryChange = true;
     ctx.template set_config_bool<ConfigKeys::rampSaturates>(false);
@@ -129,7 +129,7 @@ struct PolarMode : public LegacyMode
     categoryChange = false;
   }
 
-  static void reset(auto& ctx) { ctx.state.categoryChange = true; }
+  static void on_enter_mode(auto& ctx) { ctx.state.categoryChange = true; }
 
   struct StateTy
   {
@@ -177,7 +177,7 @@ struct ColorWipeMode : public LegacyMode
     }
   }
 
-  static void reset(auto& ctx) { ctx.state.complementaryColor.reset(); }
+  static void on_enter_mode(auto& ctx) { ctx.state.complementaryColor.reset(); }
 
   struct StateTy
   {
@@ -202,7 +202,7 @@ struct RandomFillMode : public LegacyMode
     }
   }
 
-  static void reset(auto& ctx) { ctx.state.randomColor.reset(); }
+  static void on_enter_mode(auto& ctx) { ctx.state.randomColor.reset(); }
 
   struct StateTy
   {
@@ -226,7 +226,7 @@ struct PingPongMode : public LegacyMode
     }
   }
 
-  static void reset(auto& ctx) { ctx.state.complementaryPingPongColor.reset(); }
+  static void on_enter_mode(auto& ctx) { ctx.state.complementaryPingPongColor.reset(); }
 
   struct StateTy
   {
@@ -247,7 +247,7 @@ struct VuMeterMode : public LegacyMode
     animations::vu_meter(state.redToGreenGradient, 128, ctx.lamp.getLegacyStrip());
   }
 
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     auto& state = ctx.state;
     state.redToGreenGradient.reset();
@@ -264,7 +264,7 @@ struct FftMode : public LegacyMode
 {
   static void loop(auto& ctx) { animations::fft_display(64, 64, PalettePartyColors, ctx.lamp.getLegacyStrip()); }
 
-  static void reset(auto& ctx) {}
+  static void on_enter_mode(auto& ctx) {}
 
   struct StateTy
   {
@@ -298,7 +298,7 @@ struct LiquideMode : public LegacyMode
     state._color = state._colors[rampIndex];
   }
 
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     auto& state = ctx.state;
     for (DynamicColor* color: state._colors)
@@ -342,7 +342,7 @@ struct LiquideRainMode : public LegacyMode
 
   static void custom_ramp_update(auto& ctx, uint8_t rampValue) { ctx.state.density = rampValue; }
 
-  static void reset(auto& ctx)
+  static void on_enter_mode(auto& ctx)
   {
     auto& state = ctx.state;
     state.color.reset();

--- a/src/modes/user/indexable_behavior.hpp
+++ b/src/modes/user/indexable_behavior.hpp
@@ -98,6 +98,8 @@ void button_clicked_default(const uint8_t clicks)
       fprintf(stderr, " - hasBrightCallback\n");
     if (manager.everyCustomRamp[_groupId][_modeId])
       fprintf(stderr, " - hasCustomRamp\n");
+    if (manager.state.rampHandler.animEffect)
+      fprintf(stderr, " - has anim effect\n");
     if (manager.everyRequireUserThread[_groupId][_modeId])
       fprintf(stderr, " - requireUserThread\n");
     if (manager.everySystemCallbacks[_groupId][_modeId])

--- a/src/modes/user/indexable_behavior.hpp
+++ b/src/modes/user/indexable_behavior.hpp
@@ -56,7 +56,6 @@ void read_parameters()
 {
   auto manager = get_context();
   manager.read_parameters();
-  manager.reset_mode();
 }
 
 void button_clicked_default(const uint8_t clicks)


### PR DESCRIPTION
Correctly reset the ramp handler to prevent the set value to be propagated between modes
Close #252 