### PR TITLE
Add function to set sunset timer to minimum duration

### DIFF
--- a/src/system/logic/alerts.cpp
+++ b/src/system/logic/alerts.cpp
@@ -1,5 +1,5 @@
 #include "alerts.h"
-
+#include "src/system/logic/sunset_timer.h"
 #include "src/system/platform/time.h"
 #include "src/system/platform/bluetooth.h"
 #include "src/system/platform/registers.h"
@@ -348,6 +348,7 @@ struct Alert_BatteryLow : public AlertBase
   /// Execution will lower the brigthness output
   void execute() const override
   {
+      logic::sunset::set_to_minimum_duration();
     // limit brightness to quarter of the max value
     constexpr brightness_t clampedBrightness =
             static_cast<brightness_t>(0.25 * ::lampda::brightness::absoluteMaximumBrightness);
@@ -422,6 +423,7 @@ struct Alert_TempTooHigh : public AlertBase
   /// Execution will lower the max brightness of the output
   void execute() const override
   {
+     logic::sunset::set_to_minimum_duration();
     // limit brightness to half the max value
     constexpr brightness_t clampedBrightness =
             static_cast<brightness_t>(0.5 * ::lampda::brightness::absoluteMaximumBrightness);

--- a/src/system/logic/sunset_timer.cpp
+++ b/src/system/logic/sunset_timer.cpp
@@ -165,6 +165,24 @@ void bump_timer()
   }
 }
 
+void set_to_minimum_duration()
+
+{
+
+  const uint32_t currentTime_s = platform::time_s();
+  // Timer is disabled or has already expired
+
+  if (sunsetTimerEndTime_s == 0 or sunsetTimerEndTime_s <= currentTime_s)
+    return;
+  const uint32_t minimumEndTime_s = currentTime_s + brightnessRampDownTime_s;
+  // Never extend a timer that already has 3 minutes or less remaining
+  if (sunsetTimerEndTime_s <= minimumEndTime_s)
+    return;
+  sunsetTimerEndTime_s = minimumEndTime_s;
+  // Notify consumers that the timer progress changed
+  signal_sunset_update();
+}
+
 /// cancel the current active timer
 void cancel_timer()
 {

--- a/src/system/logic/sunset_timer.h
+++ b/src/system/logic/sunset_timer.h
@@ -21,6 +21,12 @@ void add_time_minutes(const uint8_t time_minutes);
 /// signal to the timer that some time may be added
 void bump_timer();
 
+
+/// Reduce the active sunset timer to the minimum duration.
+/// Does nothing if the timer is disabled or already below the minimum duration.
+
+
+void set_to_minimum_duration();
 /// cancel the current active timer
 void cancel_timer();
 


### PR DESCRIPTION
## Summary

This PR adds a function to reduce the active sunset timer to its minimum duration (about 3 minutes).

The function is called when the following alerts are triggered:

- BATTERY_LOW

- TEMP_TOO_HIGH

## Behavior

- Does nothing if the timer is disabled.

- Does nothing if the remaining time is already 3 minutes or less.

- Otherwise, sets the remaining time to the minimum duration.