### PR TITLE
BLE: Only allow the lastest connected user to reconnect again

### DIFF
--- a/hal/adafruit_nrf/bluetooth.cpp
+++ b/hal/adafruit_nrf/bluetooth.cpp
@@ -15,6 +15,7 @@
 
 #include "src/system/hal/time.h"
 #include "src/system/hal/queues.h"
+#include "src/system/hal/filesystem.h"
 
 #include "src/system/bsp/text_out.h"
 #include "src/system/bsp/threads.h"
@@ -34,6 +35,8 @@ namespace __private {
 
 #define BLE_APPEARANCE_LIGHT_SOURCE_GENERIC          0x07C0 /**< Light fixture BLE appearance flag (official flags) */
 #define BLE_APPEARANCE_LIGHT_SOURCE_MULTICOLOR_ARRAY 0x07C6 /**< Light fixture BLE appearance flag (official flags) */
+
+static constexpr const char* const BLE_BOUND_PEER_FILE = "/.ble_bound.par";
 
 /// Indicates if the last advertising cancel command was automatic or requested
 bool advertisingStoppedByRequest = false;
@@ -65,6 +68,51 @@ void byte_to_str(char* buff, uint8_t val)
   buff[1] = nibble_to_hex(val);
 }
 
+// Compare two BLE addresses.
+// NOTE: addr_type is intentionally ignored here because after bonding and
+// RPA resolution, the SoftDevice provides the identity address regardless of
+// which address type the phone used during the connection attempt.
+bool addressMatches(const ble_gap_addr_t& a, const ble_gap_addr_t& b)
+{
+  return (memcmp(a.addr, b.addr, BLE_GAP_ADDR_LEN) == 0);
+}
+
+/// Paired device address
+static ble_gap_addr_t identityAddr = {0};
+/// If true, the identityAddr is set, refuse all other connections
+static bool hasBondedPeer = false;
+/// If true, the device is in pairing mode, and can accept all connections
+static volatile bool pairingMode = false;
+
+bool try_load_bounded_pair(ble_gap_addr_t& addr)
+{
+  // Try to load the bounded address file
+  hal::filesystem::HAL_File boundFile;
+  if (boundFile.open(BLE_BOUND_PEER_FILE, hal::filesystem::HAL_File::OpenType::READ) and boundFile.is_open() and
+      boundFile.is_available() and boundFile.seek(0))
+  {
+    const bool isAdressOk =
+            (boundFile.read(reinterpret_cast<uint8_t*>(&addr), sizeof(ble_gap_addr_t)) == sizeof(ble_gap_addr_t));
+    boundFile.close();
+    return isAdressOk;
+  }
+  boundFile.close();
+  return false;
+}
+
+void try_save_bounded_peer(const ble_gap_addr_t& addr)
+{
+  // Try to load the bounded address file
+  hal::filesystem::HAL_File boundFile;
+
+  // load content, without deletion
+  if (boundFile.open(BLE_BOUND_PEER_FILE, hal::filesystem::HAL_File::OpenType::WRITE) and boundFile.is_open())
+  {
+    boundFile.write(reinterpret_cast<const uint8_t*>(&addr), sizeof(ble_gap_addr_t));
+  }
+  boundFile.close();
+}
+
 void stop_advertising()
 {
   if (not is_activated())
@@ -79,6 +127,56 @@ void connect_callback(uint16_t conn_hdl)
   if (not is_activated())
     return;
 
+  BLEConnection* conn = Bluefruit.Connection(conn_hdl);
+  ble_gap_addr_t peerAddr = conn->getPeerAddr();
+
+  bsp::lampda_print("[BLE] Connection from – type=0x%02X %02X:%02X:%02X:%02X:%02X:%02X",
+                    peerAddr.addr_type,
+                    peerAddr.addr[5],
+                    peerAddr.addr[4],
+                    peerAddr.addr[3],
+                    peerAddr.addr[2],
+                    peerAddr.addr[1],
+                    peerAddr.addr[0]);
+
+  // ── pairing mode — allow anyone, will bond to the first connected device ─────────
+  if (pairingMode or not hasBondedPeer)
+  {
+    bsp::lampda_print("[Security] Pairing mode — accepting connection for bonding.");
+
+    identityAddr = conn->getPeerAddr();
+    hasBondedPeer = true;
+    pairingMode = false;
+
+    bsp::lampda_print("[Bond] Stored identity – type=0x%02X %02X:%02X:%02X:%02X:%02X:%02X",
+                      identityAddr.addr_type,
+                      identityAddr.addr[5],
+                      identityAddr.addr[4],
+                      identityAddr.addr[3],
+                      identityAddr.addr[2],
+                      identityAddr.addr[1],
+                      identityAddr.addr[0]);
+  }
+  // ── reject unknown devices when a bond already exists ─────────
+  else if (hasBondedPeer)
+  {
+    // NOTE on RPA: if the phone is using an RPA and the SoftDevice has
+    // not yet resolved it, addressMatches() will fail even for the legit
+    // bonded peer. The SoftDevice resolves via stored IRKs internally —
+    // if the peer is bonded, the SoftDevice will have ALREADY matched
+    // the RPA before surfacing this callback, so getPeerAddr() should
+    // return the identity address for a known peer.
+    // An unknown device will appear with a random address that does NOT
+    // match the stored identity → correctly rejected below.
+
+    if (!addressMatches(peerAddr, identityAddr))
+    {
+      bsp::lampda_print("[Security] Unknown device — disconnecting immediately.");
+      Bluefruit.disconnect(conn_hdl);
+      return;
+    }
+  }
+
   _wasUsed = true;
 
   const auto batteryLevel = component::battery::get_battery_minimum_cell_level();
@@ -92,9 +190,9 @@ void disconnect_callback(uint16_t conn_hdl, uint8_t reason)
     return;
 
   // Dont stop advertising here, some BLE drivers can send one command by connections.
-  // Instead, restart the advertising
-  start_advertising();
-  bsp::lampda_print("Bluetooth disconnected");
+  // Instead, restart the advertising with the same mode
+  start_advertising(__private::pairingMode);
+  bsp::lampda_print("Bluetooth disconnected (reason=0x%02X)", reason);
 }
 
 void adv_stop_callback(void)
@@ -105,7 +203,8 @@ void adv_stop_callback(void)
   // auto turned off, start again !
   if (not advertisingStoppedByRequest)
   {
-    start_advertising();
+    // restart with the same pairing mode
+    start_advertising(__private::pairingMode);
     bsp::lampda_print("BLE Advertising timeout, advertising restarted.");
   }
   else
@@ -204,6 +303,12 @@ void startup_sequence()
   Bluefruit.Periph.setConnectCallback(connect_callback);
   Bluefruit.Periph.setDisconnectCallback(disconnect_callback);
 
+  // Try to load the bounded peer if it exist
+  if (try_load_bounded_pair(identityAddr))
+  {
+    __private::hasBondedPeer = true;
+  }
+
   isInitialized = true;
 }
 
@@ -218,16 +323,47 @@ bool is_activated() { return __private::isInitialized; }
 
 bool is_advertising() { return is_activated() and Bluefruit.Advertising.isRunning(); }
 
+bool is_open_to_all() { return is_activated() and __private::pairingMode; }
+
 bool is_connected() { return is_activated() and Bluefruit.connected() != 0; }
+
+bool is_bounded(std::array<uint8_t, 8>& buffer)
+{
+  if (is_activated() and __private::hasBondedPeer)
+  {
+    buffer[0] = __private::identityAddr.addr_type;
+    buffer[1] = __private::identityAddr.addr[5];
+    buffer[2] = __private::identityAddr.addr[4];
+    buffer[3] = __private::identityAddr.addr[3];
+    buffer[4] = __private::identityAddr.addr[2];
+    buffer[5] = __private::identityAddr.addr[1];
+    buffer[6] = __private::identityAddr.addr[0];
+    return true;
+  }
+  return false;
+}
 
 // void display_infos() { Bluefruit.printInfo(); }
 
-void start_advertising()
+void start_advertising(bool allowUnknownConnections)
 {
   if (not is_activated())
   {
     // call once when the program starts
     __private::startup_sequence();
+  }
+
+  // startup sequence can load a bound adress, so set the pairing mode after
+  if (allowUnknownConnections)
+  {
+    // visual signal in case of a status update
+    if (not __private::pairingMode)
+    {
+      bsp::lampda_print("Advertising connection open to all");
+      logic::alerts::manager.raise(logic::alerts::Type::BLUETOOTH_ADVERT);
+    }
+    // force pairing mode, will accept any connection
+    __private::pairingMode = true;
   }
   // no need to start again
   if (is_advertising())
@@ -268,6 +404,9 @@ bool was_used() { return __private::_wasUsed; }
 
 void shutdown()
 {
+  if (__private::hasBondedPeer)
+    __private::try_save_bounded_peer(__private::identityAddr);
+
   __private::isInitialized = false;
   // NRF_RADIO->POWER = 0;
 }

--- a/hal/adafruit_nrf/bluetooth.cpp
+++ b/hal/adafruit_nrf/bluetooth.cpp
@@ -1,6 +1,7 @@
 #include "src/system/hal/bluetooth.h"
 
 #include <bluefruit.h>
+#include <InternalFileSystem.h>
 #include <FreeRTOS.h>
 #include <queue.h>
 #include <task.h>
@@ -78,11 +79,14 @@ bool addressMatches(const ble_gap_addr_t& a, const ble_gap_addr_t& b)
 }
 
 /// Paired device address
-static ble_gap_addr_t identityAddr = {0};
+inline static ble_gap_addr_t identityAddr = {0};
 /// If true, the identityAddr is set, refuse all other connections
 static bool hasBondedPeer = false;
 /// If true, the device is in pairing mode, and can accept all connections
 static volatile bool pairingMode = false;
+
+/// Keep track of the currently authorized handle.
+static uint16_t authorizedConnHdl = BLE_CONN_HANDLE_INVALID;
 
 bool try_load_bounded_pair(ble_gap_addr_t& addr)
 {
@@ -115,97 +119,35 @@ void try_save_bounded_peer(const ble_gap_addr_t& addr)
 
 void stop_advertising()
 {
-  if (not is_activated())
-    return;
-
+  __private::pairingMode = false;
   logic::alerts::manager.clear(logic::alerts::Type::BLUETOOTH_ADVERT);
+
+  if (not is_activated())
+    return;
+
   Bluefruit.Advertising.stop();
-}
-
-void connect_callback(uint16_t conn_hdl)
-{
-  if (not is_activated())
-    return;
-
-  BLEConnection* conn = Bluefruit.Connection(conn_hdl);
-  ble_gap_addr_t peerAddr = conn->getPeerAddr();
-
-  bsp::lampda_print("[BLE] Connection from – type=0x%02X %02X:%02X:%02X:%02X:%02X:%02X",
-                    peerAddr.addr_type,
-                    peerAddr.addr[5],
-                    peerAddr.addr[4],
-                    peerAddr.addr[3],
-                    peerAddr.addr[2],
-                    peerAddr.addr[1],
-                    peerAddr.addr[0]);
-
-  // ── pairing mode — allow anyone, will bond to the first connected device ─────────
-  if (pairingMode or not hasBondedPeer)
-  {
-    bsp::lampda_print("[Security] Pairing mode — accepting connection for bonding.");
-
-    identityAddr = conn->getPeerAddr();
-    hasBondedPeer = true;
-    pairingMode = false;
-
-    bsp::lampda_print("[Bond] Stored identity – type=0x%02X %02X:%02X:%02X:%02X:%02X:%02X",
-                      identityAddr.addr_type,
-                      identityAddr.addr[5],
-                      identityAddr.addr[4],
-                      identityAddr.addr[3],
-                      identityAddr.addr[2],
-                      identityAddr.addr[1],
-                      identityAddr.addr[0]);
-  }
-  // ── reject unknown devices when a bond already exists ─────────
-  else if (hasBondedPeer)
-  {
-    // NOTE on RPA: if the phone is using an RPA and the SoftDevice has
-    // not yet resolved it, addressMatches() will fail even for the legit
-    // bonded peer. The SoftDevice resolves via stored IRKs internally —
-    // if the peer is bonded, the SoftDevice will have ALREADY matched
-    // the RPA before surfacing this callback, so getPeerAddr() should
-    // return the identity address for a known peer.
-    // An unknown device will appear with a random address that does NOT
-    // match the stored identity → correctly rejected below.
-
-    if (!addressMatches(peerAddr, identityAddr))
-    {
-      bsp::lampda_print("[Security] Unknown device — disconnecting immediately.");
-      Bluefruit.disconnect(conn_hdl);
-      return;
-    }
-  }
-
-  _wasUsed = true;
-
-  const auto batteryLevel = component::battery::get_battery_minimum_cell_level();
-  write_battery_level(static_cast<uint8_t>(batteryLevel / 100));
-  bsp::lampda_print("Bluetooth connected");
-}
-
-void disconnect_callback(uint16_t conn_hdl, uint8_t reason)
-{
-  if (not is_activated())
-    return;
-
-  // Dont stop advertising here, some BLE drivers can send one command by connections.
-  // Instead, restart the advertising with the same mode
-  start_advertising(__private::pairingMode);
-  bsp::lampda_print("Bluetooth disconnected (reason=0x%02X)", reason);
 }
 
 void adv_stop_callback(void)
 {
+  // clear the alert
+  logic::alerts::manager.clear(logic::alerts::Type::BLUETOOTH_ADVERT);
+
+  // skip if bluetooth is off
   if (not is_activated())
     return;
 
   // auto turned off, start again !
   if (not advertisingStoppedByRequest)
   {
-    // restart with the same pairing mode
-    start_advertising(__private::pairingMode);
-    bsp::lampda_print("BLE Advertising timeout, advertising restarted.");
+    // Dont restart if this was the pairing mode: it timedout and need restarting
+    if (not __private::pairingMode and __private::hasBondedPeer)
+      start_advertising(false);
+    else
+    {
+      __private::stop_advertising();
+      bsp::lampda_print("BLE Advertising stopped");
+    }
   }
   else
   {
@@ -213,6 +155,167 @@ void adv_stop_callback(void)
     bsp::lampda_print("BLE Advertising stop requested.");
   }
   advertisingStoppedByRequest = false;
+}
+
+void pair_complete_callback(uint16_t conn_hdl, uint8_t authStatus)
+{
+  if (not is_activated())
+    return;
+
+  if (authStatus != 0)
+  {
+    bsp::lampda_print("[Sec]: Pairing failed (0x%02X) - disconnecting", authStatus);
+    Bluefruit.disconnect(conn_hdl);
+    return;
+  }
+
+  if (not Bluefruit.connected(conn_hdl))
+  {
+    bsp::lampda_print("[Sec] connection handle is already disconnected");
+    return;
+  }
+
+  bsp::lampda_print("[Sec]: Pairing & bounding success");
+
+  BLEConnection* conn = Bluefruit.Connection(conn_hdl);
+  if (conn == NULL)
+  {
+    bsp::lampda_print("[Pair] connection handle invalid");
+    return;
+  }
+
+  identityAddr = conn->getPeerAddr();
+  hasBondedPeer = true;
+  pairingMode = false;
+
+  bsp::lampda_print("[Bond] Stored identity type=0x%02X %02X:%02X:%02X:%02X:%02X:%02X",
+                    identityAddr.addr_type,
+                    identityAddr.addr[5],
+                    identityAddr.addr[4],
+                    identityAddr.addr[3],
+                    identityAddr.addr[2],
+                    identityAddr.addr[1],
+                    identityAddr.addr[0]);
+}
+
+void secured_connection_callback(uint16_t conn_hdl)
+{
+  if (not is_activated())
+    return;
+
+  if (not Bluefruit.connected(conn_hdl))
+  {
+    bsp::lampda_print("[Security] connection handle is already disconnected");
+    return;
+  }
+
+  BLEConnection* conn = Bluefruit.Connection(conn_hdl);
+  if (conn == NULL)
+  {
+    bsp::lampda_print("[Security] connection handle invalid");
+    return;
+  }
+  const ble_gap_addr_t& resolvedAddr = conn->getPeerAddr();
+
+  bsp::lampda_print("[Security] Secure connection activated=0x%02X %02X:%02X:%02X:%02X:%02X:%02X",
+                    resolvedAddr.addr_type,
+                    resolvedAddr.addr[5],
+                    resolvedAddr.addr[4],
+                    resolvedAddr.addr[3],
+                    resolvedAddr.addr[2],
+                    resolvedAddr.addr[1],
+                    resolvedAddr.addr[0]);
+
+  // ── Refresh the stored address if it was an RPA at pairing time ───────
+  // By now the SoftDevice has fully resolved the identity address.
+  if (hasBondedPeer and not pairingMode)
+  {
+    // Check that address are matching
+    if (!addressMatches(resolvedAddr, identityAddr))
+    {
+      bsp::lampda_print("[Security] Unknown device — disconnecting immediately");
+      Bluefruit.disconnect(conn_hdl);
+      return;
+    }
+  }
+  else if (pairingMode)
+  {
+    // Check that address are matching
+    if (hasBondedPeer and !addressMatches(resolvedAddr, identityAddr))
+      bsp::lampda_print("[Security] First time pairing complete, peer authorized");
+    else
+      bsp::lampda_print("[Security] Recognized authorized peer, proceed");
+  }
+
+  // Only update if we now have a non-RPA identity address
+  if (resolvedAddr.addr_type != BLE_GAP_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE)
+  {
+    identityAddr = resolvedAddr;
+    bsp::lampda_print("[Security] Updating the non-RPA identity");
+  }
+  // Save the handle: it's allowed to treat messages
+  authorizedConnHdl = conn_hdl;
+
+  // Send a battery level update
+  const auto batteryLevel = component::battery::get_battery_minimum_cell_level();
+  write_battery_level(static_cast<uint8_t>(batteryLevel / 100));
+
+  // used !
+  _wasUsed = true;
+
+  // Stop advertising manually
+  adv_stop_callback();
+}
+
+void connect_callback(uint16_t conn_hdl)
+{
+  if (not is_activated())
+    return;
+
+  bsp::lampda_print("[BLE] Connected (handle=%d)", conn_hdl);
+
+  BLEConnection* conn = Bluefruit.Connection(conn_hdl);
+  if (conn == NULL)
+  {
+    bsp::lampda_print("[Connect] connection handle invalid");
+    return;
+  }
+
+  // skip the safety layer to reject devices fast !
+  if (hasBondedPeer and not pairingMode)
+  {
+    bond_keys_t ltkey;
+    if (not conn->loadBondKey(&ltkey))
+    {
+      Bluefruit.disconnect(conn_hdl);
+      bsp::lampda_print("[Connect] Fast disconnect unallowed user");
+      return;
+    }
+  }
+
+  conn->requestPHY(); // Request 2Mbps PHY
+  conn->requestMtuExchange(247);
+
+  // Immediatly request pairing, or any msg will be rejected !
+  conn->requestPairing();
+}
+
+void disconnect_callback(uint16_t conn_hdl, uint8_t reason)
+{
+  if (not is_activated())
+    return;
+
+  // this connection is dead, disconnect it
+  if (authorizedConnHdl == conn_hdl)
+  {
+    authorizedConnHdl = BLE_CONN_HANDLE_INVALID;
+  }
+
+  // Dont stop advertising here, some BLE drivers can send one command by connections.
+  // Fake call the advertising callback
+  adv_stop_callback();
+
+  bsp::lampda_print("Bluetooth disconnected (reason=0x%02X)", reason);
 }
 
 void set_device_informations()
@@ -300,14 +403,15 @@ void startup_sequence()
   Bluefruit.Advertising.setInterval(32, 244);             // in unit of 0.625 ms
   Bluefruit.Advertising.setFastTimeout(ADV_TIMEOUT_FAST); // advertisement timeout
 
+  Bluefruit.Security.setPairCompleteCallback(pair_complete_callback);
+  Bluefruit.Security.setSecuredCallback(secured_connection_callback);
+  Bluefruit.Security.setMITM(true); // Man In The Middle protection
+
   Bluefruit.Periph.setConnectCallback(connect_callback);
   Bluefruit.Periph.setDisconnectCallback(disconnect_callback);
 
-  // Try to load the bounded peer if it exist
-  if (try_load_bounded_pair(identityAddr))
-  {
-    __private::hasBondedPeer = true;
-  }
+  // If not done yet
+  load_bound_file();
 
   isInitialized = true;
 }
@@ -327,9 +431,11 @@ bool is_open_to_all() { return is_activated() and __private::pairingMode; }
 
 bool is_connected() { return is_activated() and Bluefruit.connected() != 0; }
 
+bool is_bounded() { return __private::hasBondedPeer; }
+
 bool is_bounded(std::array<uint8_t, 8>& buffer)
 {
-  if (is_activated() and __private::hasBondedPeer)
+  if (__private::hasBondedPeer)
   {
     buffer[0] = __private::identityAddr.addr_type;
     buffer[1] = __private::identityAddr.addr[5];
@@ -343,15 +449,71 @@ bool is_bounded(std::array<uint8_t, 8>& buffer)
   return false;
 }
 
+void disconnect()
+{
+  if (is_connected())
+    Bluefruit.disconnect(Bluefruit.connHandle());
+}
+
+bool is_connection_allowed(uint16_t connectionHandle)
+{
+  // refuse connections with the incorrect handle
+  return is_activated() and connectionHandle != BLE_CONN_HANDLE_INVALID and
+         connectionHandle == __private::authorizedConnHdl;
+}
+
+void clear_bounded_devices()
+{
+  // In some case, the file system may need to be restarted
+  InternalFS.begin();
+
+  InternalFS.remove(__private::BLE_BOUND_PEER_FILE);
+  __private::identityAddr = {0};
+  __private::hasBondedPeer = false;
+  bsp::lampda_print("[Bond] Bond file cleared.");
+
+  // Internal adafruit clear
+  bond_clear_all();
+}
+
 // void display_infos() { Bluefruit.printInfo(); }
 
-void start_advertising(bool allowUnknownConnections)
+void load_bound_file()
+{
+  // Try to load the bounded peer if it exist
+  ble_gap_addr_t boundAdress;
+  if (__private::try_load_bounded_pair(boundAdress))
+  {
+    bsp::lampda_print("[Bond] Loaded address: %02X:%02X:%02X:%02X:%02X:%02X",
+                      boundAdress.addr[5],
+                      boundAdress.addr[4],
+                      boundAdress.addr[3],
+                      boundAdress.addr[2],
+                      boundAdress.addr[1],
+                      boundAdress.addr[0]);
+
+    __private::identityAddr = boundAdress;
+    __private::hasBondedPeer = true;
+  }
+  else
+  {
+    __private::identityAddr = {0};
+    __private::hasBondedPeer = false;
+  }
+}
+
+void init()
 {
   if (not is_activated())
   {
     // call once when the program starts
     __private::startup_sequence();
   }
+}
+
+void start_advertising(bool allowUnknownConnections)
+{
+  init();
 
   // startup sequence can load a bound adress, so set the pairing mode after
   if (allowUnknownConnections)
@@ -359,12 +521,18 @@ void start_advertising(bool allowUnknownConnections)
     // visual signal in case of a status update
     if (not __private::pairingMode)
     {
-      bsp::lampda_print("Advertising connection open to all");
+      // stop current advertizing
+      __private::adv_stop_callback();
       logic::alerts::manager.raise(logic::alerts::Type::BLUETOOTH_ADVERT);
     }
     // force pairing mode, will accept any connection
     __private::pairingMode = true;
+
+    __private::advertisingStoppedByRequest = false;
+    Bluefruit.Advertising.start(ADV_TIMEOUT); // Stop advertising entirely after ADV_TIMEOUT seconds
+    return;
   }
+
   // no need to start again
   if (is_advertising())
     return;
@@ -372,9 +540,6 @@ void start_advertising(bool allowUnknownConnections)
   __private::advertisingStoppedByRequest = false;
 
   Bluefruit.Advertising.start(ADV_TIMEOUT); // Stop advertising entirely after ADV_TIMEOUT seconds
-
-  // reraise the alert every minutes
-  logic::alerts::manager.raise(logic::alerts::Type::BLUETOOTH_ADVERT);
 }
 
 void stop_bluetooth_advertising()
@@ -414,10 +579,21 @@ void shutdown()
 namespace serial {
 bool is_activated()
 {
-  return hal::bluetooth::is_activated() and Bluefruit.connected() and __private::bleuart.notifyEnabled();
+  const bool isUartActivated =
+          hal::bluetooth::is_activated() and Bluefruit.connected() and __private::bleuart.notifyEnabled();
+  if (not isUartActivated)
+    return false;
+
+  // prevent stray enqueud messages
+  if (not is_connection_allowed(__private::authorizedConnHdl))
+  {
+    __private::bleuart.flush();
+    return false;
+  }
+  return true;
 }
 
-bool is_available() { return __private::bleuart.available(); }
+bool is_available() { return __private::bleuart.available() and is_connection_allowed(__private::authorizedConnHdl); }
 
 char read() { return (char)__private::bleuart.read(); }
 

--- a/hal/adafruit_nrf/bluetooth/elk_service.cpp
+++ b/hal/adafruit_nrf/bluetooth/elk_service.cpp
@@ -37,7 +37,11 @@ err_t BLEElkService::begin(void)
 
 void BLEElkService::elk_commmand_handle(uint16_t conn_hdl, const uint8_t* data, uint16_t len) const
 {
-  std::ignore = conn_hdl;
+  if (not hal::bluetooth::is_connection_allowed(conn_hdl))
+  {
+    bsp::lampda_print("Unallowed connection, refusing message");
+    return;
+  }
 
   common::elk::Package elkPackage;
   if (common::elk::decode_ELK_message(data, len, elkPackage))

--- a/hal/adafruit_nrf/filesystem.cpp
+++ b/hal/adafruit_nrf/filesystem.cpp
@@ -120,7 +120,7 @@ size_t HAL_File::size() const
   return mInternalFile->size();
 }
 
-size_t HAL_File::write(uint8_t* in, size_t sz)
+size_t HAL_File::write(const uint8_t* const in, size_t sz)
 {
   if (not is_setup() or not mInternalFile)
     return false;

--- a/hal/adafruit_nrf/filesystem.cpp
+++ b/hal/adafruit_nrf/filesystem.cpp
@@ -2,6 +2,8 @@
 
 #include <InternalFileSystem.h>
 
+#include "src/system/bsp/text_out.h"
+
 namespace lampda {
 namespace hal {
 namespace filesystem {
@@ -43,15 +45,15 @@ void shutdown_shared_filesystem_instance()
   }
 }
 
-} // namespace __private
+bool is_setup() { return __private::isInternalFsStarted; }
 
-bool setup() { return __private::setup_shared_filesystem_instance(); }
+} // namespace __private
 
 void shutdown() { __private::shutdown_shared_filesystem_instance(); }
 
 void format_file_system()
 {
-  setup();
+  // DO not start before formatting
   InternalFS.format();
 }
 
@@ -59,8 +61,6 @@ void format_file_system()
  *
  *
  */
-
-bool is_setup() { return __private::isInternalFsStarted; }
 
 HAL_File::HAL_File()
 {
@@ -75,9 +75,9 @@ HAL_File::~HAL_File() {}
 bool HAL_File::open(const char* fname, const HAL_File::OpenType& mode)
 {
   // setup the filesystem !
-  setup();
+  __private::setup_shared_filesystem_instance();
 
-  if (not is_setup() or not mInternalFile)
+  if (not __private::is_setup() or not mInternalFile)
     return false;
 
   switch (mode)
@@ -94,56 +94,56 @@ bool HAL_File::open(const char* fname, const HAL_File::OpenType& mode)
 
 bool HAL_File::is_open() const
 {
-  if (not is_setup() or not mInternalFile)
+  if (not __private::is_setup() or not mInternalFile)
     return false;
   return mInternalFile->isOpen();
 }
 
 bool HAL_File::is_available() const
 {
-  if (not is_setup() or not mInternalFile)
+  if (not __private::is_setup() or not mInternalFile)
     return false;
   return mInternalFile->available();
 }
 
 void HAL_File::close()
 {
-  if (not is_setup() or not mInternalFile)
+  if (not __private::is_setup() or not mInternalFile)
     return;
   mInternalFile->close();
 }
 
 size_t HAL_File::size() const
 {
-  if (not is_setup() or not mInternalFile)
+  if (not __private::is_setup() or not mInternalFile)
     return 0;
   return mInternalFile->size();
 }
 
 size_t HAL_File::write(const uint8_t* const in, size_t sz)
 {
-  if (not is_setup() or not mInternalFile)
+  if (not __private::is_setup() or not mInternalFile)
     return false;
   return mInternalFile->write(in, sz);
 }
 
 size_t HAL_File::read(uint8_t* out, size_t sz)
 {
-  if (not is_setup() or not mInternalFile)
+  if (not __private::is_setup() or not mInternalFile)
     return 0;
   return mInternalFile->read(out, sz);
 }
 
 bool HAL_File::seek(uint8_t sz)
 {
-  if (not is_setup() or not mInternalFile)
+  if (not __private::is_setup() or not mInternalFile)
     return false;
   return mInternalFile->seek(sz);
 }
 
 void HAL_File::truncate(uint8_t sz)
 {
-  if (not is_setup() or not mInternalFile)
+  if (not __private::is_setup() or not mInternalFile)
     return;
   mInternalFile->truncate(sz);
 }

--- a/hal/adafruit_nrf/serial.cpp
+++ b/hal/adafruit_nrf/serial.cpp
@@ -8,9 +8,17 @@ namespace hal {
 namespace serial {
 
 void init() { Serial.begin(115200); }
-bool is_activated() { return TinyUSBDevice.ready(); }
+
+bool is_activated()
+{
+  const bool isSerial = Serial;
+  return isSerial;
+}
+
 bool is_available() { return Serial.available() ? true : false; }
+
 char read() { return (char)Serial.read(); }
+
 size_t write(const char* const buffer, size_t bufferSize) { return Serial.write(buffer, bufferSize); }
 
 uint16_t mtu_size() { return Serial.availableForWrite(); }

--- a/hal/simulator/bluetooth.cpp
+++ b/hal/simulator/bluetooth.cpp
@@ -4,25 +4,50 @@
 
 #include "src/system/hal/bluetooth.h"
 
+namespace simulator::bluetooth {
+bool isStarted = false;
+bool hasBoundedPeer = false;
+bool isAdvertising = false;
+
+bool isAdvertisingOpenToAll = false;
+
+bool isConnected = false;
+
+} // namespace simulator::bluetooth
+
 namespace lampda {
 namespace hal {
 namespace bluetooth {
 
-bool is_activated() { return false; }
+bool is_activated() { return simulator::bluetooth::isStarted; }
 
-bool is_advertising() { return false; }
+bool is_advertising() { return simulator::bluetooth::isAdvertising; }
 
-bool is_open_to_all() { return false; }
+bool is_open_to_all() { return simulator::bluetooth::isAdvertisingOpenToAll; }
 
 bool is_connected() { return false; }
 
-bool is_bounded(std::array<uint8_t, 8>& buffer) { return false; }
+bool is_bounded() { return simulator::bluetooth::hasBoundedPeer; }
+
+bool is_bounded(std::array<uint8_t, 8>& buffer) { return simulator::bluetooth::hasBoundedPeer; }
+
+void disconnect() { simulator::bluetooth::isConnected = false; }
+
+bool is_connection_allowed(uint16_t connectionHandle) { return true; }
+
+void load_bound_file() { simulator::bluetooth::hasBoundedPeer = true; }
+
+void clear_bounded_devices() { simulator::bluetooth::hasBoundedPeer = false; }
 
 // start the advertising sequence (with a timeout)
-void start_advertising(bool allowUnknownConnections) {}
+void start_advertising(bool allowUnknownConnections)
+{
+  simulator::bluetooth::isAdvertising = true;
+  simulator::bluetooth::isAdvertisingOpenToAll = allowUnknownConnections;
+}
 
 // disable the bluetooth controler
-void stop_bluetooth_advertising() {}
+void stop_bluetooth_advertising() { simulator::bluetooth::isAdvertising = false; }
 
 void write_battery_level(const uint8_t batteryLevel) {}
 

--- a/hal/simulator/bluetooth.cpp
+++ b/hal/simulator/bluetooth.cpp
@@ -12,10 +12,14 @@ bool is_activated() { return false; }
 
 bool is_advertising() { return false; }
 
+bool is_open_to_all() { return false; }
+
 bool is_connected() { return false; }
 
+bool is_bounded(std::array<uint8_t, 8>& buffer) { return false; }
+
 // start the advertising sequence (with a timeout)
-void start_advertising() {}
+void start_advertising(bool allowUnknownConnections) {}
 
 // disable the bluetooth controler
 void stop_bluetooth_advertising() {}

--- a/hal/simulator/filesystem.cpp
+++ b/hal/simulator/filesystem.cpp
@@ -99,7 +99,7 @@ size_t HAL_File::size() const
   return 0;
 }
 
-size_t HAL_File::write(uint8_t* in, size_t sz)
+size_t HAL_File::write(const uint8_t* const in, size_t sz)
 {
   if (mInternalFile->file != nullptr)
   {

--- a/src/modes/user/default_behavior.hpp
+++ b/src/modes/user/default_behavior.hpp
@@ -114,13 +114,38 @@ bool button_start_hold_default(const uint8_t clicks, const bool isEndOfHoldEvent
         // ramp can activate bluetooth :
         // - if it is not enabled yet
         // - if it is enabled, but the bounded peer already exists (force open connection)
-        const bool shouldShowRamp = (not hal::bluetooth::is_activated()) or (not hal::bluetooth::is_open_to_all());
-        if (shouldShowRamp and
-            manager.overlay_animate_ramp(
-                    holdDuration, 2000, modes::colors::PaletteGradient<modes::colors::Blue, modes::colors::Blue>))
+
+        // Start pairing mode
+        const bool hasPairedDeviceAndNoPairing = hal::bluetooth::is_bounded() and
+                                                 not hal::bluetooth::is_advertising() and
+                                                 not hal::bluetooth::is_connected();
+        if (hasPairedDeviceAndNoPairing)
         {
-          // force connection acceptance even with bounded device
-          hal::bluetooth::start_advertising(true);
+          if (manager.overlay_animate_ramp(
+                      holdDuration, 1000, modes::colors::PaletteGradient<modes::colors::Blue, modes::colors::Blue>))
+          {
+            // Start BLE but with paired device authorization only
+            hal::bluetooth::start_advertising(false);
+
+            bsp::lampda_print("Enable BLE for paired device");
+          }
+        }
+        // else: not bounded, or already started bounded connection
+        else
+        {
+          // Start pairing mode
+          const bool isNotCurrentlyPairing =
+                  not(hal::bluetooth::is_advertising() and hal::bluetooth::is_open_to_all()) and
+                  not hal::bluetooth::is_connected();
+          if (isNotCurrentlyPairing and
+              manager.overlay_animate_ramp(
+                      holdDuration, 3000, modes::colors::PaletteGradient<modes::colors::Blue, modes::colors::Blue>))
+          {
+            // Start pairing mode
+            hal::bluetooth::start_advertising(true);
+
+            bsp::lampda_print("Enable BLE pairing mode");
+          }
         }
         return true;
       }

--- a/src/modes/user/default_behavior.hpp
+++ b/src/modes/user/default_behavior.hpp
@@ -110,11 +110,17 @@ bool button_start_hold_default(const uint8_t clicks, const bool isEndOfHoldEvent
         // 1+hold (2s): activate bluetooth advertising
         // activate bluetooth !
         auto manager = get_context();
-        if (not hal::bluetooth::is_activated() and
+
+        // ramp can activate bluetooth :
+        // - if it is not enabled yet
+        // - if it is enabled, but the bounded peer already exists (force open connection)
+        const bool shouldShowRamp = (not hal::bluetooth::is_activated()) or (not hal::bluetooth::is_open_to_all());
+        if (shouldShowRamp and
             manager.overlay_animate_ramp(
                     holdDuration, 2000, modes::colors::PaletteGradient<modes::colors::Blue, modes::colors::Blue>))
         {
-          hal::bluetooth::start_advertising();
+          // force connection acceptance even with bounded device
+          hal::bluetooth::start_advertising(true);
         }
         return true;
       }

--- a/src/system/bsp/filesystem.cpp
+++ b/src/system/bsp/filesystem.cpp
@@ -1,5 +1,6 @@
 #include "filesystem.h"
 
+#include "src/system/hal/bluetooth.h"
 #include "src/system/hal/filesystem.h"
 #include "src/system/hal/time.h"
 
@@ -15,9 +16,6 @@ namespace filesystem {
 static constexpr const char* const FILENAME_USER = "/.lampda.par";
 /// store lamp internal parameters, that should not be erased
 static constexpr const char* const FILENAME_INTERNAL = "/.internal.par";
-
-/// instance to avoid recreating objects
-hal::filesystem::HAL_File paramFile;
 
 size_t lastUserParameterSize = 0;
 std::map<uint32_t, uint32_t> _userParametersValueMap;
@@ -55,8 +53,15 @@ void shutdown() { hal::filesystem::shutdown(); }
 
 void clear_internal_fs()
 {
+  // First disconnect any BLE device
+  if (hal::bluetooth::is_connected())
+    hal::bluetooth::disconnect();
+
   hal::filesystem::format_file_system();
-  hal::delay_ms(10);
+
+  // It's very important to manually clear the bounded device list AFTER the format
+  hal::delay_ms(100);
+  hal::bluetooth::clear_bounded_devices();
 }
 
 namespace __internal {
@@ -64,6 +69,8 @@ namespace __internal {
 bool read_file_content(const char* fileName, std::map<uint32_t, uint32_t>& paramMap)
 {
   paramMap.clear();
+
+  hal::filesystem::HAL_File paramFile;
   if (paramFile.open(fileName, hal::filesystem::HAL_File::OpenType::READ) and paramFile.is_open() and
       paramFile.is_available())
   {
@@ -121,12 +128,14 @@ bool read_file_content(const char* fileName, std::map<uint32_t, uint32_t>& param
     paramFile.close();
     return true;
   }
+  paramFile.close();
   return false;
 }
 
 bool write_file(const char* filePath, const std::map<uint32_t, uint32_t>& paramMap, const bool shouldEraseFirst = false)
 {
   // check if it exists
+  hal::filesystem::HAL_File paramFile;
   if (paramFile.open(filePath, hal::filesystem::HAL_File::OpenType::WRITE) and paramFile.is_open())
   {
     if (not shouldEraseFirst)
@@ -144,7 +153,7 @@ bool write_file(const char* filePath, const std::map<uint32_t, uint32_t>& paramM
     bsp::lampda_print("file system error, resetting file format");
 
     // hardcore, format the entire file system
-    hal::filesystem::format_file_system();
+    clear_internal_fs();
   }
 
   if (not paramFile.is_open())
@@ -168,6 +177,7 @@ bool write_file(const char* filePath, const std::map<uint32_t, uint32_t>& paramM
     return false;
   }
 
+  paramFile.close();
   return true;
 }
 

--- a/src/system/global.cpp
+++ b/src/system/global.cpp
@@ -167,6 +167,8 @@ void main_setup()
 
   // setup imu
   component::imu::init();
+  // Load BLE bounds
+  hal::bluetooth::load_bound_file();
 
   if (shouldAlertUser)
   {

--- a/src/system/hal/bluetooth.h
+++ b/src/system/hal/bluetooth.h
@@ -16,6 +16,9 @@ namespace hal {
 /// Handle the platform specific bluetooth operations
 namespace bluetooth {
 
+// Load bounded devices
+void load_bound_file();
+
 /// Return true if the bluetooth is activated
 bool is_activated();
 /// Return true is the bluetooth is visible by other devices
@@ -25,7 +28,17 @@ bool is_open_to_all();
 /// Return true if a bluetooth user is connected
 bool is_connected();
 /// Return true if the bluetooth connection is bounded to a pair
+bool is_bounded();
 bool is_bounded(std::array<uint8_t, 8>& buffer);
+
+/// Force disconnection
+void disconnect();
+
+/// If this returns false, do not accept any actions from bluetooth
+bool is_connection_allowed(uint16_t connectionHandle);
+
+/// Clear the bounded bluetooth devices
+void clear_bounded_devices();
 
 /**
  * \brief start the advertising sequence (with a timeout)
@@ -44,6 +57,9 @@ void notify_battery_level(const uint8_t batteryLevel);
 
 /// Return tue if the bluetooth was used during lifetime
 bool was_used();
+
+/// Optional bypass to start the BLE device early, without advertising
+void init();
 
 /// shutdown the bluetooth and services
 void shutdown();

--- a/src/system/hal/bluetooth.h
+++ b/src/system/hal/bluetooth.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <string>
+#include <array>
 
 #include "src/system/bsp/text_in.h"
 
@@ -19,23 +20,32 @@ namespace bluetooth {
 bool is_activated();
 /// Return true is the bluetooth is visible by other devices
 bool is_advertising();
+/// Return true if the device is advertising, and all can connect
+bool is_open_to_all();
 /// Return true if a bluetooth user is connected
 bool is_connected();
+/// Return true if the bluetooth connection is bounded to a pair
+bool is_bounded(std::array<uint8_t, 8>& buffer);
 
-// start the advertising sequence (with a timeout)
-void start_advertising();
+/**
+ * \brief start the advertising sequence (with a timeout)
+ * \param[in] allowUnknownConnections If true, allow any device to be connected. If false, it will first check if a
+ * saved device exists, and if it's the case will only allow this device to connect.
+ */
+void start_advertising(bool allowUnknownConnections);
 
-// disable the bluetooth advertising, but not the bluetooth
+/// disable the bluetooth advertising, but not the bluetooth
 void stop_bluetooth_advertising();
 
-// update battery level
+/// update battery level
 void write_battery_level(const uint8_t batteryLevel);
+/// notify the connected device of a battery level
 void notify_battery_level(const uint8_t batteryLevel);
 
 /// Return tue if the bluetooth was used during lifetime
 bool was_used();
 
-// shutdown the bluetooth and services
+/// shutdown the bluetooth and services
 void shutdown();
 
 namespace serial {

--- a/src/system/hal/filesystem.h
+++ b/src/system/hal/filesystem.h
@@ -46,7 +46,7 @@ struct HAL_File
 
   size_t size() const;
 
-  size_t write(uint8_t* in, size_t sz);
+  size_t write(const uint8_t* const in, size_t sz);
 
   size_t read(uint8_t* out, size_t sz);
 

--- a/src/system/logic/alerts.cpp
+++ b/src/system/logic/alerts.cpp
@@ -495,8 +495,8 @@ struct Alert_BluetoothAdvertisement : public AlertBase
 
   bool should_be_cleared() const override
   {
-    // cleared after two pulsations
-    return raisedTime > 0 and (hal::time_ms() - raisedTime) > (frequency_on_ms * 2 + frequency_off_ms);
+    // cleared after a delay anyway
+    return raisedTime > 0 and (hal::time_ms() - raisedTime) > 60000;
   }
 };
 

--- a/src/system/logic/behavior.cpp
+++ b/src/system/logic/behavior.cpp
@@ -238,8 +238,6 @@ void setup_clean_sleep_flag()
   bsp::filesystem::system::set_value(cleanSleepKey, 0);
   // write parameters, if a crash happens, we will notice a dirty flag
   bsp::filesystem::system::write_to_file();
-  // temp shutdown
-  bsp::filesystem::shutdown();
 }
 
 void write_parameters(const bool shouldSaveUserParameters = true, const bool shouldSaveSystemParameters = true)
@@ -277,8 +275,6 @@ void write_parameters(const bool shouldSaveUserParameters = true, const bool sho
   // write all
   bsp::filesystem::user::write_to_file();
   bsp::filesystem::system::write_to_file();
-  // close filesystem
-  bsp::filesystem::shutdown();
 }
 
 // user code is running when state is output

--- a/src/system/logic/behavior.cpp
+++ b/src/system/logic/behavior.cpp
@@ -214,7 +214,8 @@ bool read_parameters()
     {
       bluetoothAutoActivationLeftCount = min<uint32_t>(maxBluetoothAutoActivations, bluetoothAutoActivation - 1);
 
-      hal::bluetooth::start_advertising();
+      // bounded device, advertize but only allow the bounded device, if it exist
+      hal::bluetooth::start_advertising(false);
     }
     else
     {

--- a/src/system/logic/command_line_interface.cpp
+++ b/src/system/logic/command_line_interface.cpp
@@ -421,14 +421,34 @@ static void cmd_ble(const common::cli::ParsedCommand&)
   bsp::lampda_print(
           "is activated: %d\n"
           "is advertising: %d\n"
+          "is open to all: %d\n"
           "is connected: %d\n"
           "is msg received: %d\n"
           "auto activations left: %d",
           hal::bluetooth::is_activated(),
           hal::bluetooth::is_advertising(),
+          hal::bluetooth::is_open_to_all(),
           hal::bluetooth::is_connected(),
           logic::inputs_bluetooth::is_bluetooth_used(),
           logic::behavior::internal::get_bluetooth_auto_activation_left());
+
+  std::array<uint8_t, 8> boundedDeviceName;
+  const bool isBounded = hal::bluetooth::is_bounded(boundedDeviceName);
+  if (isBounded)
+  {
+    bsp::lampda_print("BLE bounded to device: type=0x%02X %02X:%02X:%02X:%02X:%02X:%02X",
+                      boundedDeviceName[0],
+                      boundedDeviceName[1],
+                      boundedDeviceName[2],
+                      boundedDeviceName[3],
+                      boundedDeviceName[4],
+                      boundedDeviceName[5],
+                      boundedDeviceName[6]);
+  }
+  else
+  {
+    bsp::lampda_print("BLE not bounded to a device");
+  }
 }
 
 /// Change the system brightness

--- a/src/system/logic/command_line_interface.cpp
+++ b/src/system/logic/command_line_interface.cpp
@@ -583,8 +583,8 @@ static void cmd_time(const common::cli::ParsedCommand&)
 /// Display serial port infos
 static void cmd_serial(const common::cli::ParsedCommand&)
 {
-  bsp::lampda_print("Local serial port: active %d, ", hal::serial::is_activated());
-  bsp::lampda_print("BLE serial port: active %d, ", hal::bluetooth::serial::is_activated());
+  bsp::lampda_print("Local serial port: active %d", hal::serial::is_activated());
+  bsp::lampda_print("BLE serial port: active %d", hal::bluetooth::serial::is_activated());
 }
 
 void cmd_set_hook(const common::cli::ParsedCommand& command, const char* name);


### PR DESCRIPTION
Closes #418 : The user must pair to the device to use it, and unpaired devices are now rejected.
Closes #285 : The crash was due to the filesystem being closed after some file read.