### PR TITLE
Correct missing in objects README #309

### DIFF
--- a/objects/README.md
+++ b/objects/README.md
@@ -1,18 +1,21 @@
 # Objects
 
 The parts to print for the lampe are :
+
 - `Lampda-Poles.stl` x3 : no supports needed
 - `Lampda-LowerPart.stl` x1 : print with the logo facing down, no supports needed
 - `Lampda-Top.stl` x1: print face down, with support for the first layer only
 
 The lower part can be used without the logo, or with you own, using the `Lampda-LowerPart_no_logo.stl`
 
-Dependind on you printer settings, ou may need to remake the holes using a 3.5mm drill.
+Depending on your printer settings, you may need to re-drill the holes using a 3.5mm drill.
 
 # Bill of Material
+
 BOM:
-- cylindrical tube, external diameter 50mm, internal diameter 46mm, 12cm lenght
-- 3x21700 Li-ion batteries, in a 3S configuration
+
+- cylindrical tube, external diameter 50mm, internal diameter 46mm, 12cm length
+- 3x 21700 Li-ion batteries, in a 3S configuration
 - 15cm clear heat shrink, 60mm diameter
 - 16mm pushbutton
 - 6 wire USB-C, panel mounted
@@ -20,16 +23,21 @@ BOM:
 - 2 cylindrical pins (35mmx3mm)
 - 2 cylindrical pins (50mmx3mm)
 - the PCB
+- USB-C 6 pins RGB push button
+- Clear shrink wrap
+- JST connector for battery
 
 ![USBC 6 pins](/Medias/6pin_usb_c.png) ![RGB push button](/Medias/rgb_push_button.png) ![Clear shrink wrap](/Medias/clear_shrink_wrap.png)
 
 ## Led Strips
 
 The led strip lenght varies with strip width:
+
 - a bit less than 4m for 5mm width
 - around 2.5m for 8mm width
 
 The led strips used in my case are :
+
 - 2000K 12V, 8mm width, 480led/m COB strip : candle like color, used for the simple model
 - indexable rgb 12V, 5mm width, 160led/m COB strip : indexable rgb strip, used for RGB model
 
@@ -46,6 +54,5 @@ Place the lower_part, and push the 50mm cylindrical through the tube and the low
 Place the battery in the tube, and the 3 poles around it, with 2 vertical 35mm cylindrical pins. A drop of glue should be added at the 3 pole junction.
 
 Place the PCB and close the assembly using the top part, and a final 50mm cylindrical pin. Do not forget to place the rope in the top part before pushing the cylindrical pin.
-
 
 ![Printed assembly](/Medias/printed_assembly.png) ![Full assembly](/Medias/full_assembly.png)

--- a/objects/README.md
+++ b/objects/README.md
@@ -17,15 +17,13 @@ BOM:
 - cylindrical tube, external diameter 50mm, internal diameter 46mm, 12cm length
 - 3x 21700 Li-ion batteries, in a 3S configuration
 - 15cm clear heat shrink, 60mm diameter
-- 16mm pushbutton
 - 6 wire USB-C, panel mounted
 - 15cm of rope, 2mm diameter
 - 2 cylindrical pins (35mmx3mm)
 - 2 cylindrical pins (50mmx3mm)
 - the PCB
 - USB-C 6 pins RGB push button
-- Clear shrink wrap
-- JST connector for battery
+- JST connector for battery (JST XH2.54MM, 4P, wire length 15CM)
 
 ![USBC 6 pins](/Medias/6pin_usb_c.png) ![RGB push button](/Medias/rgb_push_button.png) ![Clear shrink wrap](/Medias/clear_shrink_wrap.png)
 


### PR DESCRIPTION
Summary of Changes
- Added missing JST connector for battery in the Bill of Materials (BOM).
- Fixed typos (e.g., lenght → length, ou → you).
- Improved wording for better clarity and consistency in the objects/README.md documentation.

Why this change is needed
The JST connector is part of the actual components required but was not listed in the documentation. Adding it makes the BOM complete. Small wording improvements also make the assembly instructions easier to follow for beginners.

Linked Issue:
Closes #309