### PR TITLE
434: resolve power gate switch timeout

### DIFF
--- a/.github/workflows/lamp-main.yml
+++ b/.github/workflows/lamp-main.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: read
+
 defaults: 
   run:
     shell: bash
@@ -21,8 +25,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
+        persist-credentials: false
         path: LampColorControler
         submodules: 'true'
     - name: verify format
@@ -33,8 +38,9 @@ jobs:
     needs: [format]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
+        persist-credentials: false
         path: LampColorControler
         submodules: 'true'
 
@@ -64,8 +70,9 @@ jobs:
         working-directory: ./LampColorControler
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
+        persist-credentials: false
         path: LampColorControler
         submodules: 'true'
     - name: Documentation
@@ -83,8 +90,9 @@ jobs:
         working-directory: ./LampColorControler
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
+        persist-credentials: false
         path: LampColorControler
         submodules: 'true'
 
@@ -108,8 +116,9 @@ jobs:
     needs: [format, run-tests]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
+        persist-credentials: false
         path: LampColorControler
         submodules: 'true'
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ arduino-cli
 _vagrant_build
 *.xcf
 generated
+
+.continue

--- a/src/system/logic/power_handler.cpp
+++ b/src/system/logic/power_handler.cpp
@@ -35,7 +35,8 @@ bool _isShutdownCompleted = false;
 /// Minimum allowed power rail clear delay.
 static constexpr uint32_t clearPowerRailMinDelay_ms = 10;
 /// Minimum power rail clear delay after which a failure is signaled.
-static constexpr uint32_t clearPowerRailFailureDelay_ms = 1000;
+/// In some rare case the rail can take up to 2 seconds to clear itself.
+static constexpr uint32_t clearPowerRailFailureDelay_ms = 3000;
 /// Delay after which the OTG_MODE will auto disable if a disconnection is detected.
 static constexpr uint32_t otgNoUseTimeToDisconnect_ms = 1000;
 /// Delay after which the OTG_MODE will auto disable if not used.
@@ -149,6 +150,8 @@ const platform::gpio::DigitalPin fastRoleSwap(platform::gpio::DigitalPin::GPIO::
 
 // if high, signal an USB fault
 const platform::gpio::DigitalPin usbFault(platform::gpio::DigitalPin::GPIO::Signal_UsbProtectionFault);
+// if high, signal a vbus gate fault
+const platform::gpio::DigitalPin vbusFault(platform::gpio::DigitalPin::GPIO::Signal_VbusGateFault);
 } // namespace __private
 
 uint32_t get_vbus_rail_voltage() { return ::lampda::power::powerDelivery::get_vbus_voltage(); }
@@ -187,6 +190,7 @@ void handle_clear_power_rails()
   if (_isInBatteryRecoveryMode)
   {
     // all is clear, skip to next step
+    __private::dischargeVbus.set_high(false);
     __private::powerMachine.skip_timeout();
     return;
   }
@@ -198,6 +202,8 @@ void handle_clear_power_rails()
   // prevent reverse current flow
   __private::vbusDirection.set_high(false);
   __private::fastRoleSwap.set_high(false);
+  // discharge power rail
+  __private::dischargeVbus.set_high(true);
 
   // disable charge & balancing if needed
   ::lampda::power::charger::set_enable_charge(false);
@@ -209,13 +215,15 @@ void handle_clear_power_rails()
   set_otg_parameters(0, 0);
 
   // wait at least a little bit
+  const auto powerRailVoltage_mv = get_power_rail_voltage();
   if (platform::time_ms() - __private::powerMachine.get_state_raised_time() >= clearPowerRailMinDelay_ms and
       // power rail below min measurment voltage
-      (_isInBatteryRecoveryMode or get_power_rail_voltage() <= 3200))
+      (powerRailVoltage_mv <= 3200))
   {
     __private::dischargeVbus.set_high(false);
     // all is clear, skip to next step
     __private::powerMachine.skip_timeout();
+    return;
   }
   else // discharge power rail
   {
@@ -274,27 +282,29 @@ void handle_output_voltage_mode()
   // never run PD in output mode !
   ::lampda::power::powerDelivery::suspend_pd_state_machine();
 
-  const uint32_t vbusVoltage = get_power_rail_voltage();
+  const auto powerRailVoltage_mv = get_power_rail_voltage();
 
-  bool isVbusVoltageOk = false;
+  bool isVoltageOk = false;
   // if we are in temporary output mode, use temporary limits
   if (platform::time_ms() < _temporaryOutputTimeOut)
   {
     set_otg_parameters(_temporaryOutputVoltage_mV, _temporaryOutputCurrent_mA);
-    isVbusVoltageOk = (vbusVoltage >= static_cast<uint32_t>(stripInputMinVoltage_mV * voltageGateLowerMultiplier) and
-                       // do not check the upper bound, this is a special DANGEROUS case
-                       vbusVoltage <= static_cast<uint32_t>(_temporaryOutputVoltage_mV * voltageGateHigherMultiplier));
+    isVoltageOk =
+            (powerRailVoltage_mv >= static_cast<uint32_t>(stripInputMinVoltage_mV * voltageGateLowerMultiplier) and
+             // do not check the upper bound, this is a special DANGEROUS case
+             powerRailVoltage_mv <= static_cast<uint32_t>(_temporaryOutputVoltage_mV * voltageGateHigherMultiplier));
   }
   else
   {
     _temporaryOutputTimeOut = 0;
     set_otg_parameters(_outputVoltage_mV, _outputCurrent_mA);
-    isVbusVoltageOk = (vbusVoltage >= static_cast<uint32_t>(stripInputMinVoltage_mV * voltageGateLowerMultiplier) and
-                       vbusVoltage <= static_cast<uint32_t>(stripInputMaxVoltage_mV * voltageGateHigherMultiplier));
+    isVoltageOk =
+            (powerRailVoltage_mv >= static_cast<uint32_t>(stripInputMinVoltage_mV * voltageGateLowerMultiplier) and
+             powerRailVoltage_mv <= static_cast<uint32_t>(stripInputMaxVoltage_mV * voltageGateHigherMultiplier));
   }
 
   // enable power gate when voltage matches expected voltage
-  if (isVbusVoltageOk)
+  if (isVoltageOk)
   {
     // enable power gate
     ::lampda::power::powergates::enable_power_gate();
@@ -307,7 +317,7 @@ void handle_output_voltage_mode()
   {
     if (s_isOutputModeReady)
       platform::lampda_print("voltage is not in required range, disabling output. Actual %dmV. Required %dmV",
-                             vbusVoltage,
+                             powerRailVoltage_mv,
                              _outputVoltage_mV);
     s_isOutputModeReady = false;
 
@@ -720,7 +730,7 @@ bool go_to_error()
 
 void set_output_voltage_mv(const uint16_t outputVoltage_mV)
 {
-  if (stripInputMinVoltage_mV == stripInputMaxVoltage_mV)
+  if constexpr (stripInputMinVoltage_mV == stripInputMaxVoltage_mV)
   {
     // NEVER EVER CHANGE fixed output VOLTAGE
     const bool isInRange = (outputVoltage_mV == 0) or (outputVoltage_mV == stripInputMaxVoltage_mV);
@@ -742,7 +752,7 @@ void set_output_max_current_mA(const uint16_t outputCurrent_mA)
 
 void set_temporary_output(const uint16_t outputVoltage_mV, const uint16_t outputCurrent_mA, const uint16_t timeout)
 {
-  if (stripInputMinVoltage_mV == stripInputMaxVoltage_mV)
+  if constexpr (stripInputMinVoltage_mV == stripInputMaxVoltage_mV)
   {
     // NEVER EVER CHANGE FIXED OUTPUT VOLTAGE
     if (outputVoltage_mV != stripInputMaxVoltage_mV)
@@ -788,6 +798,17 @@ void init()
             logic::alerts::manager.raise(logic::alerts::Type::USB_PORT_SHORT);
           },
           platform::gpio::DigitalPin::Interrupt::kFallingEdge);
+
+  /// TODO: issue #326 handle the VBUS gate fault cleanly
+#ifdef LMBD_SIMULATION
+  __private::vbusFault.attach_callback(
+          []() {
+            platform::lampda_print("-----------------");
+            platform::lampda_print("VBUS FAULT RAISED");
+            platform::lampda_print("-----------------");
+          },
+          platform::gpio::DigitalPin::Interrupt::kFallingEdge);
+#endif
 
   // init power gates
   ::lampda::power::powergates::init();

--- a/src/system/power/power_gates.cpp
+++ b/src/system/power/power_gates.cpp
@@ -10,7 +10,7 @@ namespace lampda {
 namespace power {
 namespace powergates {
 
-bool isInit = false;
+bool _isInit = false;
 
 // if this is too low, there is a risk that both gate can be active at the same time
 // potentially destructive behavior
@@ -19,32 +19,32 @@ static constexpr uint32_t gateSwitchDelay_ms = 50;
 /// max off delay of the gate blip
 static constexpr uint32_t BLIP_MAX_TIME = 10000;
 // wake up time for a blip output gate. DANGER
-static uint32_t blipWakeUpTime = 0;
+static uint32_t _blipWakeUpTime_ms = 0;
 
 // indicates if the power gate is really on, not switching or other
-bool isPowerGateReallyEnabled = false;
+bool _isPowerGateReallyEnabled = false;
 
 namespace __private {
 const platform::gpio::DigitalPin enableVbusGate(platform::gpio::DigitalPin::GPIO::Output_EnableVbusGate);
 const platform::gpio::DigitalPin enablePowerGate(platform::gpio::DigitalPin::GPIO::Output_EnableOutputGate);
 } // namespace __private
 
-bool isVbusGateEnabled = false;
-bool isVbusGateSwitching = false;
-uint32_t vbusGateStartSwitchingTime = 0;
+static bool _isVbusGateEnabled = false;
+static bool _isVbusGateSwitching = false;
+static uint32_t _vbusGateStartSwitchingTime = 0;
 
-bool isPowerGateEnabled = false;
-bool isPowerGateSwitching = false;
-uint32_t powerGateStartSwitchingTime = 0;
+static bool _isPowerGateEnabled = false;
+static bool _isPowerGateSwitching = false;
+static uint32_t _powerGateStartSwitchingTime = 0;
 
 ///
-bool is_power_gate_switched() { return platform::time_ms() - powerGateStartSwitchingTime > gateSwitchDelay_ms; }
-bool is_vbus_gate_switched() { return platform::time_ms() - vbusGateStartSwitchingTime > gateSwitchDelay_ms; }
+bool is_power_gate_switched() { return platform::time_ms() - _powerGateStartSwitchingTime > gateSwitchDelay_ms; }
+bool is_vbus_gate_switched() { return platform::time_ms() - _vbusGateStartSwitchingTime > gateSwitchDelay_ms; }
 
-bool is_power_gate_enabled() { return isPowerGateReallyEnabled; }
+bool is_power_gate_enabled() { return _isPowerGateReallyEnabled; }
 
 /// check if power gate is enabled
-bool __is_power_gate_enabled() { return isPowerGateEnabled and is_power_gate_switched(); }
+bool __is_power_gate_enabled() { return _isPowerGateEnabled and is_power_gate_switched(); }
 
 void enable_gate(bool isVbusGate)
 {
@@ -57,7 +57,7 @@ void enable_gate(bool isVbusGate)
 
   // set real status
   platform::delay_ms(1);
-  isPowerGateReallyEnabled = isPowerGateEnabled;
+  _isPowerGateReallyEnabled = isPowerGateEnabled;
 
   if (isPowerGateEnabled)
     platform::lampda_print("power gate enabled");
@@ -71,72 +71,72 @@ void disable_vbus_gate()
     platform::lampda_print("vbus gate disabled");
 
   __private::enableVbusGate.set_high(false);
-  isVbusGateEnabled = false;
-  isVbusGateSwitching = false;
+  _isVbusGateEnabled = false;
+  _isVbusGateSwitching = false;
 }
 
 void disable_power_gate()
 {
   // reset blip time
-  blipWakeUpTime = 0;
+  _blipWakeUpTime_ms = 0;
 
   if (__private::enablePowerGate.is_high())
     platform::lampda_print("power gate disabled");
 
   __private::enablePowerGate.set_high(false);
-  isPowerGateEnabled = false;
-  isPowerGateSwitching = false;
+  _isPowerGateEnabled = false;
+  _isPowerGateSwitching = false;
 }
 
 void switch_delayed_vbus_gate(bool enable)
 {
-  if (enable != isVbusGateEnabled)
+  if (enable != _isVbusGateEnabled)
   {
-    vbusGateStartSwitchingTime = platform::time_ms();
-    isVbusGateSwitching = true;
-    isVbusGateEnabled = enable;
+    _vbusGateStartSwitchingTime = platform::time_ms();
+    _isVbusGateSwitching = true;
+    _isVbusGateEnabled = enable;
   }
 }
 
 void switch_delayed_power_gate(bool enable)
 {
-  if (enable != isPowerGateEnabled)
+  if (enable != _isPowerGateEnabled)
   {
-    powerGateStartSwitchingTime = platform::time_ms();
-    isPowerGateSwitching = true;
-    isPowerGateEnabled = enable;
+    _powerGateStartSwitchingTime = platform::time_ms();
+    _isPowerGateSwitching = true;
+    _isPowerGateEnabled = enable;
   }
 }
 
 void init()
 {
   disable_gates();
-  isInit = true;
+  _isInit = true;
 }
 
 void loop()
 {
-  if (!isInit)
+  if (!_isInit)
     return;
 
   // vbus is switching
-  if (isVbusGateSwitching and is_vbus_gate_switched())
+  if (_isVbusGateSwitching and is_vbus_gate_switched())
   {
     enable_gate(true);
-    isVbusGateSwitching = false;
+    _isVbusGateSwitching = false;
   }
-  if (isPowerGateSwitching and is_power_gate_switched())
+  if (_isPowerGateSwitching and is_power_gate_switched())
   {
     enable_gate(false);
-    isPowerGateSwitching = false;
+    _isPowerGateSwitching = false;
   }
 
   // allow blipping
   // This is dangerous for the hardware, dont touch if you dont know how
-  if (isPowerGateReallyEnabled)
+  if (_isPowerGateReallyEnabled)
   {
     // prepare blip wake up
-    if (blipWakeUpTime != 0 && platform::time_ms() >= blipWakeUpTime)
+    if (_blipWakeUpTime_ms != 0 && platform::time_ms() >= _blipWakeUpTime_ms)
     {
       power::cancel_blip();
     }
@@ -144,7 +144,7 @@ void loop()
   else
   {
     // always reset if power gate is inactive
-    blipWakeUpTime = 0;
+    _blipWakeUpTime_ms = 0;
   }
 }
 
@@ -159,13 +159,13 @@ void blip(const uint32_t timing)
 #endif
 
   // hard limit on blip
-  if (timing <= 0 or timing > BLIP_MAX_TIME or not isPowerGateReallyEnabled)
+  if (timing <= 0 or timing > BLIP_MAX_TIME or not _isPowerGateReallyEnabled)
   {
-    blipWakeUpTime = 0;
+    _blipWakeUpTime_ms = 0;
     return;
   }
 
-  blipWakeUpTime = platform::time_ms() + timing;
+  _blipWakeUpTime_ms = platform::time_ms() + timing;
 
   // deactivate without checks, not that dangerous...
   __private::enablePowerGate.set_high(false);
@@ -175,16 +175,16 @@ void cancel_blip()
 {
   // This is dangerous for the hardware, dont touch if you dont know how
 
-  if (is_bliping() && isPowerGateReallyEnabled)
+  if (is_bliping() && _isPowerGateReallyEnabled)
   {
     // REALLY DANGEROUS STUFF : enable power gate without checks
     __private::enablePowerGate.set_high(true);
   }
   // reset time
-  blipWakeUpTime = 0;
+  _blipWakeUpTime_ms = 0;
 }
 
-bool is_bliping() { return blipWakeUpTime > 0; }
+bool is_bliping() { return _blipWakeUpTime_ms > 0; }
 
 } // namespace power
 
@@ -210,7 +210,7 @@ void enable_vbus_gate_DIRECT()
   enable_gate(true);
 }
 
-bool is_vbus_gate_enabled() { return isVbusGateEnabled and is_vbus_gate_switched(); }
+bool is_vbus_gate_enabled() { return _isVbusGateEnabled and is_vbus_gate_switched(); }
 
 void disable_gates()
 {


### PR DESCRIPTION
Closes #434: This bug was due to a slow gate switch on some case.
The bug makes the power rail voltage drop slowly from the max voltage to the min, similarly to an absent discharge signal, but even slower.

I could not identify why the gate was so slow in some cases.
Tries:
- Check for VBUS gate faults: no faults
- Check that gates are truly disabled: yes, no problems
- Check that the discharge signal is active: signal aways active  