### PR TITLE
Quit sunset mode when quitting output mode, remove the strip.clear

### DIFF
--- a/simulator/mocks/Adafruit_NeoPixel.h
+++ b/simulator/mocks/Adafruit_NeoPixel.h
@@ -33,8 +33,6 @@ public:
 
   uint32_t getPixelColor(uint16_t n) const { return 0; }
 
-  void clear() {};
-
   static uint32_t Color(uint8_t r, uint8_t g, uint8_t b) { return (r << 16) | (g << 8) | b; }
 
   static uint32_t ColorHSV(double h, double s = 255, double v = 255)

--- a/src/modes/default/fixed_modes.hpp
+++ b/src/modes/default/fixed_modes.hpp
@@ -5,6 +5,8 @@
 
 #include "src/modes/include/colors/palettes.hpp"
 
+#include "src/modes/include/anims/fadeout.hpp"
+
 namespace lampda {
 
 namespace modes {
@@ -16,17 +18,38 @@ namespace fixed {
  */
 struct KelvinMode : public modes::BasicMode
 {
-  static void loop(auto& ctx) { ctx.lamp.setLightTemp(ctx.get_active_custom_ramp()); }
+  static constexpr uint8_t dissolveBufferId = 0;
+  inline static anims::fadeout::GravityDissolve<dissolveBufferId> sunsetAnimation =
+          anims::fadeout::GravityDissolve<dissolveBufferId>();
+
+  static void loop(auto& ctx)
+  {
+    // clear previous animation
+    ctx.lamp.clear();
+
+    const uint32_t color = colors::fromTemp(ctx.get_active_custom_ramp());
+    // update animation
+    sunsetAnimation.loop(ctx, color);
+
+    ctx.lamp.fill(color, ctx.lamp.template getTempBuffer<dissolveBufferId>());
+  }
 
   // configure custom ramp
   static void on_enter_mode(auto& ctx)
   {
     ctx.template set_config_bool<ConfigKeys::rampSaturates>(true);
     ctx.template set_config_bool<ConfigKeys::customRampAnimEffect>(false);
+
+    sunsetAnimation.reset(ctx);
   }
+
+  /// Sunset timer will drop pixels downward, and never display them again
+  static void sunset_update(auto& ctx, float progress) { sunsetAnimation.update_depop_rate(ctx, progress); }
 
   /// hint manager to save our custom ramp
   static constexpr bool hasCustomRamp = true;
+  /// sunset animation on the fixed modes
+  static constexpr bool hasSunsetAnimation = true;
 };
 
 /**
@@ -34,25 +57,42 @@ struct KelvinMode : public modes::BasicMode
  */
 struct RainbowMode : public modes::BasicMode
 {
+  static constexpr uint8_t dissolveBufferId = 0;
+  inline static anims::fadeout::GravityDissolve<dissolveBufferId> sunsetAnimation =
+          anims::fadeout::GravityDissolve<dissolveBufferId>();
+
   // configure custom ramp
   static void on_enter_mode(auto& ctx)
   {
     ctx.template set_config_bool<ConfigKeys::customRampAnimEffect>(false);
     // this ramps should be slow
     ctx.template set_config_u32<ConfigKeys::customRampStepSpeedMs>(50);
+
+    sunsetAnimation.reset(ctx);
   }
 
   static void loop(auto& ctx)
   {
+    // clear previous animation
+    ctx.lamp.clear();
+
     const uint8_t index = ctx.get_active_custom_ramp();
     const float hue = (index / 256.f) * 360.f;
     uint32_t color = colors::fromAngleHue(hue);
 
-    ctx.lamp.fill(color);
+    // update animation
+    sunsetAnimation.loop(ctx, color);
+    // fill, with mask
+    ctx.lamp.fill(color, ctx.lamp.template getTempBuffer<dissolveBufferId>());
   }
+
+  /// Sunset timer will drop pixels downward, and never display them again
+  static void sunset_update(auto& ctx, float progress) { sunsetAnimation.update_depop_rate(ctx, progress); }
 
   /// hint manager to save our custom ramp
   static constexpr bool hasCustomRamp = true;
+  /// sunset animation on the fixed modes
+  static constexpr bool hasSunsetAnimation = true;
 };
 
 /**
@@ -62,26 +102,44 @@ struct RainbowMode : public modes::BasicMode
  */
 template<bool isStep = false> struct PaletteMode : public modes::BasicMode
 {
+  static constexpr uint8_t dissolveBufferId = 0;
+  inline static anims::fadeout::GravityDissolve<dissolveBufferId> sunsetAnimation =
+          anims::fadeout::GravityDissolve<dissolveBufferId>();
+
   static void on_enter_mode(auto& ctx)
   {
     ctx.template set_config_bool<ConfigKeys::customRampAnimEffect>(false);
     // this ramps should be slow
     ctx.template set_config_u32<ConfigKeys::customRampStepSpeedMs>(16 / 255.0f * 850);
+
+    sunsetAnimation.reset(ctx);
   }
 
   static void loop(auto& ctx)
   {
+    // clear previous animation
+    ctx.lamp.clear();
+
     const uint8_t customRamp = ctx.get_active_custom_ramp();
     uint32_t color = modes::colors::from_palette(
             // if palette is stepped, remove all intermediate colors
             static_cast<uint8_t>(isStep ? (customRamp >> 4) << 4 : customRamp),
             // not stepped, allow interpolation
             ctx.state.palette);
-    ctx.lamp.fill(color);
+
+    // update animation
+    sunsetAnimation.loop(ctx, color);
+    // fill, with mask
+    ctx.lamp.fill(color, ctx.lamp.template getTempBuffer<dissolveBufferId>());
   }
+
+  /// Sunset timer will drop pixels downward, and never display them again
+  static void sunset_update(auto& ctx, float progress) { sunsetAnimation.update_depop_rate(ctx, progress); }
 
   /// hint manager to save our custom ramp
   static constexpr bool hasCustomRamp = true;
+  /// sunset animation on the fixed modes
+  static constexpr bool hasSunsetAnimation = true;
 };
 
 /**

--- a/src/modes/include/anims/fadeout.hpp
+++ b/src/modes/include/anims/fadeout.hpp
@@ -74,14 +74,23 @@ template<uint8_t MaskBuffId> struct GravityDissolve
     const float progressPerSecond = (progress - latestProgress) / updateDuration;
 
     bool isValidCall = latestProgress >= 0 and updateDuration > 0;
+
+    // cancel the particle spawn
+    if (progress <= 0.0)
+    {
+      particlesToDepopPerIteration = 0.0;
+      latestProgress = -1;
+      isValidCall = false;
+    }
     // update progress
-    if (latestProgress != progress)
+    else if (latestProgress != progress)
     {
       latestProgress = progress;
       latestProgressTime = ctx.lamp.now;
     }
     else
       isValidCall = false;
+
     // not valid call, skip update
     if (not isValidCall)
     {
@@ -108,7 +117,7 @@ protected:
     return p.z_mm > LampTy::maxWidth * bounds or p.z_mm < -(LampTy::lampHeight_mm + LampTy::maxWidth * bounds);
   }
 
-  void depop_one_particles(auto& ctx)
+  bool depop_one_particles(auto& ctx)
   {
     bool isDepoped = false;
     // progress goes from 0 to 1
@@ -161,7 +170,9 @@ protected:
     if (not isDepoped)
     {
       platform::lampda_print("Error: Could not depop particle");
+      return false;
     }
+    return true;
   }
 
 private:

--- a/src/modes/include/anims/fadeout.hpp
+++ b/src/modes/include/anims/fadeout.hpp
@@ -1,0 +1,181 @@
+/*! \file fadeout.hpp
+    \brief Define some animations to fade out modes.
+*/
+
+#ifndef MODES_ANIM_FADEOUT_HPP
+#define MODES_ANIM_FADEOUT_HPP
+
+#include "src/modes/include/particle_system/particle_system.hpp"
+
+namespace lampda::modes::anims {
+/// Define fadout animation. They require a buffer ID, used to store the fadout mask
+namespace fadeout {
+
+/**
+ * \brief Make an animation disapear with gravity
+ * \param MaskBuffId Index of the buffer that will contain the mask values for the dropped leds
+ */
+template<uint8_t MaskBuffId> struct GravityDissolve
+{
+  void reset(auto& ctx)
+  {
+    // set all values to 1
+    ctx.lamp.template fillTempBuffer<MaskBuffId>(1);
+    // reset particles
+    particuleSystem.reset();
+    particuleSystem.set_max_particle_count(20);
+
+    latestProgress = -1;
+  }
+
+  void loop(auto& ctx, uint32_t color)
+  {
+    // find the particles to depop
+    depopRate += particlesToDepopPerIteration;
+    // time to depop one of more particle
+    float integer;
+    const float fractional = modf(depopRate, &integer);
+    if (integer >= 1.0 and particlesDropped < ctx.lamp.ledCount)
+    {
+      // time to depop !
+      for (uint8_t depopIndex = 0; depopIndex < integer; depopIndex++)
+      {
+        // depop one particle, yay !
+        depop_one_particles(ctx);
+      }
+
+      // drop depop rate
+      depopRate = fractional;
+    }
+
+    // no updats if no particles
+    if (particuleSystem.get_number_of_active() > 0)
+    {
+      // depop particles out of bounds
+      static constexpr bool shouldKeepInLampBounds = false;
+      particuleSystem.iterate_no_collisions(
+              utils::vec3d(0.0, 0.0, -9.81 / 4.0), ctx.lamp.frameDurationMs / 1000.0, shouldKeepInLampBounds);
+      particuleSystem.depop_particules(recycle_particules_if_too_far);
+      particuleSystem.show(
+              [&](int16_t n, const Particle& particle) {
+                return color;
+              },
+              ctx.lamp);
+    }
+  }
+
+  /**
+   * \brief Update the drop rate
+   * \param[in] progress Current progress
+   */
+  void update_depop_rate(auto& ctx, const float progress)
+  {
+    const float updateDuration = static_cast<float>((ctx.lamp.now - latestProgressTime) / 1000.0);
+    const float progressPerSecond = (progress - latestProgress) / updateDuration;
+
+    bool isValidCall = latestProgress >= 0 and updateDuration > 0;
+    // update progress
+    if (latestProgress != progress)
+    {
+      latestProgress = progress;
+      latestProgressTime = ctx.lamp.now;
+    }
+    else
+      isValidCall = false;
+    // not valid call, skip update
+    if (not isValidCall)
+    {
+      return;
+    }
+
+    const uint16_t particleMax = ctx.lamp.ledCount;
+    const float FramesFrequency = static_cast<float>(ctx.lamp.frameDurationMs / 1000.0);
+
+    const float particlesLeft = particleMax - particlesDropped;
+    const float trueProgress = 1.0 - particlesLeft / static_cast<float>(particleMax);
+    const float trueProgressDiff = progress - trueProgress;
+    // try to correct the update ratio by the lag or advance
+    const float correctedParticlesLeft = particleMax * (1.0 + trueProgressDiff);
+
+    // particles to depop per second is progress rate per second * particles left
+    particlesToDepopPerIteration = progressPerSecond * correctedParticlesLeft * FramesFrequency;
+  }
+
+protected:
+  static bool recycle_particules_if_too_far(const Particle& p)
+  {
+    static constexpr float bounds = 3.0;
+    return p.z_mm > LampTy::maxWidth * bounds or p.z_mm < -(LampTy::lampHeight_mm + LampTy::maxWidth * bounds);
+  }
+
+  void depop_one_particles(auto& ctx)
+  {
+    bool isDepoped = false;
+    // progress goes from 0 to 1
+    // lamp turns off when 1 is reached
+    auto& buffer = ctx.lamp.template getTempBuffer<MaskBuffId>();
+
+    // check lines by lines, keeping the first one with pixels left
+    for (int16_t y = ctx.lamp.maxHeight; y >= 0; y--)
+    {
+      // search for the first line with pixels sets, from bottom to top
+      uint8_t pixelSetCount = 0;
+      for (size_t x = 0; x <= ctx.lamp.maxWidth; x++)
+      {
+        const bool isPixelSet = buffer[modes::to_strip(x, y)] != 0;
+        // check that at leat one pixel is still set
+        if (isPixelSet)
+          pixelSetCount += 1;
+      }
+
+      // found the first line with pixels left
+      if (pixelSetCount > 0)
+      {
+        // get a random led index in this
+        uint8_t selectedLed = lmpd_map<uint8_t>(rand(), 0, RAND_MAX, 0, pixelSetCount);
+        for (size_t x = 0; x <= ctx.lamp.maxWidth; x++)
+        {
+          const auto& pixelId = modes::to_strip(x, y);
+          const bool isPixelSet = buffer[pixelId] != 0;
+          if (isPixelSet)
+          {
+            if (selectedLed == 0)
+            {
+              // drop this pixel
+              buffer[pixelId] = 0;
+              particlesDropped += 1;
+              // spawn a new particle
+              particuleSystem.init_deferred_particules(1, [pixelId](size_t) {
+                return pixelId;
+              });
+
+              isDepoped = true;
+              break;
+            }
+            selectedLed -= 1;
+          }
+        }
+        break;
+      }
+    }
+    if (not isDepoped)
+    {
+      platform::lampda_print("Error: Could not depop particle");
+    }
+  }
+
+private:
+  //
+  float latestProgress = -1.0;
+  uint32_t latestProgressTime = 0;
+
+  float particlesToDepopPerIteration = 0.0; /// numbers of particles that will fall per loop call
+  float depopRate = 0.0;                    /// accumulator rate
+  size_t particlesDropped = 0;              /// keep track of the particles that already fell or are falling
+  modes::ParticleSystem particuleSystem = modes::ParticleSystem();
+};
+
+} // namespace fadeout
+} // namespace lampda::modes::anims
+
+#endif

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -730,45 +730,9 @@ public:
     }
   }
 
-  /** \brief Fill lamp with target light temperature, if supported
-   *
-   * If LampTy::flavor is LampTypes::simple then:
-   *  - does nothing
-   *
-   * If LampTy::flavor is LampTypes::cct then:
-   *  - scale from one supported color to the the other one
-   *
-   * If LampTy::flavor is LampTypes::indexable then:
-   *  - use modes::colors::fromTemp to fill lamp with color
-   */
-  void LMBD_INLINE setLightTemp(uint8_t temp)
-  {
-    if constexpr (flavor == LampTypes::indexable)
-    {
-      fill(colors::fromTemp(temp));
-    }
-    else if constexpr (flavor == LampTypes::cct)
-    {
-      // TODO: implement
-      assert(false && "not yet implemented :(");
-    }
-    else
-    {
-      // -> intentionally do not trigger as error, for interoperability
-      assert(true);
-    }
-  }
-
   //
   // public API (indexable-only)
   //
-
-  /// (indexable) Return raw underlying strip object
-  auto& LMBD_INLINE getLegacyStrip()
-  {
-    assert(flavor == LampTypes::indexable && "current lamp is not indexable");
-    return strip;
-  }
 
   /** \brief (indexable) Fill lamp with target color, from start to end
    *

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -191,10 +191,8 @@ private:
     void show();
     void show_now();
     void signal_display();
-    void clear();
     void setBrightness(brightness_t);
     uint8_t getBrightness();
-    void fadeToBlackBy(uint8_t);
     void setPixelColor(uint16_t, uint32_t);
     uint32_t getPixelColor(uint16_t);
   };
@@ -488,7 +486,10 @@ public:
   {
     if constexpr (flavor == LampTypes::indexable)
     {
-      strip.clear();
+      for (uint16_t i = 0; i < ledCount; ++i)
+      {
+        setPixelColor(i, colors::Black);
+      }
     }
     else
     {
@@ -792,11 +793,41 @@ public:
     }
   }
 
+  /** \brief (indexable) Fill lamp with target color, from start to end. Apply a mask to display leds
+   *
+   * - See toLedCount() to set \p start and \p end
+   * - See modes::colors::fromRGB() to set \p color
+   */
+  void LMBD_INLINE fill(uint32_t color, uint16_t start, uint16_t end, const BufferTy& shouldDisplay)
+  {
+    if constexpr (flavor == LampTypes::indexable)
+    {
+      assert(start <= ledCount && "invalid start parameter");
+      assert(end <= ledCount && "invalid end parameter");
+
+      for (uint16_t I = start; I < end; ++I)
+      {
+        if (shouldDisplay[I] != 0)
+          setPixelColor(I, color);
+      }
+    }
+    else
+    {
+      assert(false && "unsupported");
+    }
+  }
+
   /** \brief (indexable) Fill lamp with target color
    *
    * See modes::colors::fromRGB() to set \p color
    */
   void LMBD_INLINE fill(uint32_t color) { fill(color, 0, ledCount); }
+
+  /** \brief (indexable) Fill lamp with target color, with a mask
+   *
+   * See modes::colors::fromRGB() to set \p color
+   */
+  void LMBD_INLINE fill(uint32_t color, const BufferTy& shouldDisplay) { fill(color, 0, ledCount, shouldDisplay); }
 
   /** \brief (indexable) Fill lamp with target palette, from start to end
    *

--- a/src/modes/include/particle_system/particle_system.hpp
+++ b/src/modes/include/particle_system/particle_system.hpp
@@ -205,6 +205,20 @@ public:
     return particleCount;
   }
 
+  /// Return the number of active particles
+  uint16_t get_number_of_active() const
+  {
+    uint16_t particleCount = 0;
+    for (size_t i = 0; i < particuleCount; ++i)
+    {
+      // do not show non allocated particles
+      if (not isAllocated[i])
+        continue;
+      particleCount += 1;
+    }
+    return particleCount;
+  }
+
 protected:
   /// Return True if the position is already occupied
   bool is_position_taken(const int16_t pos) const { return occupiedSpacesSet.find(pos) != occupiedSpacesSet.cend(); }

--- a/src/system/logic/behavior.cpp
+++ b/src/system/logic/behavior.cpp
@@ -467,6 +467,8 @@ bool check_handle_exit_output_mode()
   // should go to sleep
   if (not is_system_should_be_powered())
   {
+    logic::sunset::cancel_timer();
+
     if (is_charger_powered())
     {
       // charger is plugged, go to charger state
@@ -482,6 +484,8 @@ bool check_handle_exit_output_mode()
 #ifndef LMBD_SIMULATION
   else if (not physical::battery::is_battery_usable_as_power_source())
   {
+    logic::sunset::cancel_timer();
+
     // wait a bit then shutdown
     if (platform::time_ms() - preOutputLightCalled > 3000)
     {

--- a/src/system/logic/sunset_timer.cpp
+++ b/src/system/logic/sunset_timer.cpp
@@ -136,6 +136,7 @@ void bump_timer()
   if (sunsetTimerEndTime_s - platform::time_s() < brightnessRampDownTime_s)
   {
     sunsetTimerEndTime_s = platform::time_s() + (brightnessRampDownTime_min + 1) * 60;
+    signal_sunset_update();
   }
 }
 
@@ -144,6 +145,7 @@ void cancel_timer()
 {
   // release timer
   sunsetTimerEndTime_s = 0;
+  signal_sunset_update();
   platform::lampda_print("sunset timer cleared");
   logic::alerts::manager.clear(logic::alerts::Type::SUNSET_TIMER_ENABLED);
 }

--- a/src/system/logic/sunset_timer.cpp
+++ b/src/system/logic/sunset_timer.cpp
@@ -26,20 +26,6 @@ static constexpr uint16_t minimalSunsetUpdateCalls = 50;
 
 const char* const sunset_taskName = "sunset";
 
-void signal_sunset_update()
-{
-  if (platform::time_s() > sunsetTimerEndTime_s)
-  {
-    logic::behavior::sunset::progress_update(1.0f);
-    return;
-  }
-
-  // signal the progress change
-  const float progress = lmpd_constrain<float>(
-          (sunsetTimerEndTime_s - platform::time_s()) / static_cast<float>(brightnessRampDownTime_s), 0.0f, 1.0f);
-  logic::behavior::sunset::progress_update(1.0f - progress);
-}
-
 // sunset loop time to reduce brightness gradually
 uint32_t get_sunset_loop_timing_ms()
 {
@@ -53,9 +39,26 @@ uint32_t get_sunset_loop_timing_ms()
   return min<uint32_t>(res, brightnessRampDownTime_ms / minimalSunsetUpdateCalls);
 }
 
+void signal_sunset_update()
+{
+  if (platform::time_s() >= sunsetTimerEndTime_s)
+  {
+    logic::behavior::sunset::progress_update(1.0f);
+    return;
+  }
+  const uint32_t finishline = get_sunset_loop_timing_ms();
+
+  // signal the progress change
+  const float progress = lmpd_constrain<float>(((sunsetTimerEndTime_s * 1000.0 - finishline) - platform::time_ms()) /
+                                                       static_cast<float>(brightnessRampDownTime_s * 1000.0),
+                                               0.0f,
+                                               1.0f);
+  logic::behavior::sunset::progress_update(1.0f - progress);
+}
+
 void sunset_process_loop()
 {
-  // this thread runs very slowly
+  // this thread runs slowly
   platform::delay_ms(get_sunset_loop_timing_ms());
 
   if (sunsetTimerEndTime_s == 0)

--- a/src/system/physical/strip.h
+++ b/src/system/physical/strip.h
@@ -143,19 +143,6 @@ public:
 
   void setPixelColorXY(uint16_t x, uint16_t y, uint32_t c) { setPixelColor(LedStrip::to_strip(x, y), c); }
 
-  void fadeToBlackBy(const uint8_t fadeBy)
-  {
-    if (fadeBy == 0)
-      return; // optimization - no scaling to apply
-
-    for (uint16_t i = 0; i < LED_COUNT; ++i)
-    {
-      COLOR c;
-      c.color = getPixelColor(i);
-      setPixelColor(i, utils::color_fade(c, 255 - fadeBy));
-    }
-  }
-
   /*
    * Put a value 0 to 255 in to get a color value.
    * The colours are a transition r -> g -> b -> back to r
@@ -239,17 +226,6 @@ public:
   }
 
   uint32_t getRawPixelColor(uint16_t n) const { return Adafruit_NeoPixel::getPixelColor(n); }
-
-  void clear()
-  {
-    COLOR c;
-    c.color = 0;
-    for (uint16_t i = 0; i < LED_COUNT; ++i)
-    {
-      _colors[i] = c;
-    }
-    Adafruit_NeoPixel::clear();
-  }
 
   // signal the strip that it can display the update
   void signal_display() { hasSomeChanges = true; }


### PR DESCRIPTION
Closes #386

Resolve a minor bug where the strip.clear function breaked the ramps animations.
Remove some unused functions.

Add a disolve gravity animation related to #321 