### PR TITLE
Resolve minor sunset timer bugs

### DIFF
--- a/src/modes/default/brightness_modes.hpp
+++ b/src/modes/default/brightness_modes.hpp
@@ -22,34 +22,8 @@ struct StaticLightMode : public BasicMode
 /// One mode, alone in its group, for static lightning
 using StaticLightOnly = GroupFor<StaticLightMode>;
 
-/// Simple pulse every second
-struct OnePulse : public BasicMode
-{
-  static constexpr uint32_t periodMs = 1000;     ///< lenght of a pulse, in milliseconds
-  static constexpr uint32_t pulseSizeMs = 100;   ///< period of the animation, in milliseconds
-  static constexpr brightness_t minScaling = 50; ///< scaling of the brightness of a pulse
-  static constexpr float scaleFactor = 1.40;     ///< scale of the brigthness
-
-  static constexpr void loop(auto& ctx)
-  {
-    auto& lamp = ctx.lamp;
-
-    brightness_t base = lamp.getSavedBrightness();
-    brightness_t scaled = std::max<brightness_t>(base * scaleFactor, base + minScaling);
-
-    if (scaled > lamp.getMaxBrightness())
-      lamp.jumpBrightness(lamp.getMaxBrightness() / scaleFactor);
-
-    auto period = lamp.now % periodMs;
-    if (period < pulseSizeMs)
-      lamp.tempBrightness(scaled);
-    else
-      lamp.restoreBrightness();
-  }
-};
-
 /// Pulse N times then pause one second
-template<size_t N> struct ManyPulse : public BasicMode
+template<size_t N> struct Pulses : public BasicMode
 {
   static constexpr uint32_t pulseSizeMs = 100;                     ///< lenght of a pulse, in milliseconds
   static constexpr uint32_t periodMs = 1000 + N * pulseSizeMs * 2; ///< period of the animation, in milliseconds
@@ -63,10 +37,12 @@ template<size_t N> struct ManyPulse : public BasicMode
     brightness_t base = lamp.getSavedBrightness();
     brightness_t scaled = std::max<brightness_t>(base * scaleFactor, base + minScaling);
 
+    // overflow check
     if (scaled > lamp.getMaxBrightness())
       lamp.jumpBrightness(lamp.getMaxBrightness() / scaleFactor);
 
     auto period = lamp.now % periodMs;
+    // first part of the anim : pulse
     if (period < pulseSizeMs * N * 2)
     {
       uint32_t flipflop = period / pulseSizeMs;
@@ -75,6 +51,7 @@ template<size_t N> struct ManyPulse : public BasicMode
       else
         lamp.tempBrightness(scaled);
     }
+    // second part: just stay at the saved brightness level
     else
       lamp.restoreBrightness();
   }
@@ -334,7 +311,7 @@ struct LightningMode : public BasicMode
 /// Group for calm modes
 using CalmGroup = GroupFor<Candle, LightningMode>;
 /// Group for flashing modes
-using FlashesGroup = GroupFor<StroboscopeMode, OnePulse, ManyPulse<2>>;
+using FlashesGroup = GroupFor<StroboscopeMode, Pulses<1>, Pulses<2>>;
 
 } // namespace lampda::modes::brightness
 

--- a/src/modes/include/context_type.hpp
+++ b/src/modes/include/context_type.hpp
@@ -277,13 +277,6 @@ template<typename LocalBasicMode, typename ModeManager> struct ContextTy
   }
 
   //
-  // getters / setters for other properties
-  //
-
-  /// (getter) Return current brightness value
-  brightness_t LMBD_INLINE get_brightness() { return logic::brightness::get_brightness(); }
-
-  //
   // store
   //
 

--- a/src/modes/include/group_type.hpp
+++ b/src/modes/include/group_type.hpp
@@ -203,6 +203,9 @@ template<typename AllModes, bool earlyFail = verifyGroup<AllModes>()> struct Gro
   /// Callback for a mode entry point
   static void enter_mode(auto& ctx)
   {
+    // restore brigthness before entering a mode
+    ctx.lamp.restoreBrightness();
+
     // set ramps if they exist
     uint8_t modeIdAfter = ctx.get_active_mode(nbModes);
     ctx.state.load_ramps(ctx, modeIdAfter);

--- a/src/modes/include/group_type.hpp
+++ b/src/modes/include/group_type.hpp
@@ -204,7 +204,7 @@ template<typename AllModes, bool earlyFail = verifyGroup<AllModes>()> struct Gro
   static void enter_mode(auto& ctx)
   {
     // restore brigthness before entering a mode
-    ctx.lamp.restoreBrightness();
+    ctx.lamp.setBrightness(logic::brightness::get_saved_brightness(), false, false, true);
 
     // set ramps if they exist
     uint8_t modeIdAfter = ctx.get_active_mode(nbModes);

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -240,7 +240,8 @@ public:
     begin();
     clear();
     show_now();
-    setBrightness(logic::brightness::get_brightness(), true, true);
+    setBrightness(logic::brightness::get_saved_brightness(), true, true);
+    update_internal_brightness();
   }
 
   /** \private Does necessary work to setup lamp from a powered-off state
@@ -534,30 +535,41 @@ public:
    * Several behaviors:
    *  - by default, do not call user callbacks to avoid re-entry
    *  - by default, do call global brightness update handler (see brightness_handle.h)
+   *  - by default, do NOT save brightness using "previous_brightness_update"
+   *  - also set the brightness in underlying strip object, if necessary
    *
    * Thus:
    *  - if \p skipCallbacks is false, do call user callbacks w/ re-entry risks
    *  - if \p skipUpdateBrightness is true, only set strip object brightness,
    *    or do nothing if LampTy::flavor is not LampTypes::indexable
+   *  - if \p updateSavedBrightess is true, save brightness and next time
+   *    user navigate brightness, use it as starting point (see tempBrightness)
    *
    * Note that calls to `logic::brightness::update_brightness` are throttled to once
    * in every 50ms to avoid freezing user brightness navigation.
    *
    * Note that \p skipUpdateBrightness implies \p skipCallbacks implicitly
    */
-  void LMBD_INLINE setBrightness(brightness_t newBrightness,
+  void LMBD_INLINE setBrightness(const brightness_t newBrightness,
                                  const bool skipCallbacks = true,
-                                 const bool skipUpdateBrightness = false)
+                                 const bool skipUpdateBrightness = false,
+                                 const bool updateSavedBrightess = false)
   {
     assert((skipCallbacks || !skipUpdateBrightness) && "implicit callback skip!");
-    // limit to allowed user brightness
-    newBrightness = std::min<brightness_t>(newBrightness, getMaxBrightness());
 
     if (!skipUpdateBrightness)
     {
       uint32_t last = logic::brightness::when_last_update_brightness();
       if ((this->now - last) > brightnessDurationMs)
         logic::brightness::update_brightness(newBrightness, skipCallbacks);
+
+      // store the new temporary
+      temporary_brightness = newBrightness;
+    }
+    // if necessary, update the saved version
+    if (updateSavedBrightess)
+    {
+      saved_brightness = temporary_brightness;
     }
 
     // USE THE BRIGHTNESS VALUE AFTER THE UPDATE
@@ -592,8 +604,15 @@ public:
     }
   }
 
+  /// Special call to update the internal brightness values
+  void update_internal_brightness()
+  {
+    saved_brightness = logic::brightness::get_saved_brightness();
+    temporary_brightness = saved_brightness;
+  }
+
   /**
-   * \brief Return the actual allowed maximum brightness for the user
+   * \brief Return the actual allowed maximum brightness
    */
   brightness_t LMBD_INLINE getMaxBrightness() const { return logic::brightness::get_max_brightness(); }
 
@@ -612,7 +631,7 @@ public:
   {
     brightness_t current = getBrightness();
     if (current != brightness)
-      setBrightness(brightness, true, false);
+      setBrightness(brightness, true, false, false);
   }
 
   /**
@@ -624,9 +643,9 @@ public:
    * which imply that next time an user increases / lowers brightness, it
    * starts again from the provided brightness.
    *
-   * Equivalent to ``setBrightness(true, false)``
+   * Equivalent to ``setBrightness(true, false, true)``
    */
-  void LMBD_INLINE jumpBrightness(const brightness_t brightness) { setBrightness(brightness, true, false); }
+  void LMBD_INLINE jumpBrightness(const brightness_t brightness) { setBrightness(brightness, true, false, true); }
 
   /**
    * \brief Get brightness of the lamp
@@ -636,19 +655,10 @@ public:
    */
   brightness_t LMBD_INLINE getBrightness(const bool readPreviousBrightness = false)
   {
-    if constexpr (flavor == LampTypes::indexable)
-    {
-      if (readPreviousBrightness)
-        return std::min<brightness_t>(logic::brightness::get_saved_brightness(), getMaxBrightness());
-      return strip.getBrightness();
-    }
+    if (readPreviousBrightness)
+      return saved_brightness;
     else
-    {
-      if (readPreviousBrightness)
-        return std::min<brightness_t>(logic::brightness::get_saved_brightness(), getMaxBrightness());
-      else
-        return logic::brightness::get_brightness();
-    }
+      return temporary_brightness;
   }
 
   /// Alias for ``getBrightness(true)``
@@ -661,7 +671,7 @@ public:
     const brightness_t saved = getSavedBrightness();
 
     if (current != saved)
-      setBrightness(saved, true, false);
+      setBrightness(saved, true, false, false);
   }
 
   /** \brief Fade currently displayed content by \p fadeBy units
@@ -681,7 +691,7 @@ public:
 
       for (uint16_t i = 0; i < ledCount; ++i)
       {
-        const uint32_t c = strip.getPixelColor(i);
+        const uint32_t c = getPixelColor(i);
         setPixelColor(i, colors::fade(c, 255 - fadeBy));
       }
     }
@@ -712,13 +722,13 @@ public:
     uint32_t carryover = 0;
     for (unsigned i = 0; i < ledCount; i++)
     {
-      uint32_t cur = strip.getPixelColor(i);
+      uint32_t cur = getPixelColor(i);
       uint32_t c = cur;
       uint32_t part = colors::fade<false>(c, seep);
       cur = colors::add<true>(colors::fade<false>(c, keep), carryover);
       if (i > 0)
       {
-        c = strip.getPixelColor(i - 1);
+        c = getPixelColor(i - 1);
         setPixelColor(i - 1, colors::add<true>(c, part));
       }
       setPixelColor(i, cur);
@@ -1013,6 +1023,11 @@ public:
   {
     return physical::microphone::get_sound_characteristics();
   }
+
+  /// Define a localy consistant saved brightness. Should be similar
+  volatile brightness_t saved_brightness;
+  /// Define a localy consistant temporary brightness
+  volatile brightness_t temporary_brightness;
 
   /** \brief (physical) The "now" on milliseconds, updated just before loop.
    *

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -534,27 +534,24 @@ public:
    * Several behaviors:
    *  - by default, do not call user callbacks to avoid re-entry
    *  - by default, do call global brightness update handler (see brightness_handle.h)
-   *  - by default, do NOT save brightness using "previous_brightness_update"
-   *  - also set the brightness in underlying strip object, if necessary
    *
    * Thus:
    *  - if \p skipCallbacks is false, do call user callbacks w/ re-entry risks
    *  - if \p skipUpdateBrightness is true, only set strip object brightness,
    *    or do nothing if LampTy::flavor is not LampTypes::indexable
-   *  - if \p updateSavedBrightess is true, save brightness and next time
-   *    user navigate brightness, use it as starting point (see tempBrightness)
    *
    * Note that calls to `logic::brightness::update_brightness` are throttled to once
    * in every 50ms to avoid freezing user brightness navigation.
    *
    * Note that \p skipUpdateBrightness implies \p skipCallbacks implicitly
    */
-  void LMBD_INLINE setBrightness(const brightness_t newBrightness,
+  void LMBD_INLINE setBrightness(brightness_t newBrightness,
                                  const bool skipCallbacks = true,
-                                 const bool skipUpdateBrightness = false,
-                                 const bool updateSavedBrightess = false)
+                                 const bool skipUpdateBrightness = false)
   {
     assert((skipCallbacks || !skipUpdateBrightness) && "implicit callback skip!");
+    // limit to allowed user brightness
+    newBrightness = std::min<brightness_t>(newBrightness, getMaxBrightness());
 
     if (!skipUpdateBrightness)
     {
@@ -562,8 +559,6 @@ public:
       if ((this->now - last) > brightnessDurationMs)
         logic::brightness::update_brightness(newBrightness, skipCallbacks);
     }
-    if (updateSavedBrightess)
-      logic::brightness::update_saved_brightness();
 
     // USE THE BRIGHTNESS VALUE AFTER THE UPDATE
     // brightness can be limited by the system, so do not use the raw brightness
@@ -582,6 +577,7 @@ public:
 
     if constexpr (flavor == LampTypes::simple)
     {
+      // display an output blip on max brightness reached
       if (trueNewBrightness >= trueMaxBrightness)
         physical::outputPower::blip(50); // blip
 
@@ -597,7 +593,7 @@ public:
   }
 
   /**
-   * \brief Return the actual allowed maximum brightness
+   * \brief Return the actual allowed maximum brightness for the user
    */
   brightness_t LMBD_INLINE getMaxBrightness() const { return logic::brightness::get_max_brightness(); }
 
@@ -616,7 +612,7 @@ public:
   {
     brightness_t current = getBrightness();
     if (current != brightness)
-      setBrightness(brightness, true, false, false);
+      setBrightness(brightness, true, false);
   }
 
   /**
@@ -628,9 +624,9 @@ public:
    * which imply that next time an user increases / lowers brightness, it
    * starts again from the provided brightness.
    *
-   * Equivalent to ``setBrightness(true, false, true)``
+   * Equivalent to ``setBrightness(true, false)``
    */
-  void LMBD_INLINE jumpBrightness(const brightness_t brightness) { setBrightness(brightness, true, false, true); }
+  void LMBD_INLINE jumpBrightness(const brightness_t brightness) { setBrightness(brightness, true, false); }
 
   /**
    * \brief Get brightness of the lamp
@@ -643,13 +639,13 @@ public:
     if constexpr (flavor == LampTypes::indexable)
     {
       if (readPreviousBrightness)
-        return logic::brightness::get_saved_brightness();
+        return std::min<brightness_t>(logic::brightness::get_saved_brightness(), getMaxBrightness());
       return strip.getBrightness();
     }
     else
     {
       if (readPreviousBrightness)
-        return logic::brightness::get_saved_brightness();
+        return std::min<brightness_t>(logic::brightness::get_saved_brightness(), getMaxBrightness());
       else
         return logic::brightness::get_brightness();
     }
@@ -665,7 +661,7 @@ public:
     const brightness_t saved = getSavedBrightness();
 
     if (current != saved)
-      setBrightness(saved, true, false, false);
+      setBrightness(saved, true, false);
   }
 
   /** \brief Fade currently displayed content by \p fadeBy units

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -241,7 +241,7 @@ public:
     clear();
     show_now();
     setBrightness(logic::brightness::get_saved_brightness(), true, true);
-    update_internal_brightness();
+    align_internal_to_system_brightness();
   }
 
   /** \private Does necessary work to setup lamp from a powered-off state
@@ -557,6 +557,13 @@ public:
   {
     assert((skipCallbacks || !skipUpdateBrightness) && "implicit callback skip!");
 
+    // invalid call, fallback to enforcing
+    if (newBrightness > ::lampda::brightness::absoluteMaximumBrightness)
+    {
+      enforce_internal_brightness_limits();
+      return;
+    }
+
     // force update if we are getting lower and lower
     if (!skipUpdateBrightness or newBrightness > getMaxBrightness())
     {
@@ -610,11 +617,30 @@ public:
     }
   }
 
-  /// Special call to update the internal brightness values
-  void update_internal_brightness()
+  /// Special call to update the internal brightness values to the system brightness
+  void align_internal_to_system_brightness()
   {
     saved_brightness = min<brightness_t>(logic::brightness::get_saved_brightness(), getMaxBrightness());
     temporary_brightness = saved_brightness;
+  }
+
+  /// Enforce the brightness limits, if getMaxBrightness changed. Will call \ref setBrightness
+  void enforce_internal_brightness_limits()
+  {
+    const auto maxAllowedBrightness = getMaxBrightness();
+    const brightness_t new_saved_brightness =
+            min<brightness_t>(static_cast<brightness_t>(saved_brightness), maxAllowedBrightness);
+    const brightness_t new_temporary_brightness =
+            min<brightness_t>(static_cast<brightness_t>(temporary_brightness), maxAllowedBrightness);
+
+    const bool isChanged = new_saved_brightness != saved_brightness or new_temporary_brightness != temporary_brightness;
+    if (isChanged)
+    {
+      saved_brightness = new_saved_brightness;
+      temporary_brightness = new_temporary_brightness;
+
+      setBrightness(temporary_brightness);
+    }
   }
 
   /**

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -557,19 +557,20 @@ public:
   {
     assert((skipCallbacks || !skipUpdateBrightness) && "implicit callback skip!");
 
-    if (!skipUpdateBrightness)
+    // force update if we are getting lower and lower
+    if (!skipUpdateBrightness or newBrightness > getMaxBrightness())
     {
+      // store the new temporary
+      temporary_brightness = min<brightness_t>(newBrightness, getMaxBrightness());
+
       uint32_t last = logic::brightness::when_last_update_brightness();
       if ((this->now - last) > brightnessDurationMs)
-        logic::brightness::update_brightness(newBrightness, skipCallbacks);
-
-      // store the new temporary
-      temporary_brightness = newBrightness;
+        logic::brightness::update_brightness(temporary_brightness, skipCallbacks);
     }
     // if necessary, update the saved version
     if (updateSavedBrightess)
     {
-      saved_brightness = temporary_brightness;
+      saved_brightness = min<brightness_t>(static_cast<brightness_t>(temporary_brightness), getMaxBrightness());
     }
 
     // USE THE BRIGHTNESS VALUE AFTER THE UPDATE
@@ -590,7 +591,7 @@ public:
     if constexpr (flavor == LampTypes::simple)
     {
       // display an output blip on max brightness reached
-      if (trueNewBrightness >= trueMaxBrightness)
+      if (trueNewBrightness > saved_brightness and trueNewBrightness >= trueMaxBrightness)
         physical::outputPower::blip(50); // blip
 
       constexpr uint16_t maxOutputVoltage_mV = stripInputVoltage_mV;
@@ -607,14 +608,14 @@ public:
   /// Special call to update the internal brightness values
   void update_internal_brightness()
   {
-    saved_brightness = logic::brightness::get_saved_brightness();
+    saved_brightness = min<brightness_t>(logic::brightness::get_saved_brightness(), getMaxBrightness());
     temporary_brightness = saved_brightness;
   }
 
   /**
    * \brief Return the actual allowed maximum brightness
    */
-  brightness_t LMBD_INLINE getMaxBrightness() const { return logic::brightness::get_max_brightness(); }
+  brightness_t LMBD_INLINE getMaxBrightness() const { return logic::brightness::get_max_user_brightness(); }
 
   /**
    * \brief Temporarily set brightness, without affecting brightness navigation

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -590,9 +590,15 @@ public:
 
     if constexpr (flavor == LampTypes::simple)
     {
+      // This is kind of a hack to detect that the user did this call
+      // using the known user call signature
+      const bool isUserCall = skipCallbacks and skipUpdateBrightness and not updateSavedBrightess;
+
       // display an output blip on max brightness reached
-      if (trueNewBrightness > saved_brightness and trueNewBrightness >= trueMaxBrightness)
+      if (isUserCall and trueNewBrightness >= trueMaxBrightness)
+      {
         physical::outputPower::blip(50); // blip
+      }
 
       constexpr uint16_t maxOutputVoltage_mV = stripInputVoltage_mV;
       using curve_t = utils::curves::ExponentialCurve<brightness_t, uint16_t>;

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -233,9 +233,9 @@ public:
    */
   void LMBD_INLINE startup()
   {
-    // set output voltage for indexable
-    if constexpr (flavor == LampTypes::indexable)
-      physical::outputPower::write_voltage(stripInputVoltage_mV);
+    // set output voltage for leds that will not change voltage
+    if (stripInputMinVoltage_mV == stripInputMaxVoltage_mV)
+      physical::outputPower::write_voltage(stripInputMaxVoltage_mV);
 
     begin();
     clear();
@@ -600,11 +600,10 @@ public:
         physical::outputPower::blip(50); // blip
       }
 
-      constexpr uint16_t maxOutputVoltage_mV = stripInputVoltage_mV;
       using curve_t = utils::curves::ExponentialCurve<brightness_t, uint16_t>;
       static curve_t brightnessCurve(
-              curve_t::point_t {0, 9400},
-              curve_t::point_t {::lampda::brightness::absoluteMaximumBrightness, maxOutputVoltage_mV},
+              curve_t::point_t {0, stripInputMinVoltage_mV},
+              curve_t::point_t {::lampda::brightness::absoluteMaximumBrightness, stripInputMaxVoltage_mV},
               1.0);
 
       physical::outputPower::write_voltage(round(brightnessCurve.sample(trueNewBrightness)));

--- a/src/modes/user/default_behavior.hpp
+++ b/src/modes/user/default_behavior.hpp
@@ -56,6 +56,9 @@ void brightness_update(const brightness_t brightness)
 {
   auto manager = get_context();
 
+  // force update of the internal references
+  manager.lamp.update_internal_brightness();
+
   // set brightness for underlying object (w/o re-entry in update_brightness)
   manager.lamp.setBrightness(brightness, true, true);
 

--- a/src/modes/user/default_behavior.hpp
+++ b/src/modes/user/default_behavior.hpp
@@ -56,14 +56,23 @@ void brightness_update(const brightness_t brightness)
 {
   auto manager = get_context();
 
-  // force update of the internal references
-  manager.lamp.update_internal_brightness();
+  // dont handle invalid commands
+  if (brightness <= ::lampda::brightness::absoluteMaximumBrightness)
+  {
+    // force update of the internal references
+    manager.lamp.align_internal_to_system_brightness();
 
-  // set brightness for underlying object (w/o re-entry in update_brightness)
-  manager.lamp.setBrightness(brightness, true, true);
+    // set brightness for underlying object (w/o re-entry in update_brightness)
+    manager.lamp.setBrightness(brightness, true, true);
 
-  // callbacks
-  manager.brightness_update(brightness);
+    // callbacks
+    manager.brightness_update(brightness);
+  }
+  else
+  {
+    // this call could be just a max brigthness update
+    manager.lamp.enforce_internal_brightness_limits();
+  }
 }
 
 void sunset_timer_update(const float progress)
@@ -129,6 +138,7 @@ void loop()
 bool should_spawn_thread()
 {
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
+  /// The thread is needed to update the strip, so non negociable.
   return true;
 #else
   auto manager = get_context();

--- a/src/modes/user/simple_behavior.hpp
+++ b/src/modes/user/simple_behavior.hpp
@@ -43,7 +43,7 @@ void button_clicked_default(const uint8_t clicks)
           manager.lamp.getBrightness() == ::lampda::brightness::absoluteMaximumBrightness)
       {
         // write a power boost (dangerous) for a limited time
-        physical::outputPower::write_temporary_output_limits(stripInputVoltage_mV * 1.2f, 5000, 5000);
+        physical::outputPower::write_temporary_output_limits(::lampda::stripInputMaxVoltage_mV * 1.2f, 5000, 5000);
       }
       else
       {

--- a/src/system/logic/alerts.cpp
+++ b/src/system/logic/alerts.cpp
@@ -351,7 +351,7 @@ struct Alert_BatteryLow : public AlertBase
     platform::bluetooth::stop_bluetooth_advertising();
 
     logic::brightness::set_max_brightness(clampedBrightness);
-    logic::brightness::update_brightness(logic::brightness::get_brightness());
+    logic::brightness::update_brightness(logic::brightness::get_saved_brightness());
     logic::brightness::update_saved_brightness();
   }
 
@@ -422,7 +422,7 @@ struct Alert_TempTooHigh : public AlertBase
             static_cast<brightness_t>(0.5 * ::lampda::brightness::absoluteMaximumBrightness);
 
     logic::brightness::set_max_brightness(clampedBrightness);
-    logic::brightness::update_brightness(logic::brightness::get_brightness());
+    logic::brightness::update_brightness(logic::brightness::get_saved_brightness());
     logic::brightness::update_saved_brightness();
   }
 

--- a/src/system/logic/brightness_handle.cpp
+++ b/src/system/logic/brightness_handle.cpp
@@ -41,7 +41,7 @@ void set_max_brightness(const brightness_t brg)
 void update_saved_brightness() { __internal.savedBrightness = __internal.BRIGHTNESS; }
 brightness_t get_saved_brightness() { return __internal.savedBrightness; }
 
-void update_brightness(const brightness_t newBrightness, const bool isInitialRead)
+void update_brightness(const brightness_t newBrightness, const bool shouldCallUserBrightnessCallback)
 {
   // set to the user max limit (limit can be changed by system)
   const brightness_t trueNewBrightness = min<brightness_t>(newBrightness, get_max_brightness());
@@ -51,7 +51,7 @@ void update_brightness(const brightness_t newBrightness, const bool isInitialRea
     __internal.BRIGHTNESS = trueNewBrightness;
 
     // do not call user functions when reading parameters
-    if (!isInitialRead)
+    if (!shouldCallUserBrightnessCallback)
     {
       user::brightness_update(trueNewBrightness);
     }

--- a/src/system/logic/brightness_handle.cpp
+++ b/src/system/logic/brightness_handle.cpp
@@ -5,6 +5,7 @@
 #include "src/system/platform/time.h"
 
 #include "src/system/utils/utils.h"
+#include <limits>
 
 namespace lampda {
 namespace logic {
@@ -78,7 +79,14 @@ void update_brightness(const brightness_t newBrightness, const bool shouldCallUs
   __internal.lastBrightnessUpdate = ::lampda::platform::time_ms();
 }
 
-void force_brightness_user_callback() { user::brightness_update(get_brightness()); }
+void force_brightness_user_callback()
+{
+  // special check that maximum brightness is not maximum of the type
+  static_assert(::lampda::brightness::absoluteMaximumBrightness < std::numeric_limits<brightness_t>::max());
+
+  // send an invalid command, to avoid updating the brightness
+  user::brightness_update(::lampda::brightness::absoluteMaximumBrightness + 1);
+}
 
 uint32_t when_last_update_brightness() { return __internal.lastBrightnessUpdate; }
 

--- a/src/system/logic/brightness_handle.cpp
+++ b/src/system/logic/brightness_handle.cpp
@@ -16,8 +16,10 @@ namespace brightness {
 struct BrightnessParameters
 {
   /// Upper bound for the brightness
-  /// Can be updated to limit the max birghtness, but should never ecxeed absoluteMaximumBrightness
+  /// Can be updated to limit the max brightness, but should never ecxeed absoluteMaximumBrightness
   brightness_t MaxBrightnessLimit = ::lampda::brightness::absoluteMaximumBrightness;
+  /// Upper bound of the brightness, limited to MaxBrightnessLimit. This only locks user uses.
+  brightness_t MaxUserBrightnessLimit = ::lampda::brightness::absoluteMaximumBrightness;
 
   /// Hold the current level of brightness.
   /// This is the true reference value that is stored in memory at system shutdown
@@ -33,12 +35,28 @@ BrightnessParameters __internal;
 brightness_t get_brightness() { return __internal.BRIGHTNESS; }
 
 brightness_t get_max_brightness() { return __internal.MaxBrightnessLimit; }
+
+brightness_t get_max_user_brightness() { return __internal.MaxUserBrightnessLimit; }
+
 void set_max_brightness(const brightness_t brg)
 {
   __internal.MaxBrightnessLimit = min<brightness_t>(brg, ::lampda::brightness::absoluteMaximumBrightness);
+  // update saved user brightness
+  set_max_user_brightness(__internal.MaxUserBrightnessLimit);
 }
 
-void update_saved_brightness() { __internal.savedBrightness = __internal.BRIGHTNESS; }
+void set_max_user_brightness(const brightness_t brg)
+{
+  // limited to the max system brightness
+  __internal.MaxUserBrightnessLimit = min<brightness_t>(brg, get_max_brightness());
+}
+
+void update_saved_brightness()
+{
+  __internal.savedBrightness = __internal.BRIGHTNESS;
+  __internal.MaxUserBrightnessLimit = __internal.MaxBrightnessLimit;
+}
+
 brightness_t get_saved_brightness() { return __internal.savedBrightness; }
 
 void update_brightness(const brightness_t newBrightness, const bool shouldCallUserBrightnessCallback)
@@ -59,6 +77,8 @@ void update_brightness(const brightness_t newBrightness, const bool shouldCallUs
 
   __internal.lastBrightnessUpdate = ::lampda::platform::time_ms();
 }
+
+void force_brightness_user_callback() { user::brightness_update(get_brightness()); }
 
 uint32_t when_last_update_brightness() { return __internal.lastBrightnessUpdate; }
 

--- a/src/system/logic/brightness_handle.h
+++ b/src/system/logic/brightness_handle.h
@@ -12,10 +12,12 @@ namespace logic {
 /// Handle the LED output brightness
 namespace brightness {
 
-/// Return the current brightness value (in range 0 - brightness::absoluteMaximumBrightness)
+/// Return the current brightness value (in range 0 - brightness::absoluteMaximumBrightness).
+/// It's value depends on a lot of factors and can be cantrolled by any actors.
 brightness_t get_brightness();
 
-/// Return the saved brightness level
+/// Return the saved brightness level.
+/// This shoudl be the prefered option in all computations.
 brightness_t get_saved_brightness();
 
 /// Return the maximum allowed brightness
@@ -31,9 +33,9 @@ void update_saved_brightness();
 /**
  * \brief update the internal brightness values
  * \param[in] newBrightness the new brightness value
- * \param[in] isInitialRead first call of this function when starting
+ * \param[in] shouldCallUserBrightnessCallback True if this will call the user callback call
  */
-void update_brightness(const brightness_t newBrightness, const bool isInitialRead = false);
+void update_brightness(const brightness_t newBrightness, const bool shouldCallUserBrightnessCallback = false);
 
 /// \brief Get time in milliseconds when brightness was last updated
 uint32_t when_last_update_brightness();

--- a/src/system/logic/brightness_handle.h
+++ b/src/system/logic/brightness_handle.h
@@ -23,9 +23,15 @@ brightness_t get_saved_brightness();
 /// Return the maximum allowed brightness
 brightness_t get_max_brightness();
 
+/// Return the maximum allowed brightness for the user modes
+brightness_t get_max_user_brightness();
+
 /// Set the new max brightness
 /// \param[in] brg New brightness, limited to brightness::absoluteMaximumBrightness
 void set_max_brightness(const brightness_t brg);
+
+/// Set the maximum allowed brightness for the user modes
+void set_max_user_brightness(const brightness_t brg);
 
 /// Update the saved brightness value with the current brightness
 void update_saved_brightness();
@@ -36,6 +42,9 @@ void update_saved_brightness();
  * \param[in] shouldCallUserBrightnessCallback True if this will call the user callback call
  */
 void update_brightness(const brightness_t newBrightness, const bool shouldCallUserBrightnessCallback = false);
+
+/// force an update call to the user brightness callback
+void force_brightness_user_callback();
 
 /// \brief Get time in milliseconds when brightness was last updated
 uint32_t when_last_update_brightness();

--- a/src/system/logic/inputs.cpp
+++ b/src/system/logic/inputs.cpp
@@ -276,12 +276,21 @@ void system_enabled_button_hold_callback(const uint8_t consecutiveButtonCheck,
         static int rampSide = 1;
         static uint32_t lastBrightnessUpdateTime_ms = 0;
 
+        // prevent sunset updates when we are updating it ourself
+        logic::sunset::lock_brightness_update(not isEndOfHoldEvent);
+
         if (isEndOfHoldEvent)
         {
-          // reverse on release
-          rampSide = -rampSide;
+          // update logic
           lastBrightnessUpdateTime_ms = platform::time_ms();
           logic::brightness::update_saved_brightness();
+
+          // if user set the brightness up, alert of sunset update
+          if (rampSide > 0)
+            logic::sunset::bump_timer();
+
+          // reverse ramp on release
+          rampSide = -rampSide;
           break;
         }
 
@@ -332,9 +341,6 @@ void system_enabled_button_hold_callback(const uint8_t consecutiveButtonCheck,
           /// go up
           else
           {
-            // alert of sunset update
-            logic::sunset::bump_timer();
-
             // limit max brightness
             const auto _maxBrightness = logic::brightness::get_max_brightness();
             if (brightness + brightnessUpdateStepSize >= _maxBrightness)

--- a/src/system/logic/inputs.cpp
+++ b/src/system/logic/inputs.cpp
@@ -297,7 +297,7 @@ void system_enabled_button_hold_callback(const uint8_t consecutiveButtonCheck,
         // update brightness every N milliseconds (or end of hold)
         EVERY_N_MILLIS(BRIGHTNESS_LOOP_UPDATE_EVERY)
         {
-          const brightness_t brightness = logic::brightness::get_brightness();
+          const brightness_t brightness = logic::brightness::get_saved_brightness();
 
           // first actions, set ramp side
           if (buttonHoldDuration <= BRIGHTNESS_LOOP_UPDATE_EVERY)

--- a/src/system/logic/inputs.cpp
+++ b/src/system/logic/inputs.cpp
@@ -297,7 +297,9 @@ void system_enabled_button_hold_callback(const uint8_t consecutiveButtonCheck,
         // update brightness every N milliseconds (or end of hold)
         EVERY_N_MILLIS(BRIGHTNESS_LOOP_UPDATE_EVERY)
         {
-          const brightness_t brightness = logic::brightness::get_saved_brightness();
+          // use minimum of saved vs max user brightness
+          const brightness_t brightness = std::min<brightness_t>(logic::brightness::get_saved_brightness(),
+                                                                 logic::brightness::get_max_user_brightness());
 
           // first actions, set ramp side
           if (buttonHoldDuration <= BRIGHTNESS_LOOP_UPDATE_EVERY)

--- a/src/system/logic/power_handler.cpp
+++ b/src/system/logic/power_handler.cpp
@@ -279,15 +279,16 @@ void handle_output_voltage_mode()
   if (platform::time_ms() < _temporaryOutputTimeOut)
   {
     set_otg_parameters(_temporaryOutputVoltage_mV, _temporaryOutputCurrent_mA);
-    isVbusVoltageOk = (vbusVoltage >= static_cast<uint32_t>(_temporaryOutputVoltage_mV * voltageGateLowerMultiplier) and
+    isVbusVoltageOk = (vbusVoltage >= static_cast<uint32_t>(stripInputMinVoltage_mV * voltageGateLowerMultiplier) and
+                       // do not check the upper bound, this is a special DANGEROUS case
                        vbusVoltage <= static_cast<uint32_t>(_temporaryOutputVoltage_mV * voltageGateHigherMultiplier));
   }
   else
   {
     _temporaryOutputTimeOut = 0;
     set_otg_parameters(_outputVoltage_mV, _outputCurrent_mA);
-    isVbusVoltageOk = (vbusVoltage >= static_cast<uint32_t>(_outputVoltage_mV * voltageGateLowerMultiplier) and
-                       vbusVoltage <= static_cast<uint32_t>(_outputVoltage_mV * voltageGateHigherMultiplier));
+    isVbusVoltageOk = (vbusVoltage >= static_cast<uint32_t>(stripInputMinVoltage_mV * voltageGateLowerMultiplier) and
+                       vbusVoltage <= static_cast<uint32_t>(stripInputMaxVoltage_mV * voltageGateHigherMultiplier));
   }
 
   // enable power gate when voltage matches expected voltage
@@ -303,7 +304,9 @@ void handle_output_voltage_mode()
   else
   {
     if (s_isOutputModeReady)
-      platform::lampda_print("voltage is not in required range, disabling output");
+      platform::lampda_print("voltage is not in required range, disabling output. Actual %dmV. Required %dmV",
+                             vbusVoltage,
+                             _outputVoltage_mV);
     s_isOutputModeReady = false;
 
     ::lampda::power::powergates::disable_gates();
@@ -698,14 +701,16 @@ bool go_to_error()
 
 void set_output_voltage_mv(const uint16_t outputVoltage_mV)
 {
-#ifdef LMBD_LAMP_TYPE__INDEXABLE
-  // NEVER EVER CHANGE INDEXABLE VOLTAGE
-  const bool isInRange = (outputVoltage_mV == 0) or (outputVoltage_mV == stripInputVoltage_mV);
-  if (not isInRange)
+  if (stripInputMinVoltage_mV == stripInputMaxVoltage_mV)
   {
-    assert(false);
+    // NEVER EVER CHANGE fixed output VOLTAGE
+    const bool isInRange = (outputVoltage_mV == 0) or (outputVoltage_mV == stripInputMaxVoltage_mV);
+    if (not isInRange)
+    {
+      assert(false);
+    }
   }
-#endif
+
   _temporaryOutputTimeOut = 0;
   _outputVoltage_mV = outputVoltage_mV;
 }
@@ -718,13 +723,15 @@ void set_output_max_current_mA(const uint16_t outputCurrent_mA)
 
 void set_temporary_output(const uint16_t outputVoltage_mV, const uint16_t outputCurrent_mA, const uint16_t timeout)
 {
-#ifdef LMBD_LAMP_TYPE__INDEXABLE
-  // NEVER EVER CHANGE INDEXABLE VOLTAGE
-  if (outputVoltage_mV != stripInputVoltage_mV)
+  if (stripInputMinVoltage_mV == stripInputMaxVoltage_mV)
   {
-    assert(false);
+    // NEVER EVER CHANGE FIXED OUTPUT VOLTAGE
+    if (outputVoltage_mV != stripInputMaxVoltage_mV)
+    {
+      assert(false);
+    }
   }
-#endif
+
   // set output timeout
   _temporaryOutputTimeOut = platform::time_ms() + timeout;
   _temporaryOutputVoltage_mV = outputVoltage_mV;

--- a/src/system/logic/sunset_timer.cpp
+++ b/src/system/logic/sunset_timer.cpp
@@ -40,21 +40,35 @@ uint32_t get_sunset_loop_timing_ms()
   return min<uint32_t>(res, brightnessRampDownTime_ms / minimalSunsetUpdateCalls);
 }
 
-void signal_sunset_update()
+/// Return the percent of advance of the sunset timer, from 0 to 1. 1 is end of process.
+float get_percent_of_advance()
 {
   if (platform::time_s() >= sunsetTimerEndTime_s)
-  {
-    logic::behavior::sunset::progress_update(1.0f);
-    return;
-  }
+    return 1.0;
+
   const uint32_t finishline = get_sunset_loop_timing_ms();
 
   // signal the progress change
   const float progress = lmpd_constrain<float>(((sunsetTimerEndTime_s * 1000.0 - finishline) - platform::time_ms()) /
-                                                       static_cast<float>(brightnessRampDownTime_s * 1000.0),
+                                                       static_cast<float>(brightnessRampDownTime_ms),
                                                0.0f,
                                                1.0f);
-  logic::behavior::sunset::progress_update(1.0f - progress);
+  return 1.0 - progress;
+}
+
+/// Send the timer update signal to consummers
+/// Returns the progress
+float signal_sunset_update()
+{
+  if (platform::time_s() >= sunsetTimerEndTime_s)
+  {
+    logic::behavior::sunset::progress_update(1.0f);
+    return 1.0;
+  }
+
+  const float progress = get_percent_of_advance();
+  logic::behavior::sunset::progress_update(progress);
+  return progress;
 }
 
 void sunset_process_loop()
@@ -73,28 +87,30 @@ void sunset_process_loop()
     if (platform::time_s() + brightnessRampDownTime_s >= sunsetTimerEndTime_s)
     {
       // signal the progress change
-      signal_sunset_update();
-
-      // decrease brightness every N seconds left
-      const auto currentBrightness = logic::brightness::get_brightness();
-      if (platform::time_s() >= sunsetTimerEndTime_s)
+      const float progress = signal_sunset_update();
+      if (progress >= 1.0)
       {
-        logic::brightness::update_brightness(0);
+        logic::brightness::set_max_user_brightness(0);
+        logic::brightness::force_brightness_user_callback();
         platform::lampda_print("Shutdown with sunset timer");
         logic::behavior::set_power_off();
         cancel_timer();
         return;
       }
-      else if (currentBrightness >= brightnessDecreasePerLoop)
+      else
       {
         if (isAllowedToControlBrightness)
         {
-          const brightness_t newBrightness = currentBrightness - brightnessDecreasePerLoop;
+          // new brightness to use
+          const brightness_t newBrightness =
+                  lmpd_constrain<float>(1.0 - progress, 0.0, 1.0) * logic::brightness::get_saved_brightness();
+
           // slowly decrease brighntess
-          logic::brightness::update_brightness(newBrightness);
+          logic::brightness::set_max_user_brightness(newBrightness);
+          // force an update of the brightness, with user callback
+          logic::brightness::force_brightness_user_callback();
         }
       }
-      // else: casual loop update
     }
   }
 }
@@ -129,6 +145,9 @@ void add_time_minutes(const uint8_t time_minutes)
     // added some time, so signal update
     signal_sunset_update();
   }
+
+  // restore stored brightness as the user limit
+  logic::brightness::set_max_user_brightness(logic::brightness::get_saved_brightness());
 }
 
 /// signal to the timer that some time must be added. Limited to 10 minutes
@@ -151,14 +170,19 @@ void bump_timer()
 /// cancel the current active timer
 void cancel_timer()
 {
+  const bool isSunsetActive = sunsetTimerEndTime_s != 0;
   // release timer
   sunsetTimerEndTime_s = 0;
   lock_brightness_update(false);
 
+  logic::brightness::set_max_user_brightness(logic::brightness::get_max_brightness());
   // signal change
-  signal_sunset_update();
+  if (isSunsetActive)
+  {
+    signal_sunset_update();
+    platform::lampda_print("sunset timer cleared");
+  }
 
-  platform::lampda_print("sunset timer cleared");
   logic::alerts::manager.clear(logic::alerts::Type::SUNSET_TIMER_ENABLED);
 }
 

--- a/src/system/logic/sunset_timer.cpp
+++ b/src/system/logic/sunset_timer.cpp
@@ -15,6 +15,7 @@ namespace logic {
 namespace sunset {
 
 uint32_t sunsetTimerEndTime_s = 0;
+bool isAllowedToControlBrightness = true;
 
 static constexpr uint32_t brightnessRampDownTime_min = 3;
 static constexpr uint32_t brightnessRampDownTime_s = brightnessRampDownTime_min * 60;
@@ -86,8 +87,12 @@ void sunset_process_loop()
       }
       else if (currentBrightness >= brightnessDecreasePerLoop)
       {
-        // slowly decrease brighntess
-        logic::brightness::update_brightness(currentBrightness - brightnessDecreasePerLoop);
+        if (isAllowedToControlBrightness)
+        {
+          const brightness_t newBrightness = currentBrightness - brightnessDecreasePerLoop;
+          // slowly decrease brighntess
+          logic::brightness::update_brightness(newBrightness);
+        }
       }
       // else: casual loop update
     }
@@ -129,14 +134,17 @@ void add_time_minutes(const uint8_t time_minutes)
 /// signal to the timer that some time must be added. Limited to 10 minutes
 void bump_timer()
 {
-  if (sunsetTimerEndTime_s == 0 or sunsetTimerEndTime_s < platform::time_s())
+  const auto timeS = platform::time_s();
+  if (sunsetTimerEndTime_s == 0 or sunsetTimerEndTime_s < timeS)
     return;
 
-  // if less than 3 minutes left, bump timer to N minutes
-  if (sunsetTimerEndTime_s - platform::time_s() < brightnessRampDownTime_s)
+  // if less than N minutes left, bump timer to N minutes
+  if (sunsetTimerEndTime_s - timeS < brightnessRampDownTime_s)
   {
-    sunsetTimerEndTime_s = platform::time_s() + (brightnessRampDownTime_min + 1) * 60;
-    signal_sunset_update();
+    // add 1 minute + time left
+    const uint16_t timeLeft_min = round((sunsetTimerEndTime_s - timeS) / 60.0);
+    // add some time to the sunset
+    add_time_minutes(1 + (brightnessRampDownTime_min - timeLeft_min));
   }
 }
 
@@ -145,12 +153,18 @@ void cancel_timer()
 {
   // release timer
   sunsetTimerEndTime_s = 0;
+  lock_brightness_update(false);
+
+  // signal change
   signal_sunset_update();
+
   platform::lampda_print("sunset timer cleared");
   logic::alerts::manager.clear(logic::alerts::Type::SUNSET_TIMER_ENABLED);
 }
 
 bool is_enabled() { return sunsetTimerEndTime_s > 0; }
+
+void lock_brightness_update(bool shouldLock) { isAllowedToControlBrightness = not shouldLock; }
 
 } // namespace sunset
 } // namespace logic

--- a/src/system/logic/sunset_timer.h
+++ b/src/system/logic/sunset_timer.h
@@ -27,6 +27,9 @@ void cancel_timer();
 /// True if timer is running
 bool is_enabled();
 
+/// Lock the hability of the sunset timer to control the brightness
+void lock_brightness_update(bool shouldLock);
+
 } // namespace sunset
 } // namespace logic
 } // namespace lampda

--- a/src/system/power/charging_ic.cpp
+++ b/src/system/power/charging_ic.cpp
@@ -641,8 +641,8 @@ void loop(const bool isChargeOk)
   // update the OTG functionalities
   control_OTG();
 
-  // only update every 100ms
-  EVERY_N_MILLIS_COND(isChargeChanged, 100)
+  // only update every 10ms, ADC needs to update fairly quickly
+  EVERY_N_MILLIS_COND(isChargeChanged, 10)
   {
     measurments_s.isChargeOk = isChargeOk;
 

--- a/src/system/power/power_gates.cpp
+++ b/src/system/power/power_gates.cpp
@@ -155,6 +155,7 @@ void blip(const uint32_t timing)
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
   // NEVER EVER BLIP THE INDEXABLE, the strip is too weak
   assert(false);
+  return;
 #endif
 
   // hard limit on blip

--- a/src/system/utils/constants.h
+++ b/src/system/utils/constants.h
@@ -120,7 +120,7 @@ static constexpr uint16_t batteryMinVoltageSafe_mV = minSafeLiionVoltage_mV * ba
 /// Total maximum power usage of the led strip
 static constexpr float totalCons_Watt = consWattByMeter * ledStripLength_mm / 1000.0f;
 /// Maximum led strip current usage, in Amps
-static constexpr float maxStripConsumption_A = 1000.0f * totalCons_Watt / stripInputVoltage_mV;
+static constexpr float maxStripConsumption_A = 1000.0f * totalCons_Watt / stripInputMaxVoltage_mV;
 
 /// Battery maximum charge current, in milliAmps
 static constexpr uint32_t batteryMaxChargeCurrent_mA =

--- a/src/user/cct_functions.cpp
+++ b/src/user/cct_functions.cpp
@@ -72,13 +72,14 @@ void brightness_update(const brightness_t brightness)
 
   // map to a new curve, favorising low levels
   using curve_t = utils::curves::ExponentialCurve<brightness_t, uint8_t>;
-  static curve_t brightnessCurve(curve_t::point_t {0, minBrightness},
-                                 curve_t::point_t {::lampda::brightness::absoluteMaximumBrightness, 255},
-                                 50.0);
+  static curve_t brightnessCurve(
+          curve_t::point_t {0, stripInputMinVoltage_mV},
+          curve_t::point_t {::lampda::brightness::absoluteMaximumBrightness, stripInputMaxVoltage_mV},
+          50.0);
 
   currentBrightness = round(brightnessCurve.sample(constraintBrightness));
 
-  physical::outputPower::write_voltage(stripInputVoltage_mV);
+  physical::outputPower::write_voltage(currentBrightness);
   set_color(currentColor);
 }
 

--- a/src/user/cct_functions.cpp
+++ b/src/user/cct_functions.cpp
@@ -71,7 +71,7 @@ void brightness_update(const brightness_t brightness)
   }
 
   // map to a new curve, favorising low levels
-  using curve_t = utils::curves::ExponentialCurve<brightness_t, uint8_t>;
+  using curve_t = utils::curves::ExponentialCurve<brightness_t, brightness_t>;
   static curve_t brightnessCurve(
           curve_t::point_t {0, stripInputMinVoltage_mV},
           curve_t::point_t {::lampda::brightness::absoluteMaximumBrightness, stripInputMaxVoltage_mV},

--- a/src/user/cct_functions.cpp
+++ b/src/user/cct_functions.cpp
@@ -45,7 +45,7 @@ void power_on_sequence()
   YellowColorPin.set_pin_mode(platform::gpio::DigitalPin::Mode::kOutput);
   WhiteColorPin.set_pin_mode(platform::gpio::DigitalPin::Mode::kOutput);
 
-  brightness_update(logic::brightness::get_brightness());
+  brightness_update(logic::brightness::get_saved_brightness());
 }
 
 void power_off_sequence()
@@ -95,7 +95,7 @@ void read_parameters()
     lastColor = currentColor;
   }
 
-  currentBrightness = logic::brightness::get_brightness();
+  currentBrightness = logic::brightness::get_saved_brightness();
 }
 
 bool button_start_click_default(const uint8_t clicks) { return false; }

--- a/src/user/constants.h
+++ b/src/user/constants.h
@@ -37,9 +37,10 @@ static constexpr uint8_t USER_SOFTWARE_VERSION_MINOR = 7;
 static constexpr uint32_t MAIN_LOOP_UPDATE_PERIOD_MS = static_cast<uint32_t>(1000 / 80.0f);
 
 // parameters of the led strip used
-static constexpr float consWattByMeter = 12;              // power consumption (in Watt/meters)
-static constexpr uint16_t stripInputVoltage_mV = 12000;   // voltage
-static constexpr float ledStripLength_mm = 91.0f * 25.0f; // 91 sections of 25 mm
+static constexpr float consWattByMeter = 12;               // power consumption (in Watt/meters)
+static constexpr uint16_t stripInputMinVoltage_mV = 9400;  // min allowed voltage
+static constexpr uint16_t stripInputMaxVoltage_mV = 12000; // max allowed voltage
+static constexpr float ledStripLength_mm = 91.0f * 25.0f;  // 91 sections of 25 mm
 
 // define position of led 0 to the circuit center
 static constexpr float circuitToLedZeroRotationX_degrees = 0.0f;
@@ -59,9 +60,10 @@ static constexpr float circuitToLedZeroRotationZ_degrees = 88.0f;
 static constexpr uint32_t MAIN_LOOP_UPDATE_PERIOD_MS = static_cast<uint32_t>(1000 / 80.0f);
 
 // parameters of the led strip used
-static constexpr float consWattByMeter = 10;              // power consumption (in Watt/meters)
-static constexpr uint16_t stripInputVoltage_mV = 12000;   // voltage
-static constexpr float ledStripLength_mm = 67.0f * 27.0f; // 67 sections of 27 mm
+static constexpr float consWattByMeter = 10;               // power consumption (in Watt/meters)
+static constexpr uint16_t stripInputMinVoltage_mV = 9000;  // min allowed led voltage
+static constexpr uint16_t stripInputMaxVoltage_mV = 12000; // min allowed led voltage
+static constexpr float ledStripLength_mm = 67.0f * 27.0f;  // 67 sections of 27 mm
 
 // define position of led 0 to the circuit center
 static constexpr float circuitToLedZeroRotationX_degrees = 0.0f;
@@ -80,24 +82,26 @@ static constexpr float lampBodyRadius_mm = 25; // external radius of the lamp bo
 // parameters of the led strip used
 #ifdef LMBD_LAMP_TYPE__INDEXABLE_IS_HD
 // hd 240L/m strip
-static constexpr uint16_t LED_COUNT = 870;              // How many indexable leds are attached to the controler
-static constexpr float consWattByMeter = 5;             // power consumption (in Watt/meters)
-static constexpr uint16_t stripInputVoltage_mV = 12000; // voltage
-static constexpr float ledByMeter = 244;                // the REAL indexable led by meters (for a 240Led/m)
-static constexpr float ledStripWidth_mm = 5.2f;         // width of the led strip
-static constexpr float ledStripHeigh_mm = 0.7f;         // heigh of the led strip (calibrated for this strip)
+static constexpr uint16_t LED_COUNT = 870;                 // How many indexable leds are attached to the controler
+static constexpr float consWattByMeter = 5;                // power consumption (in Watt/meters)
+static constexpr uint16_t stripInputMinVoltage_mV = 12000; // min allowed voltage
+static constexpr uint16_t stripInputMaxVoltage_mV = 12000; // max allowed voltage
+static constexpr float ledByMeter = 244;                   // the REAL indexable led by meters (for a 240Led/m)
+static constexpr float ledStripWidth_mm = 5.2f;            // width of the led strip
+static constexpr float ledStripHeigh_mm = 0.7f;            // heigh of the led strip (calibrated for this strip)
 
 // compute the expected average loop runtime (in ms)
 // defined as milliseconds / FPS
 static constexpr uint32_t MAIN_LOOP_UPDATE_PERIOD_MS = static_cast<uint32_t>(1000 / 40.0f);
 #else
 // standard 160L/m strip
-static constexpr uint16_t LED_COUNT = 580;              // How many indexable leds are attached to the controler
-static constexpr float consWattByMeter = 5;             // power consumption (in Watt/meters)
-static constexpr uint16_t stripInputVoltage_mV = 12000; // voltage
-static constexpr float ledByMeter = 162.6f;             // the REAL indexable led by meters (for a 160Led/m)
-static constexpr float ledStripWidth_mm = 5.2f;         // width of the led strip
-static constexpr float ledStripHeigh_mm = 0.7f;         // heigh of the led strip (calibrated for this strip)
+static constexpr uint16_t LED_COUNT = 580;                 // How many indexable leds are attached to the controler
+static constexpr float consWattByMeter = 5;                // power consumption (in Watt/meters)
+static constexpr uint16_t stripInputMinVoltage_mV = 12000; // min allowed voltage
+static constexpr uint16_t stripInputMaxVoltage_mV = 12000; // max allowed voltage
+static constexpr float ledByMeter = 162.6f;                // the REAL indexable led by meters (for a 160Led/m)
+static constexpr float ledStripWidth_mm = 5.2f;            // width of the led strip
+static constexpr float ledStripHeigh_mm = 0.7f;            // heigh of the led strip (calibrated for this strip)
 
 // compute the expected average loop runtime (in ms)
 // defined as milliseconds / FPS


### PR DESCRIPTION
Closes #389 

Add a new brightness layer in the lamp_type to avoid the confusion between the global system brightness and per mode brightness. Prevent user to change the system internal brightness and other system parameters.
Allow sunset timer to run on any animations, even those that changes brightness. 

Add minimum led voltage in constants, and apply stronger safety rules.

Resolve output inconsistencies when voltage used to change rapidly.
