### PR TITLE
Improve simulation for arbitrary lamp radius

### DIFF
--- a/simulator/include/default_simulation.h
+++ b/simulator/include/default_simulation.h
@@ -7,10 +7,6 @@ struct defaultSimulation
 
   float ledSizePx = 24.f;   // square size to represent one LED (in pixels)
   float ledPaddingPx = 4.f; // padding between two LEDs (in pixels)
-  float ledOffsetPx = 12.f; // how much LED offsets diagonally (in pixels)
-
-  float fakeXorigin = 0; // start lamp N led to the left
-  float fakeXend = 0;    // remove N led from right
 
   float buttonSize = 40.f;    // draw a lamp button of 40 pixels
   float buttonMargin = 15.f;  // draw a button color indicator 10 pixels larger

--- a/src/modes/include/hardware/coordinates.hpp
+++ b/src/modes/include/hardware/coordinates.hpp
@@ -1,0 +1,64 @@
+#ifndef MODES_HARDWARE_COORDINATES_HPP
+#define MODES_HARDWARE_COORDINATES_HPP
+
+#include <array>
+
+namespace modes::hardware::details {
+
+// For each Y coord, return the apparent "LED shift required" to align to grid
+template<size_t maxOverflowHeight, typename _OutTy = std::array<uint16_t, maxOverflowHeight + 1>>
+static constexpr _OutTy computeResidues(float realExactWidth)
+{
+  uint16_t floorWidth = floor(realExactWidth);
+
+  _OutTy results {};
+  for (size_t Y = 0; Y < results.size(); ++Y)
+  {
+    results[Y] = ((float)Y) * realExactWidth - ((float)Y * floorWidth);
+  }
+
+  return results;
+}
+
+// For each Y coord, return True iff given row is 1 LED longer than the others
+template<size_t maxOverflowHeight, typename _OutTy = std::array<bool, maxOverflowHeight + 1>>
+static constexpr _OutTy computeDeltaResidues(float realExactWidth)
+{
+  auto allResiduesY = computeResidues<maxOverflowHeight>(realExactWidth);
+
+  _OutTy results {};
+  for (size_t Y = 0; Y < results.size(); ++Y)
+  {
+    if (Y + 1 < allResiduesY.size())
+      results[Y] = (bool)(allResiduesY[Y] != allResiduesY[Y + 1]);
+    else
+      results[Y] = false;
+  }
+
+  return results;
+}
+
+template<size_t maxOverflowHeight, typename _OutTy = std::array<int, maxOverflowHeight + 1>>
+static constexpr _OutTy computeExtraShiftResidues(float realExactWidth)
+{
+  auto allDeltaResiduesY = computeDeltaResidues<maxOverflowHeight>(realExactWidth);
+
+  int total = 0;
+  _OutTy results {};
+  for (size_t Y = 0; Y < results.size(); ++Y)
+  {
+    results[Y] = total;
+    if (Y + 1 >= allDeltaResiduesY.size())
+      continue;
+    if (allDeltaResiduesY[Y] && allDeltaResiduesY[Y + 1])
+      total += 1;
+    if (!allDeltaResiduesY[Y] && !allDeltaResiduesY[Y + 1])
+      total -= 1;
+  }
+
+  return results;
+}
+
+} // namespace modes::hardware::details
+
+#endif

--- a/src/user/constants.h
+++ b/src/user/constants.h
@@ -70,7 +70,6 @@ static constexpr float circuitToLedZeroRotationZ_degrees = 88;
 //
 
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
-
 static constexpr float lampBodyRadius_mm = 25; // external radius of the lamp body
 
 // parameters of the led strip used
@@ -101,7 +100,7 @@ static constexpr uint32_t MAIN_LOOP_UPDATE_PERIOD_MS = 1000 / 80.0;
 #endif
 
 // physical parameters computations
-static constexpr float ledSize_mm = 1.0 / ledByMeter * 1000.0;                   // size of the individual led
+static constexpr float ledSize_mm = 1000.0 / ledByMeter;                         // size of the individual led
 static constexpr float lampBodyCircumpherence_mm = c_TWO_PI * lampBodyRadius_mm; // external circumpherence
 static constexpr float ledStripLenght_mm = LED_COUNT * ledSize_mm;
 


### PR DESCRIPTION
We attempt to expose our LED strip as an XY matrix display, however due to its geometry (a strip rolled around a lamp) some rows are longer than the others, and which rows are longer depends on the lamp radius.

For simpler animations, some rows being longer do not have impact and is pretty much invisible, but for more elaborate animations, it is useful to have a "deterministic way" of having a square XY matrix while knowing exactly which LEDs overflows and when.

This PR is the first half of the work, tested on the simulator only, which seems to be working as I try with other lamp radius than our current one. This needs more work, as denser LED strip (such as the HD indexable) seemingly breaks something, I need to figure out why.

But in this state, it's clean and works for our current LED strip and all every other radius, pushed for merge :)