### PR TITLE
Add basic logic for temporal dithering

### DIFF
--- a/simulator/include/simulator.h
+++ b/simulator/include/simulator.h
@@ -22,7 +22,8 @@
 #include <SFML/System/Time.hpp>
 #include <SFML/Window/Keyboard.hpp>
 
-#define LMBD_SIMU_REALCOLORS
+/// if defined, will display colors with the same brigthness to debug the color bending
+// #define LMBD_DEBUG_SIMU_REALCOLORS
 
 namespace simulator {
 // (_LampTy from simulator_state.h)
@@ -333,7 +334,7 @@ template<typename T> struct simulator
 #ifdef LMBD_LAMP_TYPE__INDEXABLE
           state.colorBuffer[I] =
                   isOutputEnabled ?
-                          (isVoltageHighEnough ? ::lampda::user::_private::strip.getPixelColor(I) : 0xffffff) :
+                          (isVoltageHighEnough ? ::lampda::user::_private::strip.getRawPixelColor(I) : 0xffffff) :
                           0;
           state.brightness = ::lampda::user::_private::strip.getBrightness();
 #endif
@@ -416,10 +417,16 @@ template<typename T> struct simulator
           float g = ((color >> 8) & 0xff);
           float r = ((color >> 16) & 0xff);
 
-          const auto brightness = state.brightness;
-          r = std::min<float>(r, brightness);
-          g = std::min<float>(g, brightness);
-          b = std::min<float>(b, brightness);
+#ifndef LMBD_DEBUG_SIMU_REALCOLORS
+          // break color representation, like the real strip
+          const uint8_t brigthness = state.brightness;
+
+          // scale by brightness
+          const float brightnessDivider = static_cast<float>(brigthness) / 255.0;
+          r = static_cast<uint8_t>(r * brightnessDivider);
+          g = static_cast<uint8_t>(g * brightnessDivider);
+          b = static_cast<uint8_t>(b * brightnessDivider);
+#endif
 
           shape.setFillColor(sf::Color(r, g, b));
           window.draw(shape);

--- a/simulator/include/simulator.h
+++ b/simulator/include/simulator.h
@@ -328,24 +328,30 @@ template<typename T> struct simulator
       const bool isOutputEnabled = is_output_enabled();
       if constexpr (_LampTy::flavor == ::lampda::modes::hardware::LampTypes::indexable)
       {
+#ifdef LMBD_LAMP_TYPE__INDEXABLE
+        // brightness on the indexale lamp
+        using curve_t = ::lampda::utils::curves::LinearCurve<::lampda::brightness_t, uint8_t>;
+        static curve_t brightnessCurve({curve_t::point_t {0, ::lampda::minimumAllowedBrightness_8},
+                                        curve_t::point_t {::lampda::brightness::absoluteMaximumBrightness, 255}});
+        state.brightness = brightnessCurve.sample(::lampda::logic::brightness::get_brightness());
+
         const bool isVoltageHighEnough = mock_electrical::outputVoltage > 11.5;
         for (size_t I = 0; I < _LampTy::ledCount; ++I)
         {
-#ifdef LMBD_LAMP_TYPE__INDEXABLE
           state.colorBuffer[I] =
                   isOutputEnabled ?
                           (isVoltageHighEnough ? ::lampda::user::_private::strip.getRawPixelColor(I) : 0xffffff) :
                           0;
-          state.brightness = ::lampda::user::_private::strip.getBrightness();
-#endif
         }
+#endif
       }
       else
       {
-        for (size_t I = 0; I < _LampTy::ledCount; ++I)
-          state.colorBuffer[I] = isOutputEnabled ? 0xffff00 : 0;
         state.brightness =
                 (::lampda::logic::brightness::get_brightness() * 255) / ::lampda::brightness::absoluteMaximumBrightness;
+
+        for (size_t I = 0; I < _LampTy::ledCount; ++I)
+          state.colorBuffer[I] = isOutputEnabled ? 0xffff00 : 0;
       }
 
       state.indicatorColor = mock_indicator::get_color();
@@ -418,14 +424,13 @@ template<typename T> struct simulator
           float r = ((color >> 16) & 0xff);
 
 #ifndef LMBD_DEBUG_SIMU_REALCOLORS
-          // break color representation, like the real strip
-          const uint8_t brigthness = state.brightness;
-
-          // scale by brightness
-          const float brightnessDivider = static_cast<float>(brigthness) / 255.0;
-          r = static_cast<uint8_t>(r * brightnessDivider);
-          g = static_cast<uint8_t>(g * brightnessDivider);
-          b = static_cast<uint8_t>(b * brightnessDivider);
+          if (state.brightness != 255)
+          {
+            // scale by brightness
+            r = (uint16_t(r) * state.brightness + state.brightness) >> 8;
+            g = (uint16_t(g) * state.brightness + state.brightness) >> 8;
+            b = (uint16_t(b) * state.brightness + state.brightness) >> 8;
+          }
 #endif
 
           shape.setFillColor(sf::Color(r, g, b));

--- a/simulator/mocks/Adafruit_NeoPixel.h
+++ b/simulator/mocks/Adafruit_NeoPixel.h
@@ -12,36 +12,194 @@
 
 using neoPixelType = int;
 
-static constexpr int NEO_RGB = 0;
-static constexpr int NEO_KHZ800 = 1;
+// RGB NeoPixel permutations; white and red offsets are always same
+// Offset:        W          R          G          B
+#define NEO_RGB ((0 << 6) | (0 << 4) | (1 << 2) | (2)) ///< Transmit as R,G,B
+#define NEO_RBG ((0 << 6) | (0 << 4) | (2 << 2) | (1)) ///< Transmit as R,B,G
+#define NEO_GRB ((1 << 6) | (1 << 4) | (0 << 2) | (2)) ///< Transmit as G,R,B
+#define NEO_GBR ((2 << 6) | (2 << 4) | (0 << 2) | (1)) ///< Transmit as G,B,R
+#define NEO_BRG ((1 << 6) | (1 << 4) | (2 << 2) | (0)) ///< Transmit as B,R,G
+#define NEO_BGR ((2 << 6) | (2 << 4) | (1 << 2) | (0)) ///< Transmit as B,G,R
+
+#define NEO_KHZ800 0x0000 ///< 800 KHz data transmission
 
 class Adafruit_NeoPixel
 {
 public:
-  Adafruit_NeoPixel(size_t ledCount, int16_t pin, neoPixelType type) { brightness = 255; };
-
-  void begin() {}
-
-  void show() {}
-
-  uint8_t getBrightness() const { return brightness; }
-  void setBrightness(uint8_t bright) { brightness = bright; }
-
-  void fill(uint32_t c, int a, int b) {}
-
-  void setPixelColor(uint16_t n, uint32_t c) {}
-
-  uint32_t getPixelColor(uint16_t n) const { return 0; }
-
-  static uint32_t Color(uint8_t r, uint8_t g, uint8_t b) { return (r << 16) | (g << 8) | b; }
-
-  static uint32_t ColorHSV(double h, double s = 255, double v = 255)
+  Adafruit_NeoPixel(size_t n, int16_t pin, neoPixelType t) : begun(false), brightness(0), pixels(NULL)
   {
-    return lampda::utils::ColorSpace::HSV(h, s, v).get_rgb().color;
+    updateType(t);
+    updateLength(n);
+  };
+
+  ~Adafruit_NeoPixel() { free(pixels); }
+
+  void begin() { begun = true; }
+
+  void show()
+  {
+    /// Cannot implement here, simulator handles this
+  }
+
+  uint8_t getBrightness() const { return brightness - 1; }
+
+  /// Implementation similar to Adafruit led strip
+  void setBrightness(uint8_t b)
+  {
+    // Stored brightness value is different than what's passed.
+    // This simplifies the actual scaling math later, allowing a fast
+    // 8x8-bit multiply and taking the MSB. 'brightness' is a uint8_t,
+    // adding 1 here may (intentionally) roll over...so 0 = max brightness
+    // (color values are interpreted literally; no scaling), 1 = min
+    // brightness (off), 255 = just below max brightness.
+    uint8_t newBrightness = b + 1;
+
+    if (newBrightness != brightness)
+    { // Compare against prior value
+      // Brightness has changed -- re-scale existing data in RAM,
+      // This process is potentially "lossy," especially when increasing
+      // brightness. The tight timing in the WS2811/WS2812 code means there
+      // aren't enough free cycles to perform this scaling on the fly as data
+      // is issued. So we make a pass through the existing color data in RAM
+      // and scale it (subsequent graphics commands also work at this
+      // brightness level). If there's a significant step up in brightness,
+      // the limited number of steps (quantization) in the old data will be
+      // quite visible in the re-scaled version. For a non-destructive
+      // change, you'll need to re-render the full strip data. C'est la vie.
+      uint8_t c, *ptr = pixels,
+                 oldBrightness = brightness - 1; // De-wrap old brightness value
+      uint16_t scale;
+      if (oldBrightness == 0)
+        scale = 0; // Avoid /0
+      else if (b == 255)
+        scale = 65535 / oldBrightness;
+      else
+        scale = (((uint16_t)newBrightness << 8) - 1) / oldBrightness;
+      for (uint16_t i = 0; i < numBytes; i++)
+      {
+        c = *ptr;
+        *ptr++ = (c * scale) >> 8;
+      }
+      brightness = newBrightness;
+    }
+  }
+
+  void setPixelColor(uint16_t n, uint32_t c)
+  {
+    if (n < numLEDs)
+    {
+      uint8_t *p, r = (uint8_t)(c >> 16), g = (uint8_t)(c >> 8), b = (uint8_t)c;
+      if (brightness)
+      { // See notes in setBrightness()
+        r = (r * brightness) >> 8;
+        g = (g * brightness) >> 8;
+        b = (b * brightness) >> 8;
+      }
+      if (wOffset == rOffset)
+      {
+        p = &pixels[n * 3];
+      }
+      else
+      {
+        p = &pixels[n * 4];
+        uint8_t w = (uint8_t)(c >> 24);
+        p[wOffset] = brightness ? ((w * brightness) >> 8) : w;
+      }
+      p[rOffset] = r;
+      p[gOffset] = g;
+      p[bOffset] = b;
+    }
+  }
+
+  uint32_t getPixelColor(uint16_t n) const
+  {
+    if (n >= numLEDs)
+      return 0; // Out of bounds, return no color.
+
+    uint8_t* p;
+
+    if (wOffset == rOffset)
+    { // Is RGB-type device
+      p = &pixels[n * 3];
+      if (brightness)
+      {
+        // Stored color was decimated by setBrightness(). Returned value
+        // attempts to scale back to an approximation of the original 24-bit
+        // value used when setting the pixel color, but there will always be
+        // some error -- those bits are simply gone. Issue is most
+        // pronounced at low brightness levels.
+        return (((uint32_t)(p[rOffset] << 8) / brightness) << 16) | (((uint32_t)(p[gOffset] << 8) / brightness) << 8) |
+               ((uint32_t)(p[bOffset] << 8) / brightness);
+      }
+      else
+      {
+        // No brightness adjustment has been made -- return 'raw' color
+        return ((uint32_t)p[rOffset] << 16) | ((uint32_t)p[gOffset] << 8) | (uint32_t)p[bOffset];
+      }
+    }
+    else
+    { // Is RGBW-type device
+      p = &pixels[n * 4];
+      if (brightness)
+      { // Return scaled color
+        return (((uint32_t)(p[wOffset] << 8) / brightness) << 24) | (((uint32_t)(p[rOffset] << 8) / brightness) << 16) |
+               (((uint32_t)(p[gOffset] << 8) / brightness) << 8) | ((uint32_t)(p[bOffset] << 8) / brightness);
+      }
+      else
+      { // Return raw color
+        return ((uint32_t)p[wOffset] << 24) | ((uint32_t)p[rOffset] << 16) | ((uint32_t)p[gOffset] << 8) |
+               (uint32_t)p[bOffset];
+      }
+    }
   }
 
   // vars
-  uint8_t brightness;
+  bool begun;         ///< true if begin() previously called
+  uint16_t numLEDs;   ///< Number of RGB LEDs in strip
+  uint16_t numBytes;  ///< Size of 'pixels' buffer below
+  uint8_t brightness; ///< Strip brightness 0-255 (stored as +1)
+  uint8_t* pixels;    ///< Holds LED color values (3 or 4 bytes each)
+  uint8_t rOffset;    ///< Red index within each 3- or 4-byte pixel
+  uint8_t gOffset;    ///< Index of green byte
+  uint8_t bOffset;    ///< Index of blue byte
+  uint8_t wOffset;    ///< Index of white (==rOffset if no white)
+
+private:
+  void updateType(neoPixelType t)
+  {
+    bool oldThreeBytesPerPixel = (wOffset == rOffset); // false if RGBW
+
+    wOffset = (t >> 6) & 0b11; // See notes in header file
+    rOffset = (t >> 4) & 0b11; // regarding R/G/B/W offsets
+    gOffset = (t >> 2) & 0b11;
+    bOffset = t & 0b11;
+
+    // If bytes-per-pixel has changed (and pixel data was previously
+    // allocated), re-allocate to new size. Will clear any data.
+    if (pixels)
+    {
+      bool newThreeBytesPerPixel = (wOffset == rOffset);
+      if (newThreeBytesPerPixel != oldThreeBytesPerPixel)
+        updateLength(numLEDs);
+    }
+  }
+
+  void updateLength(uint16_t n)
+  {
+    free(pixels); // Free existing data (if any)
+
+    // Allocate new data -- note: ALL PIXELS ARE CLEARED
+    numBytes = n * ((wOffset == rOffset) ? 3 : 4);
+    if ((pixels = (uint8_t*)malloc(numBytes)))
+    {
+      memset(pixels, 0, numBytes);
+      numLEDs = n;
+    }
+    else
+    {
+      numLEDs = numBytes = 0;
+    }
+  }
 };
 
 #endif

--- a/src/modes/include/colors/palettes.hpp
+++ b/src/modes/include/colors/palettes.hpp
@@ -390,8 +390,9 @@ static constexpr PaletteTy PalettePartyColors = {0x5500AB,
                                                  0x2F00D0,
                                                  0x0007F9};
 
-/// Black body radiation
-static constexpr PaletteTy PaletteBlackBodyColors = {0xff3800,
+/// Black body radiation, with the high end changed to be nicer
+static constexpr PaletteTy PaletteBlackBodyColors = {0xE73E05,
+                                                     // 0xff3800, true black body
                                                      0xff5300,
                                                      0xff6500,
                                                      0xff7300,

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -592,6 +592,7 @@ public:
       static curve_t brightnessCurve({curve_t::point_t {0, minBrightness},
                                       curve_t::point_t {::lampda::brightness::absoluteMaximumBrightness, 255}});
 
+      /// @warning: this is actually heavy to run
       strip.setBrightness(brightnessCurve.sample(trueNewBrightness));
     }
 

--- a/src/modes/include/hardware/lamp_type.hpp
+++ b/src/modes/include/hardware/lamp_type.hpp
@@ -587,9 +587,13 @@ public:
 
     if constexpr (flavor == LampTypes::indexable)
     {
-      constexpr uint8_t minBrightness = 5;
+#ifndef LMBD_LAMP_TYPE__INDEXABLE
+      static constexpr uint8_t minimumAllowedBrightness = 5;
+#else
+      static constexpr uint8_t minimumAllowedBrightness = ::lampda::minimumAllowedBrightness_8;
+#endif
       using curve_t = utils::curves::LinearCurve<brightness_t, uint8_t>;
-      static curve_t brightnessCurve({curve_t::point_t {0, minBrightness},
+      static curve_t brightnessCurve({curve_t::point_t {0, minimumAllowedBrightness},
                                       curve_t::point_t {::lampda::brightness::absoluteMaximumBrightness, 255}});
 
       /// @warning: this is actually heavy to run

--- a/src/system/global.cpp
+++ b/src/system/global.cpp
@@ -38,6 +38,9 @@ void secondary_thread()
     return;
 
   user::user_thread();
+
+  // prevent infinite loop
+  platform::delay_ms(1);
 }
 
 void check_loop_runtime(const uint32_t runTime)

--- a/src/system/physical/strip.h
+++ b/src/system/physical/strip.h
@@ -100,6 +100,15 @@ public:
     return brightness;
   }
 
+  // Accessor to set a color
+  void setPixelColor(uint16_t n, COLOR c)
+  {
+    if (n >= LED_COUNT)
+      return;
+
+    _colors[n] = c;
+  }
+
   /**
    * EXPLICIT CALLS TO THE LIBRARY
    */
@@ -111,23 +120,8 @@ public:
     Adafruit_NeoPixel::setBrightness(255);
   }
 
-  void setPixelColor(uint16_t n, COLOR c)
-  {
-    if (n >= LED_COUNT)
-      return;
-
-    if (brightness != UINT8_MAX)
-    {
-      const uint8_t trueBrightness = brightness + 1;
-      c.blue = static_cast<uint8_t>((c.blue * trueBrightness) >> 8);
-      c.green = static_cast<uint8_t>((c.green * trueBrightness) >> 8);
-      c.red = static_cast<uint8_t>((c.red * trueBrightness) >> 8);
-    }
-
-    _colors[n] = c;
-    Adafruit_NeoPixel::setPixelColor(n, c.color);
-  }
-
+  /// Return the raw color value stored in the send buffer.
+  /// \warning Should not be used except for debug
   uint32_t getRawPixelColor(uint16_t n) const
   {
     // ,o colors outside of strip
@@ -137,9 +131,10 @@ public:
     COLOR c;
     c.color = Adafruit_NeoPixel::getPixelColor(n);
 
-    if (brightness != UINT8_MAX)
+    // We use brightnessAtShowTime here, our the colors can break when brightness changed
+    if (brightnessAtShowTime != UINT8_MAX)
     {
-      const uint8_t trueBrightness = brightness + 1;
+      const uint8_t trueBrightness = brightnessAtShowTime + 1;
       c.blue = static_cast<uint8_t>((uint32_t)(c.blue << 8) / trueBrightness);
       c.green = static_cast<uint8_t>((uint32_t)(c.green << 8) / trueBrightness);
       c.red = static_cast<uint8_t>((uint32_t)(c.red << 8) / trueBrightness);
@@ -148,9 +143,46 @@ public:
     return c.color;
   }
 
+  /// \private: write the buffered colors to the led driver
+  void write_to_led_driver(const uint8_t writeBrightness)
+  {
+    // store all pixels for display
+    const bool isNotMaxBrightness = writeBrightness != UINT8_MAX;
+
+    if (writeBrightness == UINT8_MAX)
+    {
+      // brightness at maxium, change nothing
+      for (uint16_t i = 0; i < LED_COUNT; ++i)
+      {
+        Adafruit_NeoPixel::setPixelColor(i, _colors[i].color);
+      }
+    }
+    else
+    {
+      // brightness should be adjusted, do it
+      const uint8_t trueBrightness = writeBrightness + 1;
+      for (uint16_t i = 0; i < LED_COUNT; ++i)
+      {
+        // indirection by copy
+        COLOR c;
+        c.color = _colors[i].color;
+
+        c.blue = static_cast<uint8_t>((c.blue * trueBrightness) >> 8);
+        c.green = static_cast<uint8_t>((c.green * trueBrightness) >> 8);
+        c.red = static_cast<uint8_t>((c.red * trueBrightness) >> 8);
+
+        // set strip color
+        Adafruit_NeoPixel::setPixelColor(i, c.color);
+      }
+    }
+  }
+
   /// Show the current data, independant of changes
   void show_now()
   {
+    brightnessAtShowTime = brightness;
+    write_to_led_driver(brightnessAtShowTime);
+
     Adafruit_NeoPixel::show();
     hasSomeChanges = false;
   }
@@ -307,7 +339,12 @@ public:
 
 private:
   volatile bool hasSomeChanges;
+
+  /// Out strip brightness
   volatile uint8_t brightness;
+
+  /// Store a reference to the brightness value from the last show() call
+  volatile uint8_t brightnessAtShowTime;
 };
 
 } // namespace physical

--- a/src/system/physical/strip.h
+++ b/src/system/physical/strip.h
@@ -88,24 +88,65 @@ public:
     return max<float>(baseCurrentConsumption, estimatedCurrentDraw);
   }
 
+  /// Brightness is an internal counter
+  void setBrightness(uint8_t b) { brightness = b; }
+
+  /// Brightness is an internal flag
+  uint8_t getBrightness() const
+  {
+    // check that this never changes
+    assert(Adafruit_NeoPixel::getBrightness() == 255);
+
+    return brightness;
+  }
+
   /**
    * EXPLICIT CALLS TO THE LIBRARY
    */
 
-  void setBrightness(uint8_t b) { Adafruit_NeoPixel::setBrightness(b); }
-
-  uint8_t getBrightness() const { return Adafruit_NeoPixel::getBrightness(); }
-
-  void begin() { Adafruit_NeoPixel::begin(); }
+  void begin()
+  {
+    Adafruit_NeoPixel::begin();
+    // brightness always at the maximum level
+    Adafruit_NeoPixel::setBrightness(255);
+  }
 
   void setPixelColor(uint16_t n, COLOR c)
   {
-    n = lmpd_constrain<uint16_t>(n, 0, LED_COUNT - 1);
+    if (n >= LED_COUNT)
+      return;
+
+    if (brightness != UINT8_MAX)
+    {
+      const uint8_t trueBrightness = brightness + 1;
+      c.blue = static_cast<uint8_t>((c.blue * trueBrightness) >> 8);
+      c.green = static_cast<uint8_t>((c.green * trueBrightness) >> 8);
+      c.red = static_cast<uint8_t>((c.red * trueBrightness) >> 8);
+    }
+
     _colors[n] = c;
     Adafruit_NeoPixel::setPixelColor(n, c.color);
   }
 
-  uint32_t getRawPixelColor(uint16_t n) const { return Adafruit_NeoPixel::getPixelColor(n); }
+  uint32_t getRawPixelColor(uint16_t n) const
+  {
+    // ,o colors outside of strip
+    if (n >= LED_COUNT)
+      return 0;
+
+    COLOR c;
+    c.color = Adafruit_NeoPixel::getPixelColor(n);
+
+    if (brightness != UINT8_MAX)
+    {
+      const uint8_t trueBrightness = brightness + 1;
+      c.blue = static_cast<uint8_t>((uint32_t)(c.blue << 8) / trueBrightness);
+      c.green = static_cast<uint8_t>((uint32_t)(c.green << 8) / trueBrightness);
+      c.red = static_cast<uint8_t>((uint32_t)(c.red << 8) / trueBrightness);
+    }
+
+    return c.color;
+  }
 
   /// Show the current data, independant of changes
   void show_now()
@@ -266,6 +307,7 @@ public:
 
 private:
   volatile bool hasSomeChanges;
+  volatile uint8_t brightness;
 };
 
 } // namespace physical

--- a/src/system/physical/strip.h
+++ b/src/system/physical/strip.h
@@ -38,7 +38,8 @@ struct LampTy;
 
 namespace physical {
 
-class LedStrip : public Adafruit_NeoPixel
+/// protected inheritence to avoid uncontroled hardware calls
+class LedStrip : private Adafruit_NeoPixel
 {
   using BufferTy = std::array<uint32_t, LED_COUNT>;
   friend struct modes::hardware::LampTy;
@@ -59,14 +60,8 @@ public:
     if (hasSomeChanges)
     {
       // only show if some changes were made
-      Adafruit_NeoPixel::show();
+      show_now();
     }
-    hasSomeChanges = false;
-  }
-
-  void show_now()
-  {
-    Adafruit_NeoPixel::show();
     hasSomeChanges = false;
   }
 
@@ -93,12 +88,35 @@ public:
     return max<float>(baseCurrentConsumption, estimatedCurrentDraw);
   }
 
+  /**
+   * EXPLICIT CALLS TO THE LIBRARY
+   */
+
+  void setBrightness(uint8_t b) { Adafruit_NeoPixel::setBrightness(b); }
+
+  uint8_t getBrightness() const { return Adafruit_NeoPixel::getBrightness(); }
+
+  void begin() { Adafruit_NeoPixel::begin(); }
+
   void setPixelColor(uint16_t n, COLOR c)
   {
     n = lmpd_constrain<uint16_t>(n, 0, LED_COUNT - 1);
     _colors[n] = c;
     Adafruit_NeoPixel::setPixelColor(n, c.color);
   }
+
+  uint32_t getRawPixelColor(uint16_t n) const { return Adafruit_NeoPixel::getPixelColor(n); }
+
+  /// Show the current data, independant of changes
+  void show_now()
+  {
+    Adafruit_NeoPixel::show();
+    hasSomeChanges = false;
+  }
+
+  /**
+   * END OF EXPLICIT CALLS
+   */
 
   void setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b)
   {
@@ -224,8 +242,6 @@ public:
   {
     addPixelColor(LedStrip::to_strip(x, y), color, fast);
   }
-
-  uint32_t getRawPixelColor(uint16_t n) const { return Adafruit_NeoPixel::getPixelColor(n); }
 
   // signal the strip that it can display the update
   void signal_display() { hasSomeChanges = true; }

--- a/src/system/physical/strip.h
+++ b/src/system/physical/strip.h
@@ -47,21 +47,26 @@ class LedStrip : private Adafruit_NeoPixel
   using BufferTy = std::array<uint32_t, LED_COUNT>;
   friend struct modes::hardware::LampTy;
 
-  // need AT LEAST 2*30 FPS for a smooth animation
-  static constexpr bool useTemporalDithering = MAIN_LOOP_UPDATE_PERIOD_MS < static_cast<uint32_t>(1000 / 60.0f);
-  static constexpr bool randomizeErrorDistributionsInTemporalDithering = true;
+  /// Use a blue noise pattern to dither the colors
+  static constexpr bool useColorDithering = true;
+  /// Use time to dither the colors using error diffusion. It needs AT LEAST 2*30 FPS for a smooth animation
+  static constexpr bool useTemporalDithering = false;
+  static constexpr uint16_t refreshFramesCount = 10; ///< blue noise refresh rate speed
 
 public:
-  LedStrip(int16_t pin, neoPixelType type = NEO_RGB + NEO_KHZ800) : Adafruit_NeoPixel(LED_COUNT, pin, type)
+  LedStrip(int16_t pin, neoPixelType type = NEO_RGB + NEO_KHZ800) :
+    Adafruit_NeoPixel(LED_COUNT, pin, type),
+    shownCount(0)
   {
+    assert(_colorErrors.size() > 0);
+
     COLOR c;
     c.color = 0;
     for (uint16_t i = 0; i < LED_COUNT; ++i)
     {
       if constexpr (useTemporalDithering)
       {
-        COLOR initialError;
-        _colorErrors[i] = initialError;
+        _colorErrors[i] = c;
       }
 
       _colors[i] = c;
@@ -158,8 +163,10 @@ public:
     // Adjust brightness to the desired output
     for (uint16_t i = 0; i < LED_COUNT; ++i)
     {
-      COLOR& error = _colorErrors[i];
-      const COLOR c = convert_color_with_brigthness(_colors[i], writeBrightness, error);
+      const COLOR c = convert_color_with_brigthness(_colors[i],
+                                                    writeBrightness,
+                                                    i + shownCount % refreshFramesCount,
+                                                    _colorErrors[useTemporalDithering ? i : 0]);
       // set strip color
       Adafruit_NeoPixel::setPixelColor(i, c.color);
     }
@@ -168,11 +175,14 @@ public:
   /// Show the current data, independant of changes
   void show_now()
   {
+    // copy the pattern to show to the display buffer
     brightnessAtShowTime = brightness;
     write_to_led_driver(brightnessAtShowTime);
-
+    // show on hardware
     Adafruit_NeoPixel::show();
     hasSomeChanges = false;
+    // increment show count
+    shownCount += 1;
   }
 
   /**
@@ -199,26 +209,52 @@ public:
 
   /**
    * \brief Convert a color to the desired brightness level, with an error adjustment
-   *\param[in] colorIn Raw color data to convert
-   *\param[in] errorIn Additive color error from last run
-   *\param[in] brightness Desired brightness level (0 - 255)
+   * \param[in] colorIn Raw color data to convert
+   * \param[in] errorIn Additive color error from last run
+   * \param[in] brightness Desired brightness level (0 - 255)
+   * \param[in] index Index of the noise to use
    * \return Pair of converted color and new error component
    */
-  static std::pair<uint8_t, uint8_t> get_brightness_color_and_error(uint8_t colorIn,
-                                                                    uint8_t errorIn,
-                                                                    const uint8_t brightness)
+  static std::pair<uint8_t, uint8_t> get_brightness_color_and_error(const uint8_t colorIn,
+                                                                    uint16_t errorIn,
+                                                                    const uint8_t brightness,
+                                                                    const uint16_t index)
   {
+    // blue noise look up table
+    static constexpr std::array<uint8_t, 64> BLUE_NOISE_LUT = {
+            0,  32, 8,  40, 2,  34, 10, 42, 48, 16, 56, 24, 50, 18, 58, 26, 12, 44, 4,  36, 14, 46,
+            6,  38, 60, 28, 52, 20, 62, 30, 54, 22, 3,  35, 11, 43, 1,  33, 9,  41, 51, 19, 59, 27,
+            49, 17, 57, 25, 15, 47, 7,  39, 13, 45, 5,  37, 63, 31, 55, 23, 61, 29, 53, 21};
+
     // only special case
     if (colorIn == 0)
       return {0, 0};
 
-    uint16_t fullColor = colorIn * brightness + brightness;
-    if ((fullColor >> 8) == 0)
+    // scale color by brightness
+    const uint16_t scaledColor = colorIn * brightness + brightness;
+
+    // When using standard and temporal dithering, shift the pattern
+    if constexpr (useColorDithering and useTemporalDithering)
     {
-      return {0, 0};
+      const uint8_t allowedError = UINT8_MAX - (scaledColor & 0xFF);
+      errorIn += min<uint16_t>(allowedError, BLUE_NOISE_LUT[index % BLUE_NOISE_LUT.size()]);
     }
-    fullColor += errorIn;
-    return {fullColor >> 8, fullColor & 0xFF};
+
+    // add error
+    const uint32_t fullColor = min<uint32_t>(scaledColor + errorIn, 0xFF00);
+
+    // compute final color and new error
+    uint32_t finalColorRaw = fullColor >> 8;
+    const uint8_t finalError = fullColor & 0xFF;
+
+    // When using only color dithering, add a blue noise error to the final color
+    if constexpr (useColorDithering and not useTemporalDithering)
+    {
+      finalColorRaw += (finalError > BLUE_NOISE_LUT[index % BLUE_NOISE_LUT.size()] ? 1 : 0);
+    }
+
+    const uint8_t finalColor = (finalColorRaw > 255) ? 255 : finalColorRaw;
+    return {finalColor, finalError};
   }
 
   /**
@@ -226,9 +262,13 @@ public:
    * \warning The given brightness should be 0-255
    * \param[in] c Color to convert, in the full scale 0-255, unadjusted to brightness
    * \param[in] brightness The brightness to apply (0 - 255).
+   * \param[in] index Index of the noise to use
    * \param[in, out] error Error components of the current colors
    */
-  COLOR convert_color_with_brigthness(const COLOR& c, const uint8_t brightness, COLOR& error)
+  static COLOR convert_color_with_brigthness(const COLOR& c,
+                                             const uint8_t brightness,
+                                             const uint16_t index,
+                                             COLOR& error)
   {
     // no temporal dithering: no error propagation
     if constexpr (not useTemporalDithering)
@@ -237,23 +277,15 @@ public:
       error.green = 0;
       error.blue = 0;
     }
-    // convert colors and errors
-    const auto& [red, redError] = get_brightness_color_and_error(c.red, error.red, brightness);
-    const auto& [green, greenError] = get_brightness_color_and_error(c.green, error.green, brightness);
-    const auto& [blue, blueError] = get_brightness_color_and_error(c.blue, error.blue, brightness);
+    // convert colors and errors, with small offsets for the different chanels
+    const auto& [red, redError] = get_brightness_color_and_error(c.red, error.red, brightness, index);
+    const auto& [green, greenError] = get_brightness_color_and_error(c.green, error.green, brightness, index + 1);
+    const auto& [blue, blueError] = get_brightness_color_and_error(c.blue, error.blue, brightness, index + 2);
 
     // store error components
     error.red = redError;
     error.green = greenError;
     error.blue = blueError;
-
-    if constexpr (useTemporalDithering && randomizeErrorDistributionsInTemporalDithering)
-    {
-      // error scaled
-      error.red += (error.red == 0 or error.red == 255 ? 0 : random8() % error.red);
-      error.green += (error.green == 0 or error.green == 255 ? 0 : random8() % error.green);
-      error.blue += (error.blue == 0 or error.blue == 255 ? 0 : random8() % error.blue);
-    }
 
     COLOR result;
     result.red = red;
@@ -400,10 +432,13 @@ public:
     memset(_buffers[index].data(), value, sizeof(BufferTy));
   }
 
+  /// store the display colors, with no brightness scaling
   COLOR _colors[LED_COUNT];
-  COLOR _colorErrors[LED_COUNT]; ///< used for temporal dithering
 
-  // buffers for computations
+  /// used for temporal dithering
+  std::array<COLOR, useTemporalDithering ? LED_COUNT : 1> _colorErrors;
+
+  /// buffers for computations
   BufferTy _buffers[stripNbBuffers];
 
 private:
@@ -414,6 +449,9 @@ private:
 
   /// Store a reference to the brightness value from the last show() call
   volatile uint8_t brightnessAtShowTime;
+
+  /// keep track of the show call count. Allowed to circle back to 0
+  volatile uint8_t shownCount;
 };
 
 } // namespace physical

--- a/src/system/physical/strip.h
+++ b/src/system/physical/strip.h
@@ -19,6 +19,9 @@
 #endif
 
 #include "src/system/ext/scale8.h"
+
+#include "src/system/ext/random8.h"
+
 #include "src/system/utils/constants.h"
 #include "src/system/utils/utils.h"
 #include "src/system/utils/vector_math.h"
@@ -44,6 +47,10 @@ class LedStrip : private Adafruit_NeoPixel
   using BufferTy = std::array<uint32_t, LED_COUNT>;
   friend struct modes::hardware::LampTy;
 
+  // need AT LEAST 2*30 FPS for a smooth animation
+  static constexpr bool useTemporalDithering = MAIN_LOOP_UPDATE_PERIOD_MS < static_cast<uint32_t>(1000 / 60.0f);
+  static constexpr bool randomizeErrorDistributionsInTemporalDithering = true;
+
 public:
   LedStrip(int16_t pin, neoPixelType type = NEO_RGB + NEO_KHZ800) : Adafruit_NeoPixel(LED_COUNT, pin, type)
   {
@@ -51,6 +58,12 @@ public:
     c.color = 0;
     for (uint16_t i = 0; i < LED_COUNT; ++i)
     {
+      if constexpr (useTemporalDithering)
+      {
+        COLOR initialError;
+        _colorErrors[i] = initialError;
+      }
+
       _colors[i] = c;
     }
   }
@@ -131,14 +144,10 @@ public:
     COLOR c;
     c.color = Adafruit_NeoPixel::getPixelColor(n);
 
-    // We use brightnessAtShowTime here, our the colors can break when brightness changed
-    if (brightnessAtShowTime != UINT8_MAX)
-    {
-      const uint8_t trueBrightness = brightnessAtShowTime + 1;
-      c.blue = static_cast<uint8_t>((uint32_t)(c.blue << 8) / trueBrightness);
-      c.green = static_cast<uint8_t>((uint32_t)(c.green << 8) / trueBrightness);
-      c.red = static_cast<uint8_t>((uint32_t)(c.red << 8) / trueBrightness);
-    }
+    // We use brightnessAtShowTime here, or the colors can break when brightness changed
+    c.blue = restore_color_with_brightness(c.blue, brightnessAtShowTime);
+    c.green = restore_color_with_brightness(c.green, brightnessAtShowTime);
+    c.red = restore_color_with_brightness(c.red, brightnessAtShowTime);
 
     return c.color;
   }
@@ -146,34 +155,13 @@ public:
   /// \private: write the buffered colors to the led driver
   void write_to_led_driver(const uint8_t writeBrightness)
   {
-    // store all pixels for display
-    const bool isNotMaxBrightness = writeBrightness != UINT8_MAX;
-
-    if (writeBrightness == UINT8_MAX)
+    // Adjust brightness to the desired output
+    for (uint16_t i = 0; i < LED_COUNT; ++i)
     {
-      // brightness at maxium, change nothing
-      for (uint16_t i = 0; i < LED_COUNT; ++i)
-      {
-        Adafruit_NeoPixel::setPixelColor(i, _colors[i].color);
-      }
-    }
-    else
-    {
-      // brightness should be adjusted, do it
-      const uint8_t trueBrightness = writeBrightness + 1;
-      for (uint16_t i = 0; i < LED_COUNT; ++i)
-      {
-        // indirection by copy
-        COLOR c;
-        c.color = _colors[i].color;
-
-        c.blue = static_cast<uint8_t>((c.blue * trueBrightness) >> 8);
-        c.green = static_cast<uint8_t>((c.green * trueBrightness) >> 8);
-        c.red = static_cast<uint8_t>((c.red * trueBrightness) >> 8);
-
-        // set strip color
-        Adafruit_NeoPixel::setPixelColor(i, c.color);
-      }
+      COLOR& error = _colorErrors[i];
+      const COLOR c = convert_color_with_brigthness(_colors[i], writeBrightness, error);
+      // set strip color
+      Adafruit_NeoPixel::setPixelColor(i, c.color);
     }
   }
 
@@ -190,6 +178,89 @@ public:
   /**
    * END OF EXPLICIT CALLS
    */
+
+  /**
+   * \brief Convert a color to the standard range, assuming it starts as brightness level.
+   * \warning This breaks the color resolution, on purpose !
+   *\param[in] colorIn Raw color data to convert
+   *\param[in] brightness Desired brightness level (0 - 255)
+   * \return converted color
+   */
+  static uint8_t restore_color_with_brightness(uint8_t colorIn, const uint8_t brightness)
+  {
+    // only special case
+    const uint16_t colorShifted = (uint16_t)colorIn << 8;
+    if (colorShifted <= brightness or brightness == 0)
+      return 0;
+
+    uint8_t fullColor = (colorShifted - brightness) / brightness;
+    return fullColor;
+  }
+
+  /**
+   * \brief Convert a color to the desired brightness level, with an error adjustment
+   *\param[in] colorIn Raw color data to convert
+   *\param[in] errorIn Additive color error from last run
+   *\param[in] brightness Desired brightness level (0 - 255)
+   * \return Pair of converted color and new error component
+   */
+  static std::pair<uint8_t, uint8_t> get_brightness_color_and_error(uint8_t colorIn,
+                                                                    uint8_t errorIn,
+                                                                    const uint8_t brightness)
+  {
+    // only special case
+    if (colorIn == 0)
+      return {0, 0};
+
+    uint16_t fullColor = colorIn * brightness + brightness;
+    if ((fullColor >> 8) == 0)
+    {
+      return {0, 0};
+    }
+    fullColor += errorIn;
+    return {fullColor >> 8, fullColor & 0xFF};
+  }
+
+  /**
+   * \brief Convert a color to the correct brightness, with temporal dithering.
+   * \warning The given brightness should be 0-255
+   * \param[in] c Color to convert, in the full scale 0-255, unadjusted to brightness
+   * \param[in] brightness The brightness to apply (0 - 255).
+   * \param[in, out] error Error components of the current colors
+   */
+  COLOR convert_color_with_brigthness(const COLOR& c, const uint8_t brightness, COLOR& error)
+  {
+    // no temporal dithering: no error propagation
+    if constexpr (not useTemporalDithering)
+    {
+      error.red = 0;
+      error.green = 0;
+      error.blue = 0;
+    }
+    // convert colors and errors
+    const auto& [red, redError] = get_brightness_color_and_error(c.red, error.red, brightness);
+    const auto& [green, greenError] = get_brightness_color_and_error(c.green, error.green, brightness);
+    const auto& [blue, blueError] = get_brightness_color_and_error(c.blue, error.blue, brightness);
+
+    // store error components
+    error.red = redError;
+    error.green = greenError;
+    error.blue = blueError;
+
+    if constexpr (useTemporalDithering && randomizeErrorDistributionsInTemporalDithering)
+    {
+      // error scaled
+      error.red += (error.red == 0 or error.red == 255 ? 0 : random8() % error.red);
+      error.green += (error.green == 0 or error.green == 255 ? 0 : random8() % error.green);
+      error.blue += (error.blue == 0 or error.blue == 255 ? 0 : random8() % error.blue);
+    }
+
+    COLOR result;
+    result.red = red;
+    result.green = green;
+    result.blue = blue;
+    return result;
+  }
 
   void setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b)
   {
@@ -284,10 +355,7 @@ public:
   }
 
   uint32_t getPixelColor(uint16_t n) const { return _colors[lmpd_constrain<uint16_t>(n, 0, LED_COUNT - 1)].color; }
-  uint32_t getPixelColorXY(int16_t x, int16_t y) const
-  {
-    return _colors[lmpd_constrain<uint16_t>(LedStrip::to_strip(x, y), 0, LED_COUNT - 1)].color;
-  }
+  uint32_t getPixelColorXY(int16_t x, int16_t y) const { return getPixelColor(LedStrip::to_strip(x, y)); }
 
   // Blends the specified color with the existing pixel color.
   void blendPixelColor(uint16_t n, uint32_t color, uint8_t blend)
@@ -333,6 +401,7 @@ public:
   }
 
   COLOR _colors[LED_COUNT];
+  COLOR _colorErrors[LED_COUNT]; ///< used for temporal dithering
 
   // buffers for computations
   BufferTy _buffers[stripNbBuffers];

--- a/src/user/constants.h
+++ b/src/user/constants.h
@@ -89,7 +89,7 @@ static constexpr uint16_t stripInputMaxVoltage_mV = 12000; // max allowed voltag
 static constexpr float ledByMeter = 244;                   // the REAL indexable led by meters (for a 240Led/m)
 static constexpr float ledStripWidth_mm = 5.2f;            // width of the led strip
 static constexpr float ledStripHeigh_mm = 0.7f;            // heigh of the led strip (calibrated for this strip)
-static constexpr uint8_t minimumAllowedBrightness_8 = 5;   // minium allowed brightnes level,0-255
+static constexpr uint8_t minimumAllowedBrightness_8 = 3;   // minium allowed brightnes level,0-255
 
 // compute the expected average loop runtime (in ms)
 // defined as milliseconds / FPS
@@ -103,7 +103,7 @@ static constexpr uint16_t stripInputMaxVoltage_mV = 12000; // max allowed voltag
 static constexpr float ledByMeter = 162.6f;                // the REAL indexable led by meters (for a 160Led/m)
 static constexpr float ledStripWidth_mm = 5.2f;            // width of the led strip
 static constexpr float ledStripHeigh_mm = 0.7f;            // heigh of the led strip (calibrated for this strip)
-static constexpr uint8_t minimumAllowedBrightness_8 = 5;   // minium allowed brightnes level,0-255
+static constexpr uint8_t minimumAllowedBrightness_8 = 3;   // minium allowed brightnes level,0-255
 
 // compute the expected average loop runtime (in ms)
 // defined as milliseconds / FPS

--- a/src/user/constants.h
+++ b/src/user/constants.h
@@ -89,6 +89,7 @@ static constexpr uint16_t stripInputMaxVoltage_mV = 12000; // max allowed voltag
 static constexpr float ledByMeter = 244;                   // the REAL indexable led by meters (for a 240Led/m)
 static constexpr float ledStripWidth_mm = 5.2f;            // width of the led strip
 static constexpr float ledStripHeigh_mm = 0.7f;            // heigh of the led strip (calibrated for this strip)
+static constexpr uint8_t minimumAllowedBrightness_8 = 5;   // minium allowed brightnes level,0-255
 
 // compute the expected average loop runtime (in ms)
 // defined as milliseconds / FPS
@@ -102,6 +103,7 @@ static constexpr uint16_t stripInputMaxVoltage_mV = 12000; // max allowed voltag
 static constexpr float ledByMeter = 162.6f;                // the REAL indexable led by meters (for a 160Led/m)
 static constexpr float ledStripWidth_mm = 5.2f;            // width of the led strip
 static constexpr float ledStripHeigh_mm = 0.7f;            // heigh of the led strip (calibrated for this strip)
+static constexpr uint8_t minimumAllowedBrightness_8 = 5;   // minium allowed brightnes level,0-255
 
 // compute the expected average loop runtime (in ms)
 // defined as milliseconds / FPS


### PR DESCRIPTION
Refactor de inner workings of the brightness in the indexable lamp.

Add a test temporal dithering based on error propagation.

Add an option in the simulator to test the color banding in the indexable lamp at low brightness.

Closes #138
Closes #323